### PR TITLE
change 'extra_attributes' type to tuple

### DIFF
--- a/custom_components/luxtronik/model.py
+++ b/custom_components/luxtronik/model.py
@@ -80,9 +80,7 @@ class LuxtronikEntityDescription(EntityDescription):
     invisible_if_value: Any | None = None
     min_firmware_version_minor: FirmwareVersionMinor | None = None
 
-    extra_attributes: list[LuxtronikEntityAttributeDescription] = field(
-        default_factory=list
-    )
+    extra_attributes: tuple(LuxtronikEntityAttributeDescription) = ()
     state_class: str | None = None
 
 

--- a/custom_components/luxtronik/number_entities_predefined.py
+++ b/custom_components/luxtronik/number_entities_predefined.py
@@ -408,14 +408,14 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         entity_category=EntityCategory.CONFIG,
         mode=NumberMode.BOX,
         factor=0.1,
-        extra_attributes=[
+        extra_attributes=(
             attr(
                 SA.LAST_THERMAL_DESINFECTION,
                 LC.C0017_DHW_TEMPERATURE,
                 SensorAttrFormat.TIMESTAMP_LAST_OVER,
                 True,
             ),
-        ],
+        ),
     ),
     # region Solar
     LuxtronikNumberDescription(

--- a/custom_components/luxtronik/sensor_entities_predefined.py
+++ b/custom_components/luxtronik/sensor_entities_predefined.py
@@ -46,12 +46,12 @@ SENSORS_STATUS: list[descr] = [
         luxtronik_key=LC.C0080_STATUS,
         icon_by_state=LUX_STATE_ICON_MAP,
         device_class=SensorDeviceClass.ENUM,
-        extra_attributes=[
+        extra_attributes=(
             attr(SA.EVU_FIRST_START_TIME, LC.UNSET, None, True),
             attr(SA.EVU_FIRST_END_TIME, LC.UNSET, None, True),
             attr(SA.EVU_SECOND_START_TIME, LC.UNSET, None, True),
             attr(SA.EVU_SECOND_END_TIME, LC.UNSET, None, True),
-        ],
+        ),
         options=[e.value for e in LuxOperationMode],
         update_interval=UPDATE_INTERVAL_NORMAL,
     ),
@@ -79,7 +79,7 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfTime.SECONDS,
         entity_registry_visible_default=False,
         native_precision=0,
-        extra_attributes=[
+        extra_attributes=(
             attr(SA.STATUS_TEXT, LC.C0120_STATUS_TIME, SensorAttrFormat.HOUR_MINUTE),
             attr(SA.TIMER_HEATPUMP_ON, LC.C0067_TIMER_HEATPUMP_ON),
             attr(SA.TIMER_ADD_HEAT_GENERATOR_ON, LC.C0068_TIMER_ADD_HEAT_GENERATOR_ON),
@@ -94,7 +94,7 @@ SENSORS: list[descr] = [
             attr(SA.TIMER_BLOCK_DHW, LC.C0077_TIMER_BLOCK_DHW),
             attr(SA.TIMER_DEFROST, LC.C0141_TIMER_DEFROST),
             attr(SA.TIMER_HOT_GAS, LC.C0158_TIMER_HOT_GAS),
-        ],
+        ),
     ),
     descr(
         key=SensorKey.STATUS_LINE_1,
@@ -436,12 +436,12 @@ SENSORS: list[descr] = [
         key=SensorKey.ERROR_REASON,
         luxtronik_key=LC.C0100_ERROR_REASON,
         icon="mdi:alert",
-        extra_attributes=[
+        extra_attributes=(
             attr(SA.TIMESTAMP, LC.C0095_ERROR_TIME),
             attr(SA.CODE, LC.C0100_ERROR_REASON),
             attr(SA.CAUSE, LC.C0100_ERROR_REASON),
             attr(SA.REMEDY, LC.C0100_ERROR_REASON),
-        ],
+        ),
     ),
     # endregion Main heatpump
     # region Heating
@@ -454,13 +454,13 @@ SENSORS: list[descr] = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        extra_attributes=[
+        extra_attributes=(
             attr(
                 SA.MAX_ALLOWED,
                 LP.P0149_FLOW_IN_TEMPERATURE_MAX_ALLOWED,
                 SensorAttrFormat.CELSIUS_TENTH,
             ),
-        ],
+        ),
     ),
     descr(
         key=SensorKey.FLOW_OUT_TEMPERATURE,
@@ -481,13 +481,13 @@ SENSORS: list[descr] = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        extra_attributes=[
+        extra_attributes=(
             attr(
                 SA.SWITCH_GAP,
                 LC.C0011_FLOW_OUT_TEMPERATURE,
                 SensorAttrFormat.SWITCH_GAP,
             ),
-        ],
+        ),
     ),
     descr(
         key=SensorKey.OPERATION_HOURS_HEATING,


### PR DESCRIPTION
Hi!
After update to home assistant core 2024.1 luxtronik integration does not start properly:

```
Setup failed for custom integration 'luxtronik2': Unable to import component: Exception importing custom_components.luxtronik2
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/loader.py", line 822, in get_component
    ComponentProtocol, importlib.import_module(self.pkg_path)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/config/custom_components/luxtronik2/__init__.py", line 28, in <module>
    from .coordinator import LuxtronikCoordinator
  File "/config/custom_components/luxtronik2/coordinator.py", line 21, in <module>
    from .common import correct_key_value
  File "/config/custom_components/luxtronik2/common.py", line 25, in <module>
    from .model import LuxtronikCoordinatorData
  File "/config/custom_components/luxtronik2/model.py", line 89, in <module>
    @dataclass
     ^^^^^^^^^
  File "/usr/local/lib/python3.11/dataclasses.py", line 1230, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/usr/local/lib/python3.11/dataclasses.py", line 1220, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dataclasses.py", line 1027, in _process_class
    _init_fn(all_init_fields,
  File "/usr/local/lib/python3.11/dataclasses.py", line 545, in _init_fn
    raise TypeError(f'non-default argument {f.name!r} '
TypeError: non-default argument 'extra_attributes' follows default argument

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/setup.py", line 251, in _async_setup_component
    component = integration.get_component()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/loader.py", line 830, in get_component
    raise ImportError(f"Exception importing {self.pkg_path}") from err
ImportError: Exception importing custom_components.luxtronik2
```


I've tracked it down to the `extra_attributes` being set by the `default_factory`, which is not a value.

This PR changes type of `extra_attributes` to tuple to give it proper value in dataclass. With that change integration starts at my installation successfully.

All the best!