### PR TITLE
Feature/hot water for firmware 90

### DIFF
--- a/custom_components/luxtronik/const.py
+++ b/custom_components/luxtronik/const.py
@@ -1,4 +1,5 @@
 """Constants for the Luxtronik heatpump integration."""
+
 # region Imports
 from datetime import date, datetime, timedelta
 from decimal import Decimal
@@ -304,6 +305,7 @@ class LuxParameter(StrEnum):
     )
     P0090_RELEASE_SECOND_HEAT_GENERATOR: Final = "parameters.ID_Einst_ZWEFreig_akt"
     P0093_HEAT_SOURCE_INPUT_TEMPERATURE_MIN: Final = "parameters.ID_Einst_TWQmin_akt"
+    P0105_DHW_TARGET_TEMPERATURE: Final = "parameters.ID_Soll_BWS_akt"
     # MODE_COOLING: Automatic or Off
     P0108_MODE_COOLING: Final = "parameters.ID_Einst_BA_Kuehl_akt"
     P0110_COOLING_OUTDOOR_TEMP_THRESHOLD: Final = "parameters.ID_Einst_KuehlFreig_akt"
@@ -393,7 +395,9 @@ class LuxParameter(StrEnum):
     P1137_DHW_ENERGY_INPUT: Final = "parameters.Unknown_Parameter_1137"
     # ? P1138_SWIMMING_POOL_ENERGY_INPUT: Final = "parameters.Unknown_Parameter_1138" -->
     P1139_COOLING_ENERGY_INPUT: Final = "parameters.Unknown_Parameter_1139"
-    P1140_SECOND_HEAT_GENERATOR_AMOUNT_COUNTER: Final = "parameters.Unknown_Parameter_1140"
+    P1140_SECOND_HEAT_GENERATOR_AMOUNT_COUNTER: Final = (
+        "parameters.Unknown_Parameter_1140"
+    )
 
 
 # endregion Lux parameters
@@ -552,7 +556,9 @@ class LuxVisibility(StrEnum):
     V0086_ADDITIONAL_HEAT_GENERATOR_OPERATION_HOURS: Final = (
         "visibilities.ID_Visi_Bst_BStdZWE1"
     )
-    V0105_HEAT_SOURCE_INPUT_TEMPERATURE_MIN: Final = "visibilities.ID_Visi_EinstTemp_TWQmin"
+    V0105_HEAT_SOURCE_INPUT_TEMPERATURE_MIN: Final = (
+        "visibilities.ID_Visi_EinstTemp_TWQmin"
+    )
     V0121_EVU_LOCKED: Final = "visibilities.ID_Visi_SysEin_EVUSperre"
     V0122_ROOM_THERMOSTAT: Final = "visibilities.ID_Visi_SysEin_Raumstation"
     V0144_PUMP_OPTIMIZATION: Final = "visibilities.ID_Visi_SysEin_Pumpenoptim"
@@ -617,7 +623,7 @@ class SensorKey(StrEnum):
     ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER = (
         "additional_heat_generator_amount_counter"
     )
-    SECOND_HEAT_GENERATOR_AMOUNT_COUNTER= "second_heat_generator_amount_counter"
+    SECOND_HEAT_GENERATOR_AMOUNT_COUNTER = "second_heat_generator_amount_counter"
     ANALOG_OUT1 = "analog_out1"
     ANALOG_OUT2 = "analog_out2"
     CURRENT_HEAT_OUTPUT = "current_heat_output"

--- a/custom_components/luxtronik/manifest.json
+++ b/custom_components/luxtronik/manifest.json
@@ -3,22 +3,45 @@
   "name": "Luxtronik",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/luxtronik",
-  "requirements": ["luxtronik==0.3.14", "requests>=2.28.2", "getmac==0.8.2"],
+  "requirements": [
+    "luxtronik==0.3.14",
+    "requests>=2.28.2",
+    "getmac==0.8.2",
+    "packaging>=24.2"
+  ],
   "issue_tracker": "https://github.com/BenPru/luxtronik/issues",
-  "dependencies": ["http"],
+  "dependencies": [
+    "http"
+  ],
   "after_dependencies": [],
