### PR TITLE
Increase minimal HA version manifest.json

### DIFF
--- a/custom_components/luxtronik/manifest.json
+++ b/custom_components/luxtronik/manifest.json
@@ -19,7 +19,7 @@
   ],
   "iot_class": "local_polling",
   "version": "2025.7.20",
-  "homeassistant": "2024.8.0",
+  "homeassistant": "2025.6.0",
   "dhcp": [
     {
       "macaddress": "000E8C*"


### PR DESCRIPTION
The latest version of the release doesn't seem to work with older versions of home assistant. It's unclear from which version it breaks.