### PR TITLE
Another attempt to fix the solar detection

### DIFF
--- a/custom_components/luxtronik/luxtronik_device.py
+++ b/custom_components/luxtronik/luxtronik_device.py
@@ -156,12 +156,16 @@ class LuxtronikDevice:
         return (
             bool(self.get_value(LUX_DETECT_SOLAR_SENSOR))
             or self.get_value("parameters.ID_BSTD_Solar") > 0.01
-            or bool(self.get_value("visibilities.ID_Visi_Temp_Solarkoll"))
-            or float(self.get_value("calculations.ID_WEB_Temperatur_TSK"))
+            or 
+            (bool(self.get_value("visibilities.ID_Visi_Temp_Solarkoll"))
+            and float(self.get_value("calculations.ID_WEB_Temperatur_TSK"))
             != 5.0
-            or bool(self.get_value("visibilities.ID_Visi_Temp_Solarsp"))
-            or float(self.get_value("calculations.ID_WEB_Temperatur_TSS"))
+            )
+            or 
+            (bool(self.get_value("visibilities.ID_Visi_Temp_Solarsp"))
+            and float(self.get_value("calculations.ID_WEB_Temperatur_TSS"))
             != 150.0
+            )
         )
 
         

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -737,9 +737,9 @@ async def async_setup_entry(
             )
 
         # Temp. disabled:
-        # solar_present = luxtronik.detect_solar_present()
-        # if solar_present:
-        if luxtronik.get_value("visibilities.ID_Visi_Temp_Solarkoll") > 0:
+        solar_present = luxtronik.detect_solar_present()
+        if solar_present:
+        #if luxtronik.get_value("visibilities.ID_Visi_Temp_Solarkoll") > 0:
             entities += [
                 LuxtronikSensor(
                     luxtronik,
@@ -751,7 +751,7 @@ async def async_setup_entry(
                     entity_category=None,
                 ),
             ]
-        if luxtronik.get_value("visibilities.ID_Visi_Temp_Solarsp") > 0:
+        #if luxtronik.get_value("visibilities.ID_Visi_Temp_Solarsp") > 0:
             entities += [
                 LuxtronikSensor(
                     luxtronik,
@@ -763,7 +763,7 @@ async def async_setup_entry(
                     entity_category=None,
                 ),
             ]
-        if luxtronik.get_value("parameters.ID_BSTD_Solar") > 0:
+        #if luxtronik.get_value("parameters.ID_BSTD_Solar") > 0:
             text_operation_hours_solar = get_sensor_text(lang, "operation_hours_solar")
             entities += [
                 LuxtronikSensor(


### PR DESCRIPTION
2023.01.29 still added solar sensors to my setup, where I do not have a solar collector :-(

The problem in my view is that 
1) the solar detection from luxtronik_device.py was not used (disabled) in sensor.py
2) in my heatpump:
LUX_DETECT_SOLAR_SENSOR = 0
ID_Visi_Temp_Solarkoll =1
ID_Visi_Temp_Solarsp = 1
ID_WEB_Temperatur_TSK = 5 
ID_WEB_Temperatur_TSS = 150

I tried fixing the problem for my setup without breaking it for others...