-  "codeowners": ["@BenPru"],
+  "codeowners": [
+    "@BenPru"
+  ],
   "iot_class": "local_polling",
   "version": "2025.1.4",
   "homeassistant": "2024.8.0",
   "dhcp": [
-    { "macaddress": "000E8C*" },
-    { "macaddress": "001999*" },
-    { "macaddress": "000982*" },
-    { "macaddress": "04D16E*" },
-    { "macaddress": "40ECF8*" },
-    { "hostname": "wp-novelan" }
+    {
+      "macaddress": "000E8C*"
+    },
+    {
+      "macaddress": "001999*"
+    },
+    {
+      "macaddress": "000982*"
+    },
+    {
+      "macaddress": "04D16E*"
+    },
+    {
+      "macaddress": "40ECF8*"
+    },
+    {
+      "hostname": "wp-novelan"
+    }
   ],
   "integration_type": "hub",
-  "loggers": ["luxtronik"]
+  "loggers": [
+    "luxtronik"
+  ]
 }

--- a/custom_components/luxtronik/model.py
+++ b/custom_components/luxtronik/model.py
@@ -1,10 +1,12 @@
 """The Luxtronik models."""
+
 # region Imports
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+from packaging.version import Version
 from typing import Any
 
 from luxtronik import Calculations, Parameters, Visibilities
@@ -19,20 +21,16 @@ from homeassistant.components.number import NumberEntityDescription, NumberMode
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.components.switch import SwitchEntityDescription
 from homeassistant.components.update import UpdateEntityDescription, UpdateDeviceClass
-from homeassistant.components.water_heater import (
-    WaterHeaterEntityFeature
-)
+from homeassistant.components.water_heater import WaterHeaterEntityFeature
 
 # fix breaking change due to typo in WaterHeaterEntityDescription (#132888)
 WaterHeaterEntityDescription = None
 
 try:
-    from homeassistant.components.water_heater import (
-        WaterHeaterEntityDescription
-    )
+    from homeassistant.components.water_heater import WaterHeaterEntityDescription
 except ImportError:
     from homeassistant.components.water_heater import (
-        WaterHeaterEntityEntityDescription as WaterHeaterEntityDescription
+        WaterHeaterEntityEntityDescription as WaterHeaterEntityDescription,
     )
 
 from homeassistant.const import Platform, UnitOfTemperature
@@ -91,6 +89,8 @@ class LuxtronikEntityDescription(EntityDescription):
     visibility: LuxVisibility = LuxVisibility.UNSET
     invisible_if_value: Any | None = None
     min_firmware_version_minor: FirmwareVersionMinor | None = None
+    min_firmware_version: Version | None = None
+    max_firmware_version: Version | None = None
 
     extra_attributes: tuple(LuxtronikEntityAttributeDescription) = ()
     state_class: str | None = None
