### PR TITLE
Update icons for low and high pressure sensors

### DIFF
--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -428,6 +428,7 @@ async def async_setup_entry(
             unit_of_measurement=UnitOfPressure.BAR,
             entity_registry_enabled_default=False,
             device_class=SensorDeviceClass.PRESSURE,
+            icon=mdi:gauge,
         ),
         LuxtronikSensor(
             luxtronik,
@@ -439,6 +440,7 @@ async def async_setup_entry(
             unit_of_measurement=UnitOfPressure.BAR,
             entity_registry_enabled_default=False,
             device_class=SensorDeviceClass.PRESSURE,
+            icon=mdi:gauge-low
         ),
         LuxtronikSensor(
             luxtronik,

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -428,7 +428,7 @@ async def async_setup_entry(
             unit_of_measurement=UnitOfPressure.BAR,
             entity_registry_enabled_default=False,
             device_class=SensorDeviceClass.PRESSURE,
-            icon=mdi:gauge,
+            icon="mdi:gauge-full",
         ),
         LuxtronikSensor(
             luxtronik,
@@ -440,7 +440,7 @@ async def async_setup_entry(
             unit_of_measurement=UnitOfPressure.BAR,
             entity_registry_enabled_default=False,
             device_class=SensorDeviceClass.PRESSURE,
-            icon=mdi:gauge-low
+            icon="mdi:gauge-low",
         ),
         LuxtronikSensor(
             luxtronik,


### PR DESCRIPTION
Without this change, the pressure sensors are shown using a thermometer icon.
