### PR TITLE
style: 🎨 fix ruff format regressions from merge commits

### DIFF
--- a/custom_components/luxtronik/climate.py
+++ b/custom_components/luxtronik/climate.py
@@ -397,7 +397,9 @@ class LuxtronikThermostat(LuxtronikEntity, ClimateEntity, RestoreEntity):
         if preset_mode in [PRESET_COMFORT]:
             lux_mode = LuxMode.automatic
         elif preset_mode != PRESET_NONE:
-            lux_mode = next(k for k, v in HVAC_PRESET_MAPPING.items() if v == preset_mode)
+            lux_mode = next(
+                k for k, v in HVAC_PRESET_MAPPING.items() if v == preset_mode
+            )
             if self._last_hvac_mode_before_preset is None:
                 self._last_hvac_mode_before_preset = self._attr_hvac_mode
         elif self._last_hvac_mode_before_preset is not None:

--- a/custom_components/luxtronik/coordinator.py
+++ b/custom_components/luxtronik/coordinator.py
@@ -152,9 +152,7 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         host = config[CONF_HOST]
         port = config[CONF_PORT]
         timeout = config.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)
-        max_data_length = (
-            config.get(CONF_MAX_DATA_LENGTH, DEFAULT_MAX_DATA_LENGTH)
-        )
+        max_data_length = config.get(CONF_MAX_DATA_LENGTH, DEFAULT_MAX_DATA_LENGTH)
 
         client = Luxtronik(
             host=host,
@@ -285,8 +283,7 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         # Check maximum minor version if specified
         return (
             description.max_firmware_version_minor is not None
-            and self.firmware_version_minor
-            > description.max_firmware_version_minor
+            and self.firmware_version_minor > description.max_firmware_version_minor
         )
 
     @property
@@ -472,13 +469,11 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
             or self.get_value(LP.P0882_SOLAR_OPERATION_HOURS) > 0.01
             or (
                 bool(self.get_value(LV.V0038_SOLAR_COLLECTOR))
-                and float(self.get_value(LC.C0026_SOLAR_COLLECTOR_TEMPERATURE))
-                != 5.0
+                and float(self.get_value(LC.C0026_SOLAR_COLLECTOR_TEMPERATURE)) != 5.0
             )
             or (
                 bool(self.get_value(LV.V0039_SOLAR_BUFFER))
-                and float(self.get_value(LC.C0027_SOLAR_BUFFER_TEMPERATURE))
-                != 150.0
+                and float(self.get_value(LC.C0027_SOLAR_BUFFER_TEMPERATURE)) != 150.0
             )
         )
 


### PR DESCRIPTION
style: 🎨 fix ruff format regressions from merge commits

🎨 **What:** Reformat `climate.py` and `coordinator.py` to pass `ruff format --check`.

📋 **Changes:**
- Fix line wrapping in `climate.py` (long `next()` expression)
- Fix line wrapping in `coordinator.py` (parenthesized expressions, boolean chains)

💡 **Why:** Formatting from #553 was lost during merge of stacked PRs #548–#552 (GitHub merge commits reverted some line-wrapping changes). After this PR, `ruff format --check` passes cleanly.

📊 **Scope:** 2 files changed (7 insertions, 10 deletions)

🔗 Final cleanup PR for the linter modernization series (#547–#553).