### PR TITLE
added time and day related evu events (related #38) #248

### DIFF
--- a/custom_components/luxtronik/const.py
+++ b/custom_components/luxtronik/const.py
@@ -731,6 +731,7 @@ class SensorAttrKey(StrEnum):
     EVU_SECOND_START_TIME = "EVU_second_start_time"
     EVU_SECOND_END_TIME = "EVU_second_end_time"
     EVU_MINUTES_UNTIL_NEXT_EVENT = "EVU_minutes_until_next_event"
+    EVU_DAYS = "EVU_days"
     TIMESTAMP = "timestamp"
     CODE = "code"
     CAUSE = "cause"

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -187,6 +187,7 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
     _attr_cache[SA.EVU_FIRST_END_TIME] = time.min
     _attr_cache[SA.EVU_SECOND_START_TIME] = time.min
     _attr_cache[SA.EVU_SECOND_END_TIME] = time.min
+    _attr_cache[SA.EVU_DAYS] = []
 
     _unrecorded_attributes = frozenset(
         LuxtronikSensorEntity._unrecorded_attributes
@@ -198,6 +199,7 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
             SA.EVU_SECOND_START_TIME,
             SA.EVU_SECOND_END_TIME,
             SA.EVU_MINUTES_UNTIL_NEXT_EVENT,
+            SA.EVU_DAYS,
         }
     )
 
@@ -212,6 +214,7 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
         super()._handle_coordinator_update(data)
         time_now = time(datetime.now().hour, datetime.now().minute)
         evu = LuxOperationMode.evu.value
+        weekday = datetime.today().weekday()
         if self._attr_native_value is None or self._last_state is None:
             pass
         elif self._attr_native_value == evu and str(self._last_state) != evu:
@@ -228,6 +231,8 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
                 self._attr_cache[SA.EVU_FIRST_START_TIME] = time_now
             else:
                 self._attr_cache[SA.EVU_SECOND_START_TIME] = time_now
+                if weekday not in self._attr_cache[SA.EVU_DAYS]:
+                    self._attr_cache[SA.EVU_DAYS].append(weekday)
         elif self._attr_native_value != evu and str(self._last_state) == evu:
             # evu end
             if (
@@ -384,7 +389,19 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
         if evu_time == time.min:
             return None
         evu_hours = (24 if evu_time < time_now else 0) + evu_time.hour
-        return (evu_hours - time_now.hour) * 60 + evu_time.minute - time_now.minute
+        weekday = datetime.today().weekday()
+        evu_pause = 0
+        if not self._attr_cache[SA.EVU_DAYS] and weekday not in self._attr_cache[SA.EVU_DAYS]:
+                evu_pause += 1440
+                for i in range(1, 7):
+                    if weekday+i > 6:
+                        i = -7+i
+                    if weekday+i in self._attr_cache[SA.EVU_DAYS]:
+                        return (evu_hours - time_now.hour) * 60 + evu_time.minute - time_now.minute + evu_pause
+                    else:
+                        evu_pause += 1440
+        else:
+            return (evu_hours - time_now.hour) * 60 + evu_time.minute - time_now.minute
 
     def _get_next_evu_event_time(self) -> time:
         event: time = time.min

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -392,7 +392,7 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
         weekday = datetime.today().weekday()
         evu_pause = 0
         if not self._attr_cache[SA.EVU_DAYS] and weekday not in self._attr_cache[SA.EVU_DAYS]:
-                evu_pause += 1440
+                evu_pause += (24 - datetime.now().hour)*60 - datetime.now().minute
                 for i in range(1, 7):
                     if weekday+i > 6:
                         i = -7+i

--- a/custom_components/luxtronik/sensor_entities_predefined.py
+++ b/custom_components/luxtronik/sensor_entities_predefined.py
@@ -51,6 +51,7 @@ SENSORS_STATUS: list[descr] = [
             attr(SA.EVU_FIRST_END_TIME, LC.UNSET, None, True),
             attr(SA.EVU_SECOND_START_TIME, LC.UNSET, None, True),
             attr(SA.EVU_SECOND_END_TIME, LC.UNSET, None, True),
+            attr(SA.EVU_DAYS, LC.UNSET, None, True),
         ),
         options=[e.value for e in LuxOperationMode],
         update_interval=UPDATE_INTERVAL_NORMAL,


### PR DESCRIPTION
i've added a new attribute `SA.EVU_DAYS` and a logic which saves the evu days into the mentioned attribute.
in the `_calc_next_evu_event_minutes(self)` is now a new fraction of code which takes care of the days on which the evu is not present. it calculates the "pause" time and adds it to `EVU_minutes_until_next_event`

Knows Bug:
@BenPru currently i get the following error because of wrong types:
```
  File "/config/custom_components/luxtronik2/sensor.py", line 443, in _wd_txt
    for i in value:
TypeError: 'datetime.time' object is not iterable
```

NOTE: i`ve changed `_attr_cache: dict[SA, object] = {}`