### PR TITLE
Fix linter workflow checkout for fork PRs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Ruff check
         uses: astral-sh/ruff-action@v3


### PR DESCRIPTION
## Fix linter workflow checkout for fork PRs 🔧

### Problem
The linter workflow fails on checkout when a PR is submitted from a fork:

```
git fetch ... +refs/heads/fix/remove-statusline3-warning*:...
The process '/usr/bin/git' failed with exit code 1
```

### Root Cause
The checkout step uses `ref: ${{ github.head_ref || github.ref_name }}`, which resolves to the **fork's branch name**. Since that branch doesn't exist on the upstream repo, the fetch fails. ❌

### Fix
Removed the explicit `ref:` parameter. The default `actions/checkout` behavior for `pull_request` events already correctly checks out the PR merge commit — including PRs from forks. ✅

### Note
⚠️ This fix must be merged into `main` first, as GitHub Actions uses the workflow file from the **base branch** for `pull_request` events.
