### PR TITLE
Fix firmware version check for V3.91

### DIFF
--- a/custom_components/luxtronik/update.py
+++ b/custom_components/luxtronik/update.py
@@ -155,9 +155,9 @@ class LuxtronikUpdateEntity(LuxtronikEntity, UpdateEntity):
                     datetime.utcnow().timestamp()
                 )
                 # Filename e.g.: wp2reg-V2.88.1-9086
-                # Extract 'V2.88.1-9086' from 'wp2reg-V2.88.1-9086'
-                # Extract V1.88.3-9717 from 'wpreg.V1.88.3-9717'
                 # Extract 'V3.91.0' from 'wp2reg-V3.91.0_d0dc76bb'
+                # Extract 'V2.88.1-9086' from 'wp2reg-V2.88.1-9086'
+                # Extract 'V1.88.3-9717' from 'wpreg.V1.88.3-9717'
                 match = re.search(r'V\d+\.\d+\.\d+(?:-\d+$)?', filename)
                 self.__firmware_version_available = match.group(0)
             except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
This PR fixes firmware version check for V3.91 version that has new filename format (wp2reg-V3.91.0_d0dc76bb) https://github.com/BenPru/luxtronik/issues/361