### PR TITLE
fix: 🔒️ add parameter validation to SERVICE_WRITE

### DIFF
--- a/custom_components/luxtronik/__init__.py
+++ b/custom_components/luxtronik/__init__.py
@@ -8,7 +8,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT, Platform as P
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_registry import (
     async_get,
@@ -87,6 +87,27 @@ def setup_hass_services(hass: HomeAssistant):
         parameter = service.data.get(ATTR_PARAMETER)
         # convert to int needed for Unknown parameters
         value = convert_to_int_if_possible(service.data.get(ATTR_VALUE))
+
+        if not parameter or not isinstance(parameter, str):
+            raise ServiceValidationError(f"Invalid parameter name: {parameter}")
+
+        # Only allow writing to known writable parameter prefixes
+        writable_prefixes = (
+            "ID_Einst_",
+            "ID_Ba_",
+            "ID_Soll_",
+            "ID_Sollwert_",
+            "ID_SU_",
+            "ID_RBE_",
+            "Unknown_Parameter_",
+            "HEATING_TARGET_TEMP_ROOM_THERMOSTAT",
+        )
+        if not parameter.startswith(writable_prefixes):
+            raise ServiceValidationError(
+                f"Parameter '{parameter}' rejected — only parameters with "
+                f"prefixes {writable_prefixes} are writable"
+            )
+
         # Find the first available coordinator
         domain_data = hass.data.get(DOMAIN, {})
         for entry_data in domain_data.values():


### PR DESCRIPTION
Addresses finding §6 from #561.

## 🔒️ Problem

The `luxtronik2.write` service allows writing **any** parameter to the heat pump controller without validation. A misconfigured automation or malicious actor could:

- Set dangerous temperature values
- Reconfigure the controller into an error state
- Potentially damage hardware

## ✅ Fix

- Validate parameter name (must be a non-empty string)
- Add a prefix-based whitelist of writable parameters (`ID_Einst_`, `ID_Ba_`, `ID_Soll_`, `ID_Sollwert_`, `ID_SU_`, `ID_RBE_`, `Unknown_Parameter_`, `HEATING_TARGET_TEMP_ROOM_THERMOSTAT`)
- Raise `ServiceValidationError` with a clear message when validation fails

## 📁 Changed Files

- `custom_components/luxtronik/__init__.py`