### PR TITLE
Be able to track history of room temperature

### DIFF
--- a/custom_components/luxtronik/sensor_entities_predefined.py
+++ b/custom_components/luxtronik/sensor_entities_predefined.py
@@ -543,6 +543,7 @@ SENSORS: list[descr] = [
         device_key=DeviceKey.heating,
         entity_category=None,
         icon="mdi:thermometer",
+        state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         visibility=LV.V0122_ROOM_THERMOSTAT,


### PR DESCRIPTION
The 'Heat room temperature' has no _state_class_ defined. Therefore it is not tracked in by the recorder into the long term statistics. 

https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics

Added the state_class to the entity.