### PR TITLE
fix #539: allow IP change via options dialog and auto-discovery

### DIFF
--- a/custom_components/luxtronik/config_flow.py
+++ b/custom_components/luxtronik/config_flow.py
@@ -19,6 +19,7 @@ from .const import (
     CONF_HA_SENSOR_PREFIX,
     CONF_MAX_DATA_LENGTH,
     CONFIG_ENTRY_VERSION,
+    DEFAULT_HOST,
     DEFAULT_MAX_DATA_LENGTH,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
@@ -333,8 +334,10 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                 )
 
-            if not await self._set_unique_id_or_abort(coordinator, config):
-                return self.async_abort(reason="already_configured")
+            await self.async_set_unique_id(coordinator.unique_id)
+            self._abort_if_unique_id_configured(
+                updates={CONF_HOST: host, CONF_PORT: int(port)}
+            )
 
             return self._create_entry(config, coordinator)
 
@@ -372,64 +375,67 @@ class LuxtronikOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the user options step."""
+        errors: dict[str, str] = {}
+
+        current_host = self.config_entry.data.get(CONF_HOST, DEFAULT_HOST)
+        current_port = self.config_entry.data.get(CONF_PORT, DEFAULT_PORT)
+        current_indoor_temp = self._get_value(CONF_HA_SENSOR_INDOOR_TEMPERATURE)
+
         try:
-            LOGGER.info("user_input: %s", user_input)
-
-            new_options = dict(self.options)
-
             if user_input is not None:
-                # User submitted the form
-                value = user_input.get(CONF_HA_SENSOR_INDOOR_TEMPERATURE)
-                if value:
-                    new_options[CONF_HA_SENSOR_INDOOR_TEMPERATURE] = value
-                elif CONF_HA_SENSOR_INDOOR_TEMPERATURE in new_options:
-                    new_options[CONF_HA_SENSOR_INDOOR_TEMPERATURE] = None
+                host = user_input.get(CONF_HOST, current_host)
+                port = int(user_input.get(CONF_PORT, current_port))
 
-                LOGGER.info("new_options: %s", new_options)
+                config = {
+                    CONF_HOST: host,
+                    CONF_PORT: port,
+                    CONF_TIMEOUT: self.config_entry.data.get(
+                        CONF_TIMEOUT, DEFAULT_TIMEOUT
+                    ),
+                    CONF_MAX_DATA_LENGTH: self.config_entry.data.get(
+                        CONF_MAX_DATA_LENGTH, DEFAULT_MAX_DATA_LENGTH
+                    ),
+                }
 
-                # Merge options from user_input into data
-                self.hass.config_entries.async_update_entry(
-                    self.config_entry,
-                    data=self.config_entry.data | user_input,
-                    options=new_options,
+                try:
+                    await connect_and_get_coordinator(self.hass, config)
+                except LuxtronikConnectionError:
+                    errors["base"] = "cannot_connect"
+                else:
+                    new_options = dict(self.options)
+                    value = user_input.get(CONF_HA_SENSOR_INDOOR_TEMPERATURE)
+                    if value:
+                        new_options[CONF_HA_SENSOR_INDOOR_TEMPERATURE] = value
+                    elif CONF_HA_SENSOR_INDOOR_TEMPERATURE in new_options:
+                        new_options[CONF_HA_SENSOR_INDOOR_TEMPERATURE] = None
+
+                    self.hass.config_entries.async_update_entry(
+                        self.config_entry,
+                        data=self.config_entry.data | user_input,
+                        options=new_options,
+                    )
+                    await self.hass.config_entries.async_reload(
+                        self.config_entry.entry_id
+                    )
+                    return self.async_create_entry(title="", data={})
+
+                # Connection failed — keep user's input for re-display
+                current_host = host
+                current_port = port
+                current_indoor_temp = user_input.get(
+                    CONF_HA_SENSOR_INDOOR_TEMPERATURE, current_indoor_temp
                 )
 
-                # Reload the config entry to apply changes immediately
-                await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-
-                return self.async_create_entry(title="", data={})
-
-            # User opened the form but didn't submit anything
-
-            config = {
-                CONF_HOST: self.config_entry.data.get(CONF_HOST),
-                CONF_PORT: self.config_entry.data.get(CONF_PORT, DEFAULT_PORT),
-                CONF_TIMEOUT: self.config_entry.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
-                CONF_MAX_DATA_LENGTH: self.config_entry.data.get(
-                    CONF_MAX_DATA_LENGTH, DEFAULT_MAX_DATA_LENGTH
-                ),
-            }
-
-            try:
-                coordinator = await connect_and_get_coordinator(self.hass, config)
-            except LuxtronikConnectionError as err:
-                return self.async_abort(
-                    reason="cannot_connect",
-                    description_placeholders={
-                        "host": err.host,
-                        "connect_error": str(err.original),
-                    },
-                )
-
-            # Show form with current value
-            title = f"{coordinator.manufacturer} {coordinator.model} {coordinator.serial_number}"
-            name = f"{title} ({self.config_entry.data[CONF_HOST]}:{self.config_entry.data[CONF_PORT]})"
-            current_value = self._get_value(CONF_HA_SENSOR_INDOOR_TEMPERATURE)
-
+            name = f"{current_host}:{current_port}"
             return self.async_show_form(
                 step_id="user",
-                data_schema=build_options_schema(current_value=current_value),
+                data_schema=build_options_schema(
+                    host=current_host,
+                    port=current_port,
+                    current_value=current_indoor_temp,
+                ),
                 description_placeholders={"name": name},
+                errors=errors,
             )
 
         except Exception as err:

--- a/custom_components/luxtronik/schema_helper.py
+++ b/custom_components/luxtronik/schema_helper.py
@@ -29,10 +29,14 @@ def build_user_data_schema(
 
 
 def build_options_schema(
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
     current_value: str | None = None,
 ) -> vol.Schema:
     return vol.Schema(
         {
+            vol.Required(CONF_HOST, default=host): str,
+            vol.Required(CONF_PORT, default=port): int,
             vol.Optional(
                 CONF_HA_SENSOR_INDOOR_TEMPERATURE,
                 default=current_value,
@@ -41,6 +45,6 @@ def build_options_schema(
                 selector.EntitySelectorConfig(
                     domain="sensor", device_class="temperature"
                 )
-            )
+            ),
         }
     )

--- a/custom_components/luxtronik/translations/de.json
+++ b/custom_components/luxtronik/translations/de.json
@@ -966,16 +966,23 @@
                 "title": "Optionen f\u00fcr {name} konfigurieren",
                 "description": "Einstellungen f\u00fcr die Luxtronik-W\u00e4rmepumpe {name}.",
                 "data": {
+                    "host": "Host",
+                    "port": "Netzwerk-Port",
                     "ha_sensor_indoor_temperature": "Sensor-ID f\u00fcr die Raumtemperatur",
                     "control_mode_home_assistant": "Experimentell!: Thermostatstatus \u00fcber Home Assistant steuern.",
                     "ha_sensor_prefix": "Pr\u00e4fix f\u00fcr Entity-IDs"
                 },
                 "data_description": {
+                    "host": "Hostname oder IP-Adresse",
+                    "port": "Normalerweise 8889 oder 8888",
                     "ha_sensor_indoor_temperature": "Ein Thermostat zur Heizungssteuerung wird in Home Assistant erstellt. Die tats\u00e4chliche Temperatur wird von einem Home Assistant-Sensor gesetzt.\nWenn Luxtronik mit einem Hardware-Raumthermostat verbunden ist, sollte dieses Feld leer bleiben.",
                     "control_mode_home_assistant": "Wenn sich das Home Assistant-Thermostat im Leerlauf befindet, wird der Aus-Zustand an Luxtronik gemeldet und Luxtronik kann dieses Element nicht starten.",
                     "ha_sensor_prefix": "Wichtig bei Verwendung mehrerer W\u00e4rmepumpen. Bei einer einzelnen kann einfach 'luxtronik' verwendet werden."
                 }
             }
+        },
+        "error": {
+            "cannot_connect": "Verbindung zur Luxtronik-W\u00e4rmepumpe fehlgeschlagen. Bitte Host und Port \u00fcberpr\u00fcfen."
         }
     }
 }

--- a/custom_components/luxtronik/translations/en.json
+++ b/custom_components/luxtronik/translations/en.json
@@ -707,16 +707,23 @@
                 "title": "Configure options for {name}",
                 "description": "Settings for the Luxtronik heat pump {name}.",
                 "data": {
+                    "host": "Host",
+                    "port": "Network Port",
                     "ha_sensor_indoor_temperature": "Sensor ID for the indoor temperature",
                     "control_mode_home_assistant": "Experimental!: Control thermostat on/off status by Home Assistant.",
                     "ha_sensor_prefix": "Prefix entity IDs"
                 },
                 "data_description": {
+                    "host": "Hostname or IP address",
+                    "port": "Normally 8889 or 8888",
                     "ha_sensor_indoor_temperature": "A thermostat for heating control is created in Home Assistant. The actual temperature for this is set by a Home Assistant sensor.\nIf Luxtronik is connected to a hardware room thermostat, then this field should be left empty.",
                     "control_mode_home_assistant": "When the Home Assistant Thermostat is in the Idle state, the Off state is reported to Luxtronik and Luxtronik cannot start this item.",
                     "ha_sensor_prefix": "Important if several heat pumps are used.\nIn the case of a single one, 'luxtronik' can simply be used."
                 }
             }
+        },
+        "error": {
+            "cannot_connect": "Failed to connect to the Luxtronik heat pump. Please check the host and port."
         }
     }
 }


### PR DESCRIPTION
Fixes: #539 

- Options flow now shows the form immediately without connecting first, so users can correct the IP when the heat pump is unreachable. Connection errors appear inline in the form instead of aborting.
- Host and port fields added to the options form.
- DHCP discovery now updates the IP of an existing entry automatically using _abort_if_unique_id_configured(updates=...) instead of just aborting when the unique ID is already known.