### PR TITLE
Change minimum value of heating_room_temperature_impact_factor to 0

### DIFF
--- a/custom_components/luxtronik/number.py
+++ b/custom_components/luxtronik/number.py
@@ -172,7 +172,7 @@ async def async_setup_entry(
                     luxtronik, deviceInfoHeating,
                     number_key=LUX_SENSOR_HEATING_ROOM_TEMPERATURE_IMPACT_FACTOR,
                     unique_id='heating_room_temperature_impact_factor', name=f"{text_heating_room_temperature_impact_factor}",
-                    icon='mdi:thermometer-chevron-up', unit_of_measurement=PERCENTAGE, min_value=100, max_value=200, step=10, mode=NumberMode.BOX, entity_category=EntityCategory.CONFIG),
+                    icon='mdi:thermometer-chevron-up', unit_of_measurement=PERCENTAGE, min_value=0, max_value=200, step=10, mode=NumberMode.BOX, entity_category=EntityCategory.CONFIG),
             ]
 
     deviceInfoDomesticWater = hass.data[f"{DOMAIN}_DeviceInfo_Domestic_Water"]


### PR DESCRIPTION
You should be able to set it to 0 to completely disable the RBE. This can be useful in an automation which detects that the window is open in the room with the RBE.

The heatpump menu also allows this.