### PR TITLE
fix: 🐛 use correct ENTITY_ID_FORMAT for select platform

### DIFF
--- a/custom_components/luxtronik/select.py
+++ b/custom_components/luxtronik/select.py
@@ -1,7 +1,6 @@
 """Support for Luxtronik selectors"""
 
-from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT
-from homeassistant.components.select import SelectEntity
+from homeassistant.components.select import ENTITY_ID_FORMAT, SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady


### PR DESCRIPTION
## 🐛 Summary

Fix wrong `ENTITY_ID_FORMAT` import in select platform — was importing from `homeassistant.components.binary_sensor` instead of `homeassistant.components.select`.

## 📋 Changes

- **select.py**: Change `from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT` to `from homeassistant.components.select import ENTITY_ID_FORMAT`

## ⚠️ Impact

- Select entities were using binary_sensor entity ID format (`binary_sensor.{}`) instead of `select.{}`, causing incorrect entity ID generation
