### PR TITLE
fix: change name of WaterHeaterEntityEntityDescription (breaking change as of HA 2025.1)

### DIFF
--- a/custom_components/luxtronik/model.py
+++ b/custom_components/luxtronik/model.py
@@ -20,9 +20,21 @@ from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.components.switch import SwitchEntityDescription
 from homeassistant.components.update import UpdateEntityDescription, UpdateDeviceClass
 from homeassistant.components.water_heater import (
-    WaterHeaterEntityEntityDescription,
-    WaterHeaterEntityFeature,
+    WaterHeaterEntityFeature
 )
+
+# fix breaking change due to typo in WaterHeaterEntityDescription (#132888)
+WaterHeaterEntityDescription = None
+
+try:
+    from homeassistant.components.water_heater import (
+        WaterHeaterEntityDescription
+    )
+except ImportError:
+    from homeassistant.components.water_heater import (
+        WaterHeaterEntityEntityDescription as WaterHeaterEntityDescription
+    )
+
 from homeassistant.const import Platform, UnitOfTemperature
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.typing import StateType
@@ -178,7 +190,7 @@ def metaclass_resolver(*classes):
 
 @dataclass
 class LuxtronikWaterHeaterDescription(
-    metaclass_resolver(LuxtronikEntityDescription, WaterHeaterEntityEntityDescription)
+    metaclass_resolver(LuxtronikEntityDescription, WaterHeaterEntityDescription)
 ):
     """Class describing Luxtronik water heater entities."""
 


### PR DESCRIPTION
`WaterHeaterEntityEntityDescription` has been renamed to `WaterHeaterEntityDescription`. This change was introduced in https://github.com/home-assistant/core/pull/132888 and is a breaking change as of HA 2025.1

This fix tries to be compatible to both names.

Should fix #309.