### PR TITLE
fix: 🩹 use HA aiohttp session and replace deprecated async_timeout

### DIFF
--- a/custom_components/luxtronik/diagnostics.py
+++ b/custom_components/luxtronik/diagnostics.py
@@ -3,10 +3,10 @@
 # region Imports
 from __future__ import annotations
 
+from asyncio import timeout
 from collections.abc import Mapping
 from typing import Any
 
-from async_timeout import timeout
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME

--- a/custom_components/luxtronik/update.py
+++ b/custom_components/luxtronik/update.py
@@ -7,13 +7,13 @@ from datetime import UTC, datetime, timedelta
 import re
 from typing import Final
 
-import aiohttp
 from awesomeversion import AwesomeVersion
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -190,36 +190,34 @@ class LuxtronikUpdateEntity(LuxtronikEntity, UpdateEntity):
             return
 
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    f"{DOWNLOAD_PORTAL_URL}{download_id}", timeout=30
-                ) as response:
-                    if response.status != 200:
-                        raise Exception(f"HTTP error: {response.status}")
+            session = async_get_clientsession(self.hass)
+            async with session.get(
+                f"{DOWNLOAD_PORTAL_URL}{download_id}", timeout=30
+            ) as response:
+                if response.status != 200:
+                    raise Exception(f"HTTP error: {response.status}")
 
-                    header_content_disposition = response.headers.get(
-                        "Content-Disposition", ""
-                    )
-                    filename_match = re.findall(
-                        "filename=(.+)", header_content_disposition
-                    )
-                    filename = filename_match[0] if filename_match else None
+                header_content_disposition = response.headers.get(
+                    "Content-Disposition", ""
+                )
+                filename_match = re.findall("filename=(.+)", header_content_disposition)
+                filename = filename_match[0] if filename_match else None
 
-                    self.__firmware_version_available_last_request = datetime.now(
-                        UTC
-                    ).timestamp()
+                self.__firmware_version_available_last_request = datetime.now(
+                    UTC
+                ).timestamp()
 
-                    self.__firmware_version_available = self.extract_firmware_version(
-                        filename
-                    )
+                self.__firmware_version_available = self.extract_firmware_version(
+                    filename
+                )
 
-                async with session.get(
-                    f"{CHANGELOG_URL}{download_id}", timeout=30
-                ) as response:
-                    if response.status != 200:
-                        raise Exception(f"HTTP error: {response.status}")
+            async with session.get(
+                f"{CHANGELOG_URL}{download_id}", timeout=30
+            ) as response:
+                if response.status != 200:
+                    raise Exception(f"HTTP error: {response.status}")
 
-                    self.__firmware_version_changelog = await response.text()
+                self.__firmware_version_changelog = await response.text()
 
         except Exception:
             LOGGER.warning(


### PR DESCRIPTION
Addresses findings §7, §16 from #561.

## 🩹 Problem

1. **`update.py`** creates its own `aiohttp.ClientSession()` instead of using HA's `async_get_clientsession()`. This bypasses HA proxy settings, skips connection pooling, and does not benefit from HA's SSL context.

2. **`diagnostics.py`** uses `from async_timeout import timeout` which is deprecated since Python 3.11. HA 2025.x recommends `asyncio.timeout`.

## ✅ Fix

- Replace `aiohttp.ClientSession()` with `async_get_clientsession(hass)` in `update.py`
- Replace `from async_timeout import timeout` with `from asyncio import timeout` in `diagnostics.py`
- Fix import grouping (stdlib vs third-party) in `diagnostics.py`

## 📁 Changed Files

- `custom_components/luxtronik/update.py`
- `custom_components/luxtronik/diagnostics.py`