### PR TITLE
Change factor value from 0.1 to 0.01 for additional_heat_generator_amount_counter 

### DIFF
--- a/custom_components/luxtronik/sensor_entities_predefined.py
+++ b/custom_components/luxtronik/sensor_entities_predefined.py
@@ -350,7 +350,7 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         invisible_if_value=0.0,
         visibility=LV.V0324_ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER,
-        factor=0.1,
+        factor=0.01,
         native_precision=1,
         update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),


### PR DESCRIPTION
The factor was incorrect for the auxiliary heating.
Instead of 54.9 kWh, 549 kWh was displayed.
With this changes it works with my:
- **Alpha-Innotec:** LWD 70A
- **Software Version:** V2.88.3
- **Heatpump Typ:** LD7