@@ -185,8 +185,13 @@ class LuxtronikClimateDescription(
 
 def metaclass_resolver(*classes):
     metaclass = tuple(set(type(cls) for cls in classes))
-    metaclass = metaclass[0] if len(metaclass)==1 else type("_".join(mcls.__name__ for mcls in metaclass), metaclass, {})   # class M_C
-    return metaclass("_".join(cls.__name__ for cls in classes), classes, {})   
+    metaclass = (
+        metaclass[0]
+        if len(metaclass) == 1
+        else type("_".join(mcls.__name__ for mcls in metaclass), metaclass, {})
+    )  # class M_C
+    return metaclass("_".join(cls.__name__ for cls in classes), classes, {})
+
 
 @dataclass
 class LuxtronikWaterHeaterDescription(
@@ -215,4 +220,3 @@ class LuxtronikUpdateEntityDescription(
 
     device_class = UpdateDeviceClass.FIRMWARE
     platform = Platform.UPDATE
-    

--- a/custom_components/luxtronik/number_entities_predefined.py
+++ b/custom_components/luxtronik/number_entities_predefined.py
@@ -1,4 +1,7 @@
 """Luxtronik number sensors definitions."""
+
+from packaging.version import Version
+
 # region Imports
 from homeassistant.components.number import NumberMode
 from homeassistant.components.sensor import SensorDeviceClass
@@ -12,6 +15,7 @@ from homeassistant.helpers.entity import EntityCategory
 
 from .const import (
     DeviceKey,
+    FirmwareVersionMinor,
     LuxCalculation as LC,
     LuxParameter as LP,
     LuxVisibility as LV,
@@ -98,7 +102,7 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         icon="mdi:download-lock",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        native_min_value=-20.0, # -9.0
+        native_min_value=-20.0,  # -9.0
         native_max_value=0.0,
         native_step=0.5,
         entity_category=EntityCategory.CONFIG,
@@ -380,6 +384,22 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         native_min_value=-40.0,
         native_max_value=60.0,
         native_step=1.0,
+        max_firmware_version=Version("3.90.0"),
+        update_interval=None,
+    ),
+    # Bug #280 since firmware 3.90.1 different set point
+    LuxtronikNumberDescription(
+        key=SensorKey.DHW_TARGET_TEMPERATURE,
+        luxtronik_key=LP.P0105_DHW_TARGET_TEMPERATURE,
+        device_key=DeviceKey.domestic_water,
+        mode=NumberMode.BOX,
+        icon="mdi:thermometer-water",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=-40.0,
+        native_max_value=60.0,
+        native_step=1.0,
+        min_firmware_version=Version("3.90.1"),
         update_interval=None,
     ),
     LuxtronikNumberDescription(
@@ -481,7 +501,7 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         key=SensorKey.COOLING_OUTDOOR_TEMP_THRESHOLD,
         luxtronik_key=LP.P0110_COOLING_OUTDOOR_TEMP_THRESHOLD,
         device_key=DeviceKey.cooling,
-        icon='mdi:sun-thermometer',
+        icon="mdi:sun-thermometer",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         native_min_value=18.0,
@@ -490,12 +510,12 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         entity_category=EntityCategory.CONFIG,
         mode=NumberMode.BOX,
         visibility=LV.V0005_COOLING,
-    ),    
+    ),
     LuxtronikNumberDescription(
         key=SensorKey.COOLING_START_DELAY_HOURS,
         luxtronik_key=LP.P0850_COOLING_START_DELAY_HOURS,
         device_key=DeviceKey.cooling,
-        icon='mdi:clock-start',
+        icon="mdi:clock-start",
         native_unit_of_measurement=UnitOfTime.HOURS,
         native_min_value=0.0,
         native_max_value=12.0,
@@ -508,7 +528,7 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         key=SensorKey.COOLING_STOP_DELAY_HOURS,
         luxtronik_key=LP.P0851_COOLING_STOP_DELAY_HOURS,
         device_key=DeviceKey.cooling,
-        icon='mdi:clock-end',
+        icon="mdi:clock-end",
         native_unit_of_measurement=UnitOfTime.HOURS,
         native_min_value=0.0,
         native_max_value=12.0,
@@ -521,7 +541,7 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         key=SensorKey.COOLING_TARGET_TEMPERATURE_MK1,
         luxtronik_key=LP.P0132_COOLING_TARGET_TEMPERATURE_MK1,
         device_key=DeviceKey.cooling,
-        icon='mdi:sun-thermometer',
+        icon="mdi:sun-thermometer",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         native_min_value=18.0,
@@ -530,12 +550,12 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         entity_category=EntityCategory.CONFIG,
         mode=NumberMode.BOX,
         visibility=LP.P0042_MIXING_CIRCUIT1_TYPE,
-    ), 
+    ),
     LuxtronikNumberDescription(
         key=SensorKey.COOLING_TARGET_TEMPERATURE_MK2,
         luxtronik_key=LP.P0133_COOLING_TARGET_TEMPERATURE_MK2,
         device_key=DeviceKey.cooling,
-        icon='mdi:sun-thermometer',
+        icon="mdi:sun-thermometer",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         native_min_value=18.0,
@@ -544,12 +564,12 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         entity_category=EntityCategory.CONFIG,
         mode=NumberMode.BOX,
         visibility=LP.P0130_MIXING_CIRCUIT2_TYPE,
-    ), 
+    ),
     LuxtronikNumberDescription(
         key=SensorKey.COOLING_TARGET_TEMPERATURE_MK3,
         luxtronik_key=LP.P0966_COOLING_TARGET_TEMPERATURE_MK3,
         device_key=DeviceKey.cooling,
-        icon='mdi:sun-thermometer',
+        icon="mdi:sun-thermometer",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         native_min_value=18.0,
@@ -558,7 +578,6 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         entity_category=EntityCategory.CONFIG,
         mode=NumberMode.BOX,
         visibility=LP.P0780_MIXING_CIRCUIT3_TYPE,
-    ), 
+    ),
     # endregion Cooling
 ]
-


### PR DESCRIPTION
This should fix the annoying bug for firmwares >= 3.90.1 to not being able to set the hot water temperature any more:

The change introduces a way to compare the firmware for min and max version (the complete version, not only the minor number, as we need to compare against 3.90.1 vs. 3.90.0), but still keeps the old logic for compatibility.

The patch uses  ID_Soll_BWS_akt for hot water target temperature now.
Fixes #280 
