### PR TITLE
chore(ci): add pyproject.toml and rewrite linter workflow

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,61 +1,61 @@
-# This workflow executes several linters 
-# disable email notifications in your settings: 
-# https://github.com/settings/notifications
 name: Linter
 
-# Ruff is a commonly used and fast linter for home assistant.
 on:
   push:
-    branches: 
+    branches:
       - "main"
+    paths:
+      - "custom_components/luxtronik/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/linter.yml"
   pull_request:
+    paths:
+      - "custom_components/luxtronik/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/linter.yml"
   workflow_dispatch:
 
-# Allow Ruff to apply fixes
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  # Ruff format is a comprehensive formatting
-  run-ruff:
+  ruff:
     name: Ruff
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false # complete all jobs
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
 
-      - name: Ruff check
-        uses: astral-sh/ruff-action@v3
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }} # optional to reduce api calls
-      
-      - name: Ruff check HA
-        uses: astral-sh/ruff-action@v3
-        with:
-          github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }} # optional to reduce api calls
-          args: "check --select F,E,W,I,UP,B,SIM,ASYNC,T20,LOG,RUF"
-      
-      - name: Ruff format
-        uses: astral-sh/ruff-action@v3
-        with:
-          github-token: ${{ secrets.CUSTOM_GITHUB_TOKEN }} # optional to reduce api calls
-          args: "format --check --diff"
+          python-version: "3.13"
 
-  # CodeSpell performs a spellcheck. English only.      
-  run-codespell:
+      - name: Install Ruff
+        run: pip install --upgrade ruff
+
+      - name: Ruff format check
+        run: ruff format --check custom_components/luxtronik tests
+
+      - name: Ruff lint check
+        run: ruff check custom_components/luxtronik tests
+
+  codespell:
     name: CodeSpell
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false # complete all jobs
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: CodeSpell
-        uses: codespell-project/actions-codespell@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          skip: cs.json,de.json,nl.json,pl.json # skip these files
-          ignore_words_list: hass # skip these words
+          python-version: "3.13"
+
+      - name: Install codespell
+        run: pip install --upgrade codespell
+
+      - name: Run codespell
+        run: codespell custom_components/luxtronik tests

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,17 +4,7 @@ on:
   push:
     branches:
       - "main"
-    paths:
-      - "custom_components/luxtronik/**"
-      - "tests/**"
-      - "pyproject.toml"
-      - ".github/workflows/linter.yml"
   pull_request:
-    paths:
-      - "custom_components/luxtronik/**"
-      - "tests/**"
-      - "pyproject.toml"
-      - ".github/workflows/linter.yml"
   workflow_dispatch:
 
 permissions:
@@ -24,6 +14,8 @@ jobs:
   ruff:
     name: Ruff
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # complete all jobs
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -31,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install Ruff
         run: pip install --upgrade ruff
@@ -45,6 +37,8 @@ jobs:
   codespell:
     name: CodeSpell
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # complete all jobs
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -52,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install codespell
         run: pip install --upgrade codespell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[tool.ruff]
+target-version = "py313"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "F",      # Pyflakes
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "I",      # isort
+    "UP",     # pyupgrade
+    "B",      # flake8-bugbear
+    "SIM",    # flake8-simplify
+    "ASYNC",  # flake8-async
+    "T20",    # flake8-print
+    "LOG",    # flake8-logging
+    "RUF",    # Ruff-specific rules
+]
+ignore = [
+    "E501",   # Line too long - not enforced, formatter handles what it can
+    "RUF009",  # Mutable dataclass defaults - standard HA entity description pattern
+    "RUF012",  # Mutable class variable - standard HA entity pattern
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+combine-as-imports = true
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.codespell]
+skip = "custom_components/luxtronik/translations"
+ignore-words-list = "hass"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"


### PR DESCRIPTION
🔧 **What:** Add centralized tool configuration and fix the CI linter workflow for fork PRs.

📋 **Changes:**
- Add `pyproject.toml` with ruff (linter + formatter), codespell, and pytest config
- Rewrite `.github/workflows/linter.yml` to use explicit `pip install` + CLI commands
- Target Python 3.13 (HA minimum), line-length 88 (ruff default)
- Ruff rules: `F, E, W, I, UP, B, SIM, ASYNC, T20, LOG, RUF`

💡 **Why:**
- The previous workflow used `astral-sh/ruff-action@v3` with `contents: write` and `ref: ${{ github.head_ref }}`, which broke on fork PRs (the ref doesn't exist on upstream)
- Centralizing config in `pyproject.toml` makes it easy to run locally: `ruff check .` / `ruff format .`

⚠️ **Note:** This PR only adds config — no code changes. Subsequent PRs apply the fixes flagged by ruff.
