### PR TITLE
fix: 🐛 fix shared mutable class attributes and NoneType crashes

### DIFF
--- a/custom_components/luxtronik/base.py
+++ b/custom_components/luxtronik/base.py
@@ -39,7 +39,6 @@ class LuxtronikEntity(CoordinatorEntity[LuxtronikCoordinator], RestoreEntity):
     entity_description: LuxtronikEntityDescription
     next_update: datetime | None = None
 
-    _attr_cache: dict[SA, Any] = {}
     _entity_component_unrecorded_attributes = frozenset(
         {
             SA.LUXTRONIK_KEY,
@@ -54,6 +53,7 @@ class LuxtronikEntity(CoordinatorEntity[LuxtronikCoordinator], RestoreEntity):
     ) -> None:
         """Init LuxtronikEntity."""
         super().__init__(coordinator=coordinator)
+        self._attr_cache: dict[SA, Any] = {}
         self._device_info_ident = device_info_ident
         self._attr_extra_state_attributes = {
             SA.LUXTRONIK_KEY: f"{description.luxtronik_key.name[1:5]} {description.luxtronik_key.value}"

--- a/custom_components/luxtronik/coordinator.py
+++ b/custom_components/luxtronik/coordinator.py
@@ -409,17 +409,20 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
     @property
     def has_heating(self) -> bool:
         """Is heating activated."""
-        return bool(self.get_value(LC.C0064_OPERATION_HOURS_HEATING) > 0)
+        val = self.get_value(LC.C0064_OPERATION_HOURS_HEATING)
+        return val is not None and val > 0
 
     @property
     def has_domestic_water(self) -> bool:
         """Is domestic water activated."""
-        return bool(self.get_value(LC.C0065_OPERATION_HOURS_DHW) > 0)
+        val = self.get_value(LC.C0065_OPERATION_HOURS_DHW)
+        return val is not None and val > 0
 
     @property
     def has_cooling(self) -> bool:
-        """Is domestic water activated."""
-        return bool(self.get_value(LC.C0066_OPERATION_HOURS_COOLING) > 0)
+        """Is cooling activated."""
+        val = self.get_value(LC.C0066_OPERATION_HOURS_COOLING)
+        return val is not None and val > 0
 
     def get_value(self, group_sensor_id: str | LP | LC | LV):
         """Get a sensor value from Luxtronik."""

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -203,7 +203,6 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
     entity_description: LuxtronikSensorDescription
 
     _coordinator: LuxtronikCoordinator
-    _evu_tracker: LuxtronikEVUTracker = LuxtronikEVUTracker()
 
     _last_state: StateType | date | datetime | Decimal = None
 
@@ -220,6 +219,18 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
             SA.EVU_DAYS,
         }
     )
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        coordinator: LuxtronikCoordinator,
+        description: LuxtronikSensorDescription,
+        device_info_ident: DeviceKey,
+    ) -> None:
+        """Init Luxtronik Status Sensor."""
+        super().__init__(hass, entry, coordinator, description, device_info_ident)
+        self._evu_tracker = LuxtronikEVUTracker()
 
     @callback
     def _handle_coordinator_update(


### PR DESCRIPTION
Addresses findings §1, §2, §5 from #561.

## 🐛 Problem

Three related bugs caused by Python class-level mutable attributes and missing None guards:

1. **`_attr_cache`** in `LuxtronikEntity` (base.py) is a class-level `dict`, shared across all entity instances. Cache writes in one entity leak into others, causing data corruption.

2. **`_evu_tracker`** in `LuxtronikStatusSensorEntity` (sensor.py) is a class-level instance of `LuxtronikEVUTracker`, shared across all status sensor instances. Multi-entry setups have mixed EVU state.

3. **`has_heating` / `has_domestic_water` / `has_cooling`** properties in `LuxtronikCoordinator` (coordinator.py) call `get_value()` which can return `None`. The expression `None > 0` raises `TypeError`, crashing the integration on first load or when data is temporarily unavailable.

## ✅ Fix

- Move `_attr_cache` initialization from class-level to `__init__` in `LuxtronikEntity`
- Move `_evu_tracker` initialization from class-level to `__init__` in `LuxtronikStatusSensorEntity`
- Guard `has_heating`/`has_domestic_water`/`has_cooling` against `None` return from `get_value()`
- Fix copy-paste docstring error in `has_cooling` (was "Is domestic water activated.")

## 📁 Changed Files

- `custom_components/luxtronik/base.py`
- `custom_components/luxtronik/coordinator.py`
- `custom_components/luxtronik/sensor.py`