### PR TITLE
Resolve Status-Cooling flickering

### DIFF
--- a/custom_components/luxtronik/common.py
+++ b/custom_components/luxtronik/common.py
@@ -95,6 +95,15 @@ def correct_key_value(
     ):
         return LuxStatus1Option.compressor_heater
     # endregion Workaround Luxtronik Bug: Line 1 shows 'pump forerun' on CompressorHeater!
+    # region Workaround Detect passive cooling operation mode
+    if (
+        sensor_id == LC.C0080_STATUS
+        and value == LuxOperationMode.no_request 
+        and bool(get_sensor_data(sensors,LC.C0119_STATUS_LINE_3) == 'cooling')
+    ):
+        return LuxOperationMode.cooling
+    # endregion Workaround Detect passive cooling operation mode
+    
     return value
 
 

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -304,27 +304,6 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
                     self._attr_native_value = LuxOperationMode.domestic_water.value
             # endregion Workaround Thermal desinfection with (only) using 2nd heatsource
 
-            # region Workaround Detect passive cooling operation mode
-            if self._attr_native_value == LuxOperationMode.no_request.value:
-                # detect passive cooling
-                if self.coordinator.detect_cooling_present():
-                    T_in = self._get_value(LC.C0010_FLOW_IN_TEMPERATURE)
-                    T_out = self._get_value(LC.C0011_FLOW_OUT_TEMPERATURE)
-                    T_heat_in = self._get_value(LC.C0204_HEAT_SOURCE_INPUT_TEMPERATURE)
-                    T_heat_out = self._get_value(
-                        LC.C0024_HEAT_SOURCE_OUTPUT_TEMPERATURE
-                    )
-                    Flow_WQ = self._get_value(LC.C0173_HEAT_SOURCE_FLOW_RATE)
-                    Pump = self._get_value(LC.C0043_PUMP_FLOW)
-                    if (
-                        (T_out > T_in)
-                        and (T_heat_out > T_heat_in)
-                        and (Flow_WQ > 0)
-                        and Pump
-                    ):
-                        # LOGGER.info(f"Cooling mode detected!!!")
-                        self._attr_native_value = LuxOperationMode.cooling.value
-            # endregion Workaround Detect passive cooling operation mode
         # endregion Workaround Luxtronik Bug
 
         self._last_state = self._attr_native_value


### PR DESCRIPTION
When cooling, HP status was displayed as idle for 0.001s every 1-2 minutes. Changed the detection and moved it from sensor.py to common.py