### PR TITLE
Fix DHW minimum temperature to match myUplink (30°C)

### DIFF
--- a/custom_components/luxtronik/const.py
+++ b/custom_components/luxtronik/const.py
@@ -42,6 +42,8 @@ UPDATE_INTERVAL_VERY_SLOW: Final = timedelta(minutes=5)
 
 
 SECOND_TO_HOUR_FACTOR: Final = 1 / 3600
+
+DEFAULT_DHW_MIN_TEMPERATURE: Final = 30.0
 # endregion Constants Main
 
 # region Conf

--- a/custom_components/luxtronik/number_entities_predefined.py
+++ b/custom_components/luxtronik/number_entities_predefined.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import EntityCategory
 
 from .const import (
+    DEFAULT_DHW_MIN_TEMPERATURE,
     DeviceKey,
     LuxCalculation as LC,
     LuxParameter as LP,
@@ -492,7 +493,7 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         icon="mdi:thermometer-water",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        native_min_value=5.0,
+        native_min_value=DEFAULT_DHW_MIN_TEMPERATURE,
         native_max_value=65.0,
         native_step=0.5,
         max_firmware_version=Version("3.90.0"),
@@ -507,7 +508,7 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         icon="mdi:thermometer-water",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        native_min_value=5.0,
+        native_min_value=DEFAULT_DHW_MIN_TEMPERATURE,
         native_max_value=65.0,
         native_step=0.5,
         min_firmware_version=Version("3.90.1"),

--- a/custom_components/luxtronik/water_heater.py
+++ b/custom_components/luxtronik/water_heater.py
@@ -29,6 +29,7 @@ from .common import get_sensor_data, key_exists
 from .const import (
     CONF_COORDINATOR,
     CONF_HA_SENSOR_PREFIX,
+    DEFAULT_DHW_MIN_TEMPERATURE,
     DOMAIN,
     LOGGER,
     DeviceKey,
@@ -135,7 +136,7 @@ class LuxtronikWaterHeater(LuxtronikEntity, WaterHeaterEntity):
 
     entity_description: LuxtronikWaterHeaterDescription
 
-    _attr_min_temp = 40.0
+    _attr_min_temp = DEFAULT_DHW_MIN_TEMPERATURE
     _attr_target_temperature_step = 0.5
 
     _last_operation_mode_before_away: str | None = None


### PR DESCRIPTION
- Lower the minimum DHW temperature from 40°C to 30°C to match the myUplink interface
- Add `DEFAULT_DHW_MIN_TEMPERATURE` constant for consistency across entities
- Apply the new minimum to both the water heater entity and the DHW target temperature number entities

## Background

The previous minimum of 40°C for the water heater was arbitrarily set during initial implementation. The number entities used 5°C which was also arbitrary. The myUplink interface allows 30-58°C, so 30°C is now used as the authoritative minimum.

No Luxtronik register exists for minimum DHW temperature (only `P0973_MAX_DHW_TEMPERATURE` for maximum), so a hardcoded value is appropriate here 😢.

## Test plan

- [x] Verify water heater entity allows setting temperature down to 30°C
- [x] Verify DHW target temperature number entity allows values down to 30°C
- [x] Confirm heat pump accepts the lower temperature setpoint

## Issues

Fixes #498