### PR TITLE
Auto discover Alpha Innotec SWC 140 H/K

### DIFF
--- a/custom_components/luxtronik/manifest.json
+++ b/custom_components/luxtronik/manifest.json
@@ -16,6 +16,7 @@
     { "macaddress": "001999*" },
     { "macaddress": "000982*" },
     { "macaddress": "04D16E*" },
+    { "macaddress": "40ECF8*" },
     { "hostname": "wp-novelan" }
   ],
   "integration_type": "hub",


### PR DESCRIPTION
The Alpha Innotec SWC 140 H/K from year 2012 has a MAC address starting with 40:EC:F8 (Siemens AG).