### PR TITLE
fix: 🐛 move shared mutable class attributes to __init__

### DIFF
--- a/custom_components/luxtronik/base.py
+++ b/custom_components/luxtronik/base.py
@@ -39,7 +39,6 @@ class LuxtronikEntity(CoordinatorEntity[LuxtronikCoordinator], RestoreEntity):
     entity_description: LuxtronikEntityDescription
     next_update: datetime | None = None
 
-    _attr_cache: dict[SA, Any] = {}
     _entity_component_unrecorded_attributes = frozenset(
         {
             SA.LUXTRONIK_KEY,
@@ -54,6 +53,7 @@ class LuxtronikEntity(CoordinatorEntity[LuxtronikCoordinator], RestoreEntity):
     ) -> None:
         """Init LuxtronikEntity."""
         super().__init__(coordinator=coordinator)
+        self._attr_cache: dict[SA, Any] = {}
         self._device_info_ident = device_info_ident
         self._attr_extra_state_attributes = {
             SA.LUXTRONIK_KEY: f"{description.luxtronik_key.name[1:5]} {description.luxtronik_key.value}"

--- a/custom_components/luxtronik/coordinator.py
+++ b/custom_components/luxtronik/coordinator.py
@@ -409,17 +409,20 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
     @property
     def has_heating(self) -> bool:
         """Is heating activated."""
-        return bool(self.get_value(LC.C0064_OPERATION_HOURS_HEATING) > 0)
+        val = self.get_value(LC.C0064_OPERATION_HOURS_HEATING)
+        return val is not None and val > 0
 
     @property
     def has_domestic_water(self) -> bool:
         """Is domestic water activated."""
-        return bool(self.get_value(LC.C0065_OPERATION_HOURS_DHW) > 0)
+        val = self.get_value(LC.C0065_OPERATION_HOURS_DHW)
+        return val is not None and val > 0
 
     @property
     def has_cooling(self) -> bool:
-        """Is domestic water activated."""
-        return bool(self.get_value(LC.C0066_OPERATION_HOURS_COOLING) > 0)
+        """Is cooling activated."""
+        val = self.get_value(LC.C0066_OPERATION_HOURS_COOLING)
+        return val is not None and val > 0
 
     def get_value(self, group_sensor_id: str | LP | LC | LV):
         """Get a sensor value from Luxtronik."""

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -203,7 +203,6 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
     entity_description: LuxtronikSensorDescription
 
     _coordinator: LuxtronikCoordinator
-    _evu_tracker: LuxtronikEVUTracker = LuxtronikEVUTracker()
 
     _last_state: StateType | date | datetime | Decimal = None
 
@@ -220,6 +219,18 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
             SA.EVU_DAYS,
         }
     )
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        coordinator: LuxtronikCoordinator,
+        description: LuxtronikSensorDescription,
+        device_info_ident: DeviceKey,
+    ) -> None:
+        """Init Luxtronik Status Sensor."""
+        super().__init__(hass, entry, coordinator, description, device_info_ident)
+        self._evu_tracker = LuxtronikEVUTracker()
 
     @callback
     def _handle_coordinator_update(


### PR DESCRIPTION
## 🐛 Summary

Fix shared mutable class-level attributes that cause cross-instance state contamination.

## 📋 Changes

- **base.py**: Move `_attr_cache: dict = {}` from class-level to `__init__` — prevents all entity instances from sharing the same cache dict
- **sensor.py**: Move `_evu_tracker: LuxtronikEVUTracker = LuxtronikEVUTracker()` from class-level to new `__init__` in `LuxtronikStatusSensorEntity` — each status sensor now gets its own EVU tracker instance
- **coordinator.py**: Guard `has_heating`/`has_domestic_water`/`has_cooling` properties against `None` return from `get_value()` (`val is not None and val > 0`), fix copy-paste docstring in `has_cooling`

## ⚠️ Impact

- Fixes potential data corruption where entity attribute caches bleed between instances
- Fixes `TypeError` when operation hours values are `None`
