### PR TITLE
fix(select): 🐛 import ENTITY_ID_FORMAT from correct module

### DIFF
--- a/custom_components/luxtronik/select.py
+++ b/custom_components/luxtronik/select.py
@@ -1,7 +1,6 @@
 """Support for Luxtronik selectors"""
 
-from homeassistant.components.binary_sensor import ENTITY_ID_FORMAT
-from homeassistant.components.select import SelectEntity
+from homeassistant.components.select import ENTITY_ID_FORMAT, SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady


### PR DESCRIPTION
Addresses finding §3 from #561.

## 🐛 Problem

`select.py` imports `ENTITY_ID_FORMAT` from `homeassistant.components.binary_sensor` instead of `homeassistant.components.select`. This causes all select entities to get the `binary_sensor.` prefix in their `entity_id` instead of the correct `select.` prefix.

## ✅ Fix

- Import `ENTITY_ID_FORMAT` from `homeassistant.components.select`
- Combine with existing `SelectEntity` import from the same module

## 📁 Changed Files

- `custom_components/luxtronik/select.py`

Resolves: #555