### PR TITLE
restore evu date attribute correctly to solve the TypeError: 'datetime.time'

### DIFF
--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -396,8 +396,10 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
             return None
         evu_hours = (24 if evu_time < time_now else 0) + evu_time.hour
         weekday = datetime.today().weekday()
-        if not isinstance(self._attr_cache[SA.EVU_DAYS], list):
-            self._attr_cache[SA.EVU_DAYS] = list() 
+        if isinstance(self._attr_cache[SA.EVU_DAYS], str):
+            self._attr_cache[SA.EVU_DAYS] = self._attr_cache[SA.EVU_DAYS].split(',')
+        elif not isinstance(self._attr_cache[SA.EVU_DAYS], list):
+            self._attr_cache[SA.EVU_DAYS] = list()
         evu_pause = 0
         if not self._attr_cache[SA.EVU_DAYS] and weekday not in self._attr_cache[SA.EVU_DAYS]:
             evu_pause += (24 - datetime.now().hour)*60 - datetime.now().minute

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -459,7 +459,7 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
                     if day == name: 
                         vals.append(idx)
                         break
-            if len(vals):
+            if vals:
                 return vals 
         return time.min 
 

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -449,18 +449,18 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
         return ','.join(days)
 
     def _restore_attr_value(self, value: Any | None) -> Any:
-        if value is not None: 
-            if ',' in str(value):
-                vals = list() 
-                for day in str(value).split(","): 
-                    for idx, name in enumerate(calendar.day_name):
-                        if day == name: 
-                            vals.append(idx)
-                            break
-                return vals
+        if value is not None:
             if ":" in str(value):
                 vals = str(value).split(":")
                 return time(int(vals[0]), int(vals[1]))
+            vals = list() 
+            for day in str(value).split(","): 
+                for idx, name in enumerate(calendar.day_name):
+                    if day == name: 
+                        vals.append(idx)
+                        break
+            if len(vals):
+                return vals 
         return time.min 
 
 

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -216,6 +216,8 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
         time_now = time(datetime.now().hour, datetime.now().minute)
         evu = LuxOperationMode.evu.value
         weekday = datetime.today().weekday()
+        if not isinstance(self._attr_cache[SA.EVU_DAYS], list):
+            self._attr_cache[SA.EVU_DAYS] = list()
         if self._attr_native_value is None or self._last_state is None:
             pass
         elif self._attr_native_value == evu and str(self._last_state) != evu:
@@ -394,16 +396,18 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
             return None
         evu_hours = (24 if evu_time < time_now else 0) + evu_time.hour
         weekday = datetime.today().weekday()
+        if not isinstance(self._attr_cache[SA.EVU_DAYS], list):
+            self._attr_cache[SA.EVU_DAYS] = list() 
         evu_pause = 0
         if not self._attr_cache[SA.EVU_DAYS] and weekday not in self._attr_cache[SA.EVU_DAYS]:
-                evu_pause += (24 - datetime.now().hour)*60 - datetime.now().minute
-                for i in range(1, 7):
-                    if weekday+i > 6:
-                        i = -7+i
-                    if weekday+i in self._attr_cache[SA.EVU_DAYS]:
-                        return (evu_hours - time_now.hour) * 60 + evu_time.minute - time_now.minute + evu_pause
-                    else:
-                        evu_pause += 1440
+            evu_pause += (24 - datetime.now().hour)*60 - datetime.now().minute
+            for i in range(1, 7):
+                if weekday+i > 6:
+                    i = -7+i
+                if weekday+i in self._attr_cache[SA.EVU_DAYS]:
+                    return (evu_hours - time_now.hour) * 60 + evu_time.minute - time_now.minute + evu_pause
+                else:
+                    evu_pause += 1440
         else:
             return (evu_hours - time_now.hour) * 60 + evu_time.minute - time_now.minute
 
@@ -445,10 +449,19 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
         return ','.join(days)
 
     def _restore_attr_value(self, value: Any | None) -> Any:
-        if value is None or ":" not in str(value):
-            return time.min
-        vals = str(value).split(":")
-        return time(int(vals[0]), int(vals[1]))
+        if value is not None: 
+            if ',' in str(value):
+                vals = list() 
+                for day in str(value).split(","): 
+                    for idx, name in enumerate(calendar.day_name):
+                        if day == name: 
+                            vals.append(idx)
+                            break
+                return vals
+            if ":" in str(value):
+                vals = str(value).split(":")
+                return time(int(vals[0]), int(vals[1]))
+        return time.min 
 
 
 class LuxtronikIndexSensor(LuxtronikSensorEntity, SensorEntity):

--- a/custom_components/luxtronik/sensor_entities_predefined.py
+++ b/custom_components/luxtronik/sensor_entities_predefined.py
@@ -468,6 +468,7 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         entity_registry_enabled_default=False,
         native_precision=0,
+        min_firmware_version_minor=FirmwareVersionMinor.minor_88,
     ),
     # endregion Main heatpump
     # region Heating


### PR DESCRIPTION
restore the evu dates attribute and solve the TypeError: 'datetime.time' issue 
fixes #249 
fixes #281