### PR TITLE
fix: 🐛 ensure water heater max_temp always returns a value

### DIFF
--- a/custom_components/luxtronik/water_heater.py
+++ b/custom_components/luxtronik/water_heater.py
@@ -181,7 +181,8 @@ class LuxtronikWaterHeater(LuxtronikEntity, WaterHeaterEntity):
                 )
                 return float(value)
         except (TypeError, ValueError):
-            return 60.0  # fallback default
+            pass
+        return 60.0  # fallback default
 
     @property
     def hvac_action(self) -> HVACAction | str | None:


### PR DESCRIPTION
## 🐛 Summary

Fix `max_temp` property in `LuxtronikDomesticWaterHeater` that could return `None` instead of the fallback `60.0` when the visibility lookup fails.

## 📋 Changes

- **water_heater.py**: Move `return 60.0` outside the `try/except` block as an unconditional fallback, change `except` body to `pass`

## ⚠️ Impact

- Prevents `max_temp` from returning `None`, which would cause HA UI errors when rendering the water heater temperature slider
