### PR TITLE
Remove unnecessary StatusLine3 warning log

### DIFF
--- a/custom_components/luxtronik/common.py
+++ b/custom_components/luxtronik/common.py
@@ -159,9 +159,6 @@ def correct_key_value(
         status_line3 = get_sensor_data(
             coordinator, LC.C0119_STATUS_LINE_3, raw_value=True
         )
-        if status_line3 is None:
-            LOGGER.warning("StatusLine3 is None!")
-
         # region Workaround Detect passive cooling operation mode
         if status_line3 is not None and status_line3 == LuxStatus3Option.cooling.value:
             return LuxOperationMode.cooling


### PR DESCRIPTION
## Remove unnecessary StatusLine3 warning log 🔇

### Problem
The `StatusLine3 is None!` warning was being logged multiple times per update cycle, flooding the logs with unnecessary noise.

### Root Cause
`StatusLine3` being `None` is a **completely expected state** when the heat pump is idle (`no_request`). The status display line 3 simply has nothing to show. ✅

### Evidence
The codebase already handles this case correctly:
- In `common.py` — all comparisons use `if status_line3 is not None and ...`
- In `sensor.py` — `None` is explicitly listed as a valid value in the workaround list

### Fix
Removed the warning log entirely since it provides no diagnostic value. 🧹