### PR TITLE
style: 🎨 remove obsolete noqa comments and simplify str conversions

### DIFF
--- a/custom_components/luxtronik/__init__.py
+++ b/custom_components/luxtronik/__init__.py
@@ -2,6 +2,7 @@
 
 # region Imports
 from __future__ import annotations
+
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -13,6 +14,7 @@ from homeassistant.helpers.entity_registry import (
     async_get,
 )
 
+from .common import convert_to_int_if_possible
 from .const import (
     ATTR_PARAMETER,
     ATTR_VALUE,
@@ -29,11 +31,10 @@ from .const import (
     SERVICE_WRITE_SCHEMA,
     SensorKey as SK,
 )
+from .coordinator import LuxtronikCoordinator, connect_and_get_coordinator
 
 # Apply global overrides before anything else
 from .lux_overrides import update_Luxtronik_HeatpumpCodes, update_Luxtronik_Parameters
-from .common import convert_to_int_if_possible
-from .coordinator import LuxtronikCoordinator, connect_and_get_coordinator
 
 # endregion Imports
 

--- a/custom_components/luxtronik/__init__.py
+++ b/custom_components/luxtronik/__init__.py
@@ -382,10 +382,7 @@ async def _up_many(
 def _identifiers_exists(
     identifiers_list: list[set[tuple[str, str]]], identifiers: set[tuple[str, str]]
 ) -> bool:
-    for ident in identifiers_list:
-        if ident == identifiers:
-            return True
-    return False
+    return any(ident == identifiers for ident in identifiers_list)
 
 
 async def _async_delete_legacy_devices(hass: HomeAssistant, config_entry: ConfigEntry):

--- a/custom_components/luxtronik/base.py
+++ b/custom_components/luxtronik/base.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
 from enum import StrEnum
+from typing import Any
 
 from homeassistant.components.water_heater import STATE_HEAT_PUMP
 from homeassistant.const import STATE_OFF, UnitOfTemperature, UnitOfTime
@@ -18,8 +18,8 @@ from homeassistant.util.dt import utcnow
 
 from .common import get_sensor_data
 from .const import (
-    DeviceKey,
     LOGGER,
+    DeviceKey,
     LuxCalculation as LC,
     LuxMode,
     LuxOperationMode,

--- a/custom_components/luxtronik/binary_sensor.py
+++ b/custom_components/luxtronik/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .base import LuxtronikEntity
 from .binary_sensor_entities_predefined import BINARY_SENSORS
 from .common import get_sensor_data, key_exists
-from .const import CONF_COORDINATOR, CONF_HA_SENSOR_PREFIX, DOMAIN, DeviceKey, LOGGER
+from .const import CONF_COORDINATOR, CONF_HA_SENSOR_PREFIX, DOMAIN, LOGGER, DeviceKey
 from .coordinator import LuxtronikCoordinator, LuxtronikCoordinatorData
 from .model import LuxtronikBinarySensorEntityDescription
 

--- a/custom_components/luxtronik/climate.py
+++ b/custom_components/luxtronik/climate.py
@@ -109,9 +109,9 @@ THERMOSTATS: list[LuxtronikClimateDescription] = [
         hvac_action_mapping=HVAC_ACTION_MAPPING_HEAT,
         preset_modes=[PRESET_NONE, PRESET_AWAY, PRESET_BOOST],
         supported_features=ClimateEntityFeature.PRESET_MODE
-        | ClimateEntityFeature.TURN_OFF  # noqa: W503
-        | ClimateEntityFeature.TURN_ON  # noqa: W503
-        | ClimateEntityFeature.TARGET_TEMPERATURE,  # noqa: W503
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TARGET_TEMPERATURE,
         luxtronik_key=LuxParameter.P0003_MODE_HEATING,
         luxtronik_key_target_temperature=LuxParameter.P1148_HEATING_TARGET_TEMP_ROOM_THERMOSTAT,
         luxtronik_key_current_action=LuxCalculation.C0080_STATUS,
@@ -131,9 +131,9 @@ THERMOSTATS: list[LuxtronikClimateDescription] = [
         hvac_action_mapping=HVAC_ACTION_MAPPING_HEAT,
         preset_modes=[PRESET_NONE, PRESET_AWAY, PRESET_BOOST],
         supported_features=ClimateEntityFeature.PRESET_MODE
-        | ClimateEntityFeature.TURN_OFF  # noqa: W503
-        | ClimateEntityFeature.TURN_ON  # noqa: W503
-        | ClimateEntityFeature.TARGET_TEMPERATURE,  # noqa: W503
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TARGET_TEMPERATURE,
         luxtronik_key=LuxParameter.P0003_MODE_HEATING,
         luxtronik_key_target_temperature=LuxCalculation.C0228_ROOM_THERMOSTAT_TEMPERATURE_TARGET,
         luxtronik_key_current_action=LuxCalculation.C0080_STATUS,
@@ -155,8 +155,8 @@ THERMOSTATS: list[LuxtronikClimateDescription] = [
         hvac_action_mapping=HVAC_ACTION_MAPPING_COOL,
         preset_modes=[PRESET_NONE],
         supported_features=ClimateEntityFeature.TURN_OFF
-        | ClimateEntityFeature.TURN_ON  # noqa: W503
-        | ClimateEntityFeature.TARGET_TEMPERATURE,  # noqa: W503
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TARGET_TEMPERATURE,
         luxtronik_key=LuxParameter.P0108_MODE_COOLING,
         luxtronik_key_target_temperature=LuxParameter.P0110_COOLING_OUTDOOR_TEMP_THRESHOLD,
         luxtronik_key_current_action=LuxCalculation.C0080_STATUS,

--- a/custom_components/luxtronik/climate.py
+++ b/custom_components/luxtronik/climate.py
@@ -384,11 +384,11 @@ class LuxtronikThermostat(LuxtronikEntity, ClimateEntity, RestoreEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         self._attr_hvac_mode = hvac_mode
-        lux_mode = [
+        lux_mode = next(
             k
             for k, v in self.entity_description.hvac_mode_mapping.items()
             if v == hvac_mode.value
-        ][0]
+        )
         await self._async_set_lux_mode(lux_mode)
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -397,9 +397,7 @@ class LuxtronikThermostat(LuxtronikEntity, ClimateEntity, RestoreEntity):
         if preset_mode in [PRESET_COMFORT]:
             lux_mode = LuxMode.automatic
         elif preset_mode != PRESET_NONE:
-            lux_mode = [k for k, v in HVAC_PRESET_MAPPING.items() if v == preset_mode][
-                0
-            ]
+            lux_mode = next(k for k, v in HVAC_PRESET_MAPPING.items() if v == preset_mode)
             if self._last_hvac_mode_before_preset is None:
                 self._last_hvac_mode_before_preset = self._attr_hvac_mode
         elif self._last_hvac_mode_before_preset is not None:

--- a/custom_components/luxtronik/climate.py
+++ b/custom_components/luxtronik/climate.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from typing import Any
-from packaging.version import Version
 
 from homeassistant.components.climate import (
     ENTITY_ID_FORMAT,
@@ -31,9 +30,10 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
+from packaging.version import Version
 
 from .base import LuxtronikEntity
-from .common import get_sensor_data, state_as_number_or_none, key_exists
+from .common import get_sensor_data, key_exists, state_as_number_or_none
 from .const import (
     CONF_COORDINATOR,
     CONF_HA_SENSOR_INDOOR_TEMPERATURE,

--- a/custom_components/luxtronik/common.py
+++ b/custom_components/luxtronik/common.py
@@ -1,12 +1,11 @@
 """Support for Luxtronik classes."""
 
 # region Imports
-from typing import Any
-
 from functools import partial
 from ipaddress import IPv6Address, ip_address
-from getmac import get_mac_address
+from typing import Any
 
+from getmac import get_mac_address
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import device_registry

--- a/custom_components/luxtronik/config_flow.py
+++ b/custom_components/luxtronik/config_flow.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 
 from typing import Any
 
-import voluptuous as vol
-
 from homeassistant import config_entries
-from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult, AbortFlow
+from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import selector
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+import voluptuous as vol
 
 from .const import (
     CONF_HA_SENSOR_INDOOR_TEMPERATURE,
@@ -26,12 +25,12 @@ from .const import (
     LOGGER,
 )
 from .coordinator import (
+    LuxtronikConnectionError,
     LuxtronikCoordinator,
     connect_and_get_coordinator,
-    LuxtronikConnectionError,
 )
 from .lux_helper import discover
-from .schema_helper import build_user_data_schema, build_options_schema
+from .schema_helper import build_options_schema, build_user_data_schema
 
 # endregion Imports
 

--- a/custom_components/luxtronik/const.py
+++ b/custom_components/luxtronik/const.py
@@ -3,16 +3,14 @@
 # region Imports
 from datetime import date, datetime, timedelta
 from decimal import Decimal
-from enum import Enum
-from typing import Final
-from enum import StrEnum
-
+from enum import Enum, StrEnum
 import logging
-import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
+from typing import Final
 
 from homeassistant.const import Platform
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import StateType
+import voluptuous as vol
 
 # endregion Imports
 

--- a/custom_components/luxtronik/coordinator.py
+++ b/custom_components/luxtronik/coordinator.py
@@ -8,7 +8,7 @@ from collections.abc import Awaitable, Callable, Coroutine, Mapping
 from functools import wraps
 import re
 from types import MappingProxyType
-from typing import Any, Concatenate, TypeVar
+from typing import Any, Concatenate, ParamSpec, TypeVar
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
@@ -18,7 +18,6 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from packaging.version import InvalidVersion, Version
-from typing_extensions import ParamSpec
 
 from .common import correct_key_value
 from .const import (

--- a/custom_components/luxtronik/coordinator.py
+++ b/custom_components/luxtronik/coordinator.py
@@ -4,23 +4,21 @@
 from __future__ import annotations
 
 import asyncio
-import re
-
 from collections.abc import Awaitable, Callable, Coroutine, Mapping
 from functools import wraps
-from packaging.version import Version, InvalidVersion
+import re
 from types import MappingProxyType
 from typing import Any, Concatenate, TypeVar
-from typing_extensions import ParamSpec
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.exceptions import ConfigEntryNotReady
+from packaging.version import InvalidVersion, Version
+from typing_extensions import ParamSpec
 
 from .common import correct_key_value
 from .const import (
@@ -29,8 +27,8 @@ from .const import (
     CONF_PARAMETERS,
     CONF_VISIBILITIES,
     DEFAULT_MAX_DATA_LENGTH,
-    DEFAULT_TIMEOUT,
     DEFAULT_PORT,
+    DEFAULT_TIMEOUT,
     DOMAIN,
     LOGGER,
     LUX_PARAMETER_MK_SENSORS,

--- a/custom_components/luxtronik/coordinator.py
+++ b/custom_components/luxtronik/coordinator.py
@@ -545,4 +545,4 @@ async def connect_and_get_coordinator(
         return coordinator
     except Exception as err:
         LOGGER.error("Luxtronik connect to device %s:%s failed: %s", host, port, err)
-        raise LuxtronikConnectionError(host, port, err)
+        raise LuxtronikConnectionError(host, port, err) from err

--- a/custom_components/luxtronik/coordinator.py
+++ b/custom_components/luxtronik/coordinator.py
@@ -151,11 +151,9 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
 
         host = config[CONF_HOST]
         port = config[CONF_PORT]
-        timeout = config[CONF_TIMEOUT] if CONF_TIMEOUT in config else DEFAULT_TIMEOUT
+        timeout = config.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
         max_data_length = (
-            config[CONF_MAX_DATA_LENGTH]
-            if CONF_MAX_DATA_LENGTH in config
-            else DEFAULT_MAX_DATA_LENGTH
+            config.get(CONF_MAX_DATA_LENGTH, DEFAULT_MAX_DATA_LENGTH)
         )
 
         client = Luxtronik(
@@ -285,14 +283,11 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
             return True
 
         # Check maximum minor version if specified
-        if (
+        return (
             description.max_firmware_version_minor is not None
-            and self.firmware_version_minor > description.max_firmware_version_minor
-        ):
-            return True
-
-        # If all checks pass or no version restrictions are specified
-        return False
+            and self.firmware_version_minor
+            > description.max_firmware_version_minor
+        )
 
     @property
     def serial_number(self) -> str:

--- a/custom_components/luxtronik/coordinator.py
+++ b/custom_components/luxtronik/coordinator.py
@@ -469,16 +469,16 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         """Detect and returns True if solar is present."""
         return (
             bool(self.get_value(LV.V0250_SOLAR))
-            or self.get_value(LP.P0882_SOLAR_OPERATION_HOURS) > 0.01  # noqa: W503
+            or self.get_value(LP.P0882_SOLAR_OPERATION_HOURS) > 0.01
             or (
-                bool(self.get_value(LV.V0038_SOLAR_COLLECTOR))  # noqa: W503
-                and float(self.get_value(LC.C0026_SOLAR_COLLECTOR_TEMPERATURE))  # noqa: W503
-                != 5.0  # noqa: W503
+                bool(self.get_value(LV.V0038_SOLAR_COLLECTOR))
+                and float(self.get_value(LC.C0026_SOLAR_COLLECTOR_TEMPERATURE))
+                != 5.0
             )
             or (
-                bool(self.get_value(LV.V0039_SOLAR_BUFFER))  # noqa: W503
-                and float(self.get_value(LC.C0027_SOLAR_BUFFER_TEMPERATURE))  # noqa: W503
-                != 150.0  # noqa: W503
+                bool(self.get_value(LV.V0039_SOLAR_BUFFER))
+                and float(self.get_value(LC.C0027_SOLAR_BUFFER_TEMPERATURE))
+                != 150.0
             )
         )
 

--- a/custom_components/luxtronik/date.py
+++ b/custom_components/luxtronik/date.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 
-from homeassistant.components.date import DateEntity, ENTITY_ID_FORMAT
+from homeassistant.components.date import ENTITY_ID_FORMAT, DateEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady

--- a/custom_components/luxtronik/date_entities_predefined.py
+++ b/custom_components/luxtronik/date_entities_predefined.py
@@ -9,7 +9,6 @@ from .model import (
     LuxtronikDateEntityDescription,
 )
 
-
 CALENDAR_ENTITIES: list[LuxtronikDateEntityDescription] = [
     LuxtronikDateEntityDescription(
         key=SK.AWAY_DHW_STARTDATE,

--- a/custom_components/luxtronik/diagnostics.py
+++ b/custom_components/luxtronik/diagnostics.py
@@ -12,9 +12,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
+from .common import async_get_mac_address
 from .const import CONF_COORDINATOR, DOMAIN
 from .coordinator import LuxtronikCoordinator
-from .common import async_get_mac_address
 
 # endregion Imports
 

--- a/custom_components/luxtronik/evu_helper.py
+++ b/custom_components/luxtronik/evu_helper.py
@@ -1,8 +1,10 @@
 """Helper class with all EVU logic"""
 
-from datetime import time
 import calendar
+from datetime import time
+
 from homeassistant.util import dt as dt_util
+
 from .const import LuxOperationMode, SensorAttrKey as SA
 
 

--- a/custom_components/luxtronik/lux_helper.py
+++ b/custom_components/luxtronik/lux_helper.py
@@ -99,7 +99,7 @@ def discover() -> list[tuple[str, int | None]]:
                     )
 
             # if the timeout triggers, go on and use the other broadcast port
-            except socket.timeout:
+            except TimeoutError:
                 break
         server.close()
     return results
@@ -237,7 +237,7 @@ class Luxtronik:
                         self._port,
                         self._socket_timeout,
                     )
-                except (socket.timeout, OSError) as err:
+                except (TimeoutError, OSError) as err:
                     LOGGER.error("Failed to connect: %s", err)
                     self._disconnect()
                     raise
@@ -352,14 +352,14 @@ class Luxtronik:
                     try:
                         raw = self._socket.recv(item_size)
                         data.append(struct.unpack(fmt, raw)[0])
-                    except (struct.error, socket.timeout) as err:
+                    except (TimeoutError, struct.error) as err:
                         LOGGER.debug("Error reading %s item: %s", label, err)
 
                 LOGGER.debug("Read %d %s items", length, label)
                 parser.parse(data)
                 return  # Success, exit after first successful attempt
 
-            except (socket.timeout, ConnectionResetError, OSError) as err:
+            except (TimeoutError, ConnectionResetError, OSError) as err:
                 LOGGER.warning(
                     "Error while reading %s (attempt %d/%d): %s",
                     label,

--- a/custom_components/luxtronik/lux_helper.py
+++ b/custom_components/luxtronik/lux_helper.py
@@ -74,7 +74,7 @@ def discover() -> list[tuple[str, int | None]]:
                 # if the response starts with the magic nonsense
                 if res.startswith(LUXTRONIK_DISCOVERY_RESPONSE_PREFIX):
                     LOGGER.debug(
-                        f"Received valid Luxtronik response from {ip_address}: {str(res_list)}"
+                        f"Received valid Luxtronik response from {ip_address}: {res_list!s}"
                     )
                     try:
                         res_port: int | None = int(res_list[2])
@@ -95,7 +95,7 @@ def discover() -> list[tuple[str, int | None]]:
 
                 else:
                     LOGGER.debug(
-                        f"Skipping invalid response from {ip_address}: {str(res_list)}"
+                        f"Skipping invalid response from {ip_address}: {res_list!s}"
                     )
 
             # if the timeout triggers, go on and use the other broadcast port

--- a/custom_components/luxtronik/lux_overrides.py
+++ b/custom_components/luxtronik/lux_overrides.py
@@ -1,6 +1,5 @@
-from luxtronik.datatypes import HeatpumpCode, Celsius, Timestamp, Percent, Percent2
+from luxtronik.datatypes import Celsius, HeatpumpCode, Percent, Percent2, Timestamp
 from luxtronik.parameters import Parameters
-
 
 # Define your new/updated custom parameters in a dictionary
 parameters_to_add_update = {

--- a/custom_components/luxtronik/model.py
+++ b/custom_components/luxtronik/model.py
@@ -6,10 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from decimal import Decimal
-from packaging.version import Version
 from typing import Any
-
-from luxtronik import Calculations, Parameters, Visibilities
 
 from homeassistant.components.binary_sensor import BinarySensorEntityDescription
 from homeassistant.components.climate import (
@@ -21,12 +18,14 @@ from homeassistant.components.date import DateEntityDescription
 from homeassistant.components.number import NumberEntityDescription, NumberMode
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.components.switch import SwitchEntityDescription
-from homeassistant.components.update import UpdateEntityDescription, UpdateDeviceClass
+from homeassistant.components.update import UpdateDeviceClass, UpdateEntityDescription
 from homeassistant.components.water_heater import WaterHeaterEntityFeature
-
 from homeassistant.const import Platform, UnitOfTemperature
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.typing import StateType
+from packaging.version import Version
+
+from luxtronik import Calculations, Parameters, Visibilities
 
 from .const import (
     UPDATE_INTERVAL_VERY_SLOW,

--- a/custom_components/luxtronik/number.py
+++ b/custom_components/luxtronik/number.py
@@ -172,7 +172,7 @@ class LuxtronikNumberEntity(LuxtronikEntity, NumberEntity):
             )
         ):
             self._attr_cache[attr.key] = dt_util.utcnow().date()
-        result = self._attr_cache[attr.key] if attr.key in self._attr_cache else ""
+        result = self._attr_cache.get(attr.key, "")
 
         return str(result)
 

--- a/custom_components/luxtronik/number_entities_predefined.py
+++ b/custom_components/luxtronik/number_entities_predefined.py
@@ -1,18 +1,17 @@
 """Luxtronik number sensors definitions."""
 
 # region Imports
-from packaging.version import Version
-
 from homeassistant.components.number import NumberMode
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     PERCENTAGE,
     UnitOfElectricPotential,
+    UnitOfPower,
     UnitOfTemperature,
     UnitOfTime,
-    UnitOfPower,
 )
 from homeassistant.helpers.entity import EntityCategory
+from packaging.version import Version
 
 from .const import (
     DEFAULT_DHW_MIN_TEMPERATURE,

--- a/custom_components/luxtronik/schema_helper.py
+++ b/custom_components/luxtronik/schema_helper.py
@@ -1,14 +1,14 @@
-import voluptuous as vol
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 from homeassistant.helpers import selector
+import voluptuous as vol
 
 from .const import (
-    CONF_MAX_DATA_LENGTH,
     CONF_HA_SENSOR_INDOOR_TEMPERATURE,
+    CONF_MAX_DATA_LENGTH,
     DEFAULT_HOST,
+    DEFAULT_MAX_DATA_LENGTH,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
-    DEFAULT_MAX_DATA_LENGTH,
 )
 
 

--- a/custom_components/luxtronik/select.py
+++ b/custom_components/luxtronik/select.py
@@ -8,18 +8,17 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-
 from .base import LuxtronikEntity
 from .common import get_sensor_data
 from .const import (
+    CONF_COORDINATOR,
+    CONF_HA_SENSOR_PREFIX,
+    DAY_NAME_TO_PARAM,
     DAY_SELECTOR_OPTIONS,
     DOMAIN,
     LOGGER,
-    CONF_COORDINATOR,
-    CONF_HA_SENSOR_PREFIX,
-    LuxDaySelectorParameter,
-    DAY_NAME_TO_PARAM,
     DeviceKey,
+    LuxDaySelectorParameter,
     LuxMode,
     LuxParameter,
     SensorKey as SK,

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -4,7 +4,7 @@
 # region Imports
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timezone, UTC
 from decimal import Decimal
 from typing import Any
 
@@ -420,7 +420,7 @@ class LuxtronikIndexSensor(LuxtronikSensorEntity, SensorEntity):
 
     def format_time(self, value_timestamp: int | None) -> datetime | None:
         if value_timestamp is not None and isinstance(value_timestamp, int):
-            value_timestamp = datetime.fromtimestamp(value_timestamp, timezone.utc)
+            value_timestamp = datetime.fromtimestamp(value_timestamp, UTC)
         if (
             value_timestamp is not None
             and isinstance(value_timestamp, datetime)

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -61,7 +61,7 @@ async def async_setup_entry(
         i.luxtronik_key
         for i in SENSORS + SENSORS_STATUS
         if not key_exists(coordinator.data, i.luxtronik_key)
-        and not i.luxtronik_key == LC.UNSET
+        and i.luxtronik_key != LC.UNSET
     ]
     if unavailable_keys:
         LOGGER.warning("Not present in Luxtronik data, skipping: %s", unavailable_keys)

--- a/custom_components/luxtronik/sensor_entities_predefined.py
+++ b/custom_components/luxtronik/sensor_entities_predefined.py
@@ -36,8 +36,8 @@ from .const import (
 )
 from .model import (
     LuxtronikEntityAttributeDescription as attr,
-    LuxtronikSensorDescription as descr,
     LuxtronikIndexSensorDescription as descr_index,
+    LuxtronikSensorDescription as descr,
 )
 
 # endregion Imports

--- a/custom_components/luxtronik/switch.py
+++ b/custom_components/luxtronik/switch.py
@@ -13,8 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base import LuxtronikEntity
 from .common import get_sensor_data, key_exists
-from .const import CONF_COORDINATOR, CONF_HA_SENSOR_PREFIX, DOMAIN, DeviceKey, LOGGER
-
+from .const import CONF_COORDINATOR, CONF_HA_SENSOR_PREFIX, DOMAIN, LOGGER, DeviceKey
 from .coordinator import LuxtronikCoordinator, LuxtronikCoordinatorData
 from .model import LuxtronikSwitchDescription
 from .switch_entities_predefined import SWITCHES

--- a/custom_components/luxtronik/update.py
+++ b/custom_components/luxtronik/update.py
@@ -3,11 +3,12 @@
 # region Imports
 from __future__ import annotations
 
-import aiohttp
-import re
-
-from awesomeversion import AwesomeVersion
 from datetime import datetime, timedelta, timezone
+import re
+from typing import Final
+
+import aiohttp
+from awesomeversion import AwesomeVersion
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE
@@ -16,15 +17,13 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from typing import Final
-
 from .base import LuxtronikEntity
 from .const import (
+    CHANGELOG_URL,
     CONF_COORDINATOR,
     CONF_HA_SENSOR_PREFIX,
     DOMAIN,
     DOWNLOAD_PORTAL_URL,
-    CHANGELOG_URL,
     FIRMWARE_UPDATE_MANUAL_DE,
     FIRMWARE_UPDATE_MANUAL_EN,
     LANG_DE,

--- a/custom_components/luxtronik/update.py
+++ b/custom_components/luxtronik/update.py
@@ -3,7 +3,7 @@
 # region Imports
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 import re
 from typing import Final
 
@@ -178,7 +178,7 @@ class LuxtronikUpdateEntity(LuxtronikEntity, UpdateEntity):
         if (
             self.__firmware_version_available_last_request is None
             or self.__firmware_version_available_last_request
-            < datetime.now(timezone.utc).timestamp()
+            < datetime.now(UTC).timestamp()
             - MIN_TIME_BETWEEN_UPDATES.total_seconds()
         ):
             await self._request_available_firmware_version()
@@ -207,7 +207,7 @@ class LuxtronikUpdateEntity(LuxtronikEntity, UpdateEntity):
                     filename = filename_match[0] if filename_match else None
 
                     self.__firmware_version_available_last_request = datetime.now(
-                        timezone.utc
+                        UTC
                     ).timestamp()
 
                     self.__firmware_version_available = self.extract_firmware_version(

--- a/custom_components/luxtronik/water_heater.py
+++ b/custom_components/luxtronik/water_heater.py
@@ -247,7 +247,7 @@ class LuxtronikWaterHeater(LuxtronikEntity, WaterHeaterEntity):
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new target operation mode."""
-        lux_mode = [k for k, v in OPERATION_MAPPING.items() if v == operation_mode][0]
+        lux_mode = next(k for k, v in OPERATION_MAPPING.items() if v == operation_mode)
         await self._async_set_lux_mode(lux_mode)
 
     async def async_turn_away_mode_on(self) -> None:

--- a/custom_components/luxtronik/water_heater.py
+++ b/custom_components/luxtronik/water_heater.py
@@ -21,7 +21,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from packaging.version import Version
-from typing_extensions import override
+from typing import override
 
 from .base import LuxtronikEntity
 from .common import get_sensor_data, key_exists

--- a/custom_components/luxtronik/water_heater.py
+++ b/custom_components/luxtronik/water_heater.py
@@ -4,9 +4,6 @@
 from __future__ import annotations
 
 from typing import Any
-from packaging.version import Version
-
-from typing_extensions import override
 
 from homeassistant.components.climate.const import HVACAction
 from homeassistant.components.water_heater import (
@@ -23,6 +20,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from packaging.version import Version
+from typing_extensions import override
 
 from .base import LuxtronikEntity
 from .common import get_sensor_data, key_exists

--- a/tests/disabled_test_config_flow.py
+++ b/tests/disabled_test_config_flow.py
@@ -1,7 +1,7 @@
-import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.core import HomeAssistant
+import pytest
 
 from custom_components.luxtronik.config_flow import (
     LuxtronikFlowHandler,

--- a/tests/disabled_test_options_flow.py
+++ b/tests/disabled_test_options_flow.py
@@ -1,6 +1,7 @@
-import pytest
 from homeassistant import data_entry_flow
 from homeassistant.core import HomeAssistant
+import pytest
+
 from custom_components.luxtronik.config_flow import LuxtronikOptionsFlowHandler
 from custom_components.luxtronik.const import (
     CONF_HA_SENSOR_INDOOR_TEMPERATURE,

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,4 +1,5 @@
 import unittest
+
 from custom_components.luxtronik.update import LuxtronikUpdateEntity
 
 


### PR DESCRIPTION
🎨 **What:** Clean up stale linter suppression comments and simplify f-string formatting.

📋 **Changes:**
- Remove obsolete `# noqa: W503` comments (W503 is not a ruff rule)
- `RUF010`: Replace `f"{str(x)}"` → `f"{x!s}"` (use conversion flag instead of explicit `str()` call)

💡 **Why:** The `W503` noqa comments were left over from flake8 and have no effect in ruff. The `!s` conversion flag is the idiomatic f-string way to call `str()`.

📊 **Scope:** 3 files changed (17 insertions, 17 deletions — net 0 lines)

🔗 **Merge order:** 6/7 — merge after #551.