### PR TITLE
Deal with non-numeric characters in minor version number

### DIFF
--- a/custom_components/luxtronik/luxtronik_device.py
+++ b/custom_components/luxtronik/luxtronik_device.py
@@ -117,7 +117,7 @@ class LuxtronikDevice:
         ver = self.firmware_version
         if ver is None:
             return 0
-        return int(ver.split('.')[1])
+        return int(re.search(r'\d+', ver.split('.')[1]).group(0))
 
     @property
     def has_second_heat_generator(self) -> bool:


### PR DESCRIPTION
Attempt to fix #104 .
V1.62B --> minor version = 62 (as integer)
I kept it an int in order not to break the comparisons on minor firmware version.