### PR TITLE
Change the device_info and similar fields to instance variables.

### DIFF
--- a/custom_components/luxtronik/config_flow.py
+++ b/custom_components/luxtronik/config_flow.py
@@ -253,8 +253,13 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 discovery_info.ip,
             )
             # Validate dhcp result with socket broadcast:
-            broadcast_discover_ip, broadcast_discover_port = discover()[0]
-            if broadcast_discover_ip != discovery_info.ip:
+            heatpump_list = discover()
+            broadcast_discover_ip = ''
+            for heatpump in heatpump_list:
+                if heatpump[0] == discovery_info.ip:
+                  broadcast_discover_ip = heatpump[0]
+                  broadcast_discover_port = heatpump[1]
+            if broadcast_discover_ip == '':
                 return self.async_abort(reason="no_devices_found")
             config = dict[str, Any]()
             config[CONF_HOST] = broadcast_discover_ip

--- a/custom_components/luxtronik/coordinator.py
+++ b/custom_components/luxtronik/coordinator.py
@@ -71,10 +71,6 @@ def catch_luxtronik_errors(
 class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
     """Representation of a Luxtronik Coordinator."""
 
-    device_infos = dict[str, DeviceInfo]()
-    update_reason_write = False
-    client: Luxtronik = None
-
     def __init__(
         self,
         hass: HomeAssistant,
@@ -86,6 +82,8 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         self.lock = threading.Lock()
         self.client = client
         self._config = config
+        self.device_infos = dict[str, DeviceInfo]()
+        self.update_reason_write = False
         super().__init__(
             hass,
             LOGGER,

--- a/custom_components/luxtronik/lux_helper.py
+++ b/custom_components/luxtronik/lux_helper.py
@@ -83,6 +83,7 @@ def discover() -> list[tuple[str, int | None]]:
                             "an old Luxtronic software version might be the reason"
                         )
                     results.append((ip_address, res_port))
+                    continue
                 LOGGER.debug(
                     "Received response from %s, but with wrong content, skipping",
                     ip_address,


### PR DESCRIPTION
Currently, when multiple heat pumps are generated, the data is overwritten in the class variable `device_infos`. To separate the data of individual heat pumps, there is now a `device_infos` for each instance.


Fixes #292.