### PR TITLE
refactor: ♻️ migrate to entry.runtime_data for config entry data

### DIFF
--- a/custom_components/luxtronik/__init__.py
+++ b/custom_components/luxtronik/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT, Platform as P
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
@@ -18,7 +18,6 @@ from .common import convert_to_int_if_possible
 from .const import (
     ATTR_PARAMETER,
     ATTR_VALUE,
-    CONF_COORDINATOR,
     CONF_HA_SENSOR_PREFIX,
     CONF_MAX_DATA_LENGTH,
     CONFIG_ENTRY_VERSION,
@@ -35,11 +34,12 @@ from .coordinator import LuxtronikCoordinator, connect_and_get_coordinator
 
 # endregion Imports
 
+type LuxtronikConfigEntry = ConfigEntry[LuxtronikCoordinator]
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+
+async def async_setup_entry(hass: HomeAssistant, entry: LuxtronikConfigEntry) -> bool:
     """Set up Luxtronik from a config entry."""
 
-    data = hass.data.setdefault(DOMAIN, {})
     config = entry.data
 
     try:
@@ -51,7 +51,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
-    data[entry.entry_id] = {CONF_COORDINATOR: coordinator}
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -69,14 +69,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.config_entries.async_update_entry(entry, title=new_title.strip())
 
-    setup_hass_services(hass)
+    setup_hass_services(hass, entry)
 
     LOGGER.info("Luxtronik integration setup completed for %s", entry.entry_id)
 
     return True
 
 
-def setup_hass_services(hass: HomeAssistant):
+def setup_hass_services(hass: HomeAssistant, entry: LuxtronikConfigEntry):
     """Register Home Assistant services (once)."""
 
     if hass.services.has_service(DOMAIN, SERVICE_WRITE):
@@ -85,11 +85,11 @@ def setup_hass_services(hass: HomeAssistant):
     async def write_parameter(service):
         """Write a parameter to the Luxtronik heatpump."""
         parameter = service.data.get(ATTR_PARAMETER)
-        # convert to int needed for Unknown parameters
-        value = convert_to_int_if_possible(service.data.get(ATTR_VALUE))
-
         if not parameter or not isinstance(parameter, str):
             raise ServiceValidationError(f"Invalid parameter name: {parameter}")
+
+        # convert to int needed for Unknown parameters
+        value = convert_to_int_if_possible(service.data.get(ATTR_VALUE))
 
         # Only allow writing to known writable parameter prefixes
         writable_prefixes = (
@@ -109,10 +109,11 @@ def setup_hass_services(hass: HomeAssistant):
             )
 
         # Find the first available coordinator
-        domain_data = hass.data.get(DOMAIN, {})
-        for entry_data in domain_data.values():
-            if isinstance(entry_data, dict) and CONF_COORDINATOR in entry_data:
-                coordinator: LuxtronikCoordinator = entry_data[CONF_COORDINATOR]
+        for config_entry in hass.config_entries.async_entries(DOMAIN):
+            if config_entry.state is ConfigEntryState.LOADED and hasattr(
+                config_entry, "runtime_data"
+            ):
+                coordinator = config_entry.runtime_data
                 await coordinator.async_write(parameter, value)
                 return
         LOGGER.error("No active Luxtronik coordinator found for service call")
@@ -122,21 +123,26 @@ def setup_hass_services(hass: HomeAssistant):
     )
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: LuxtronikConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        data = hass.data[DOMAIN].pop(entry.entry_id)
-        coordinator: LuxtronikCoordinator = data[CONF_COORDINATOR]
-        await coordinator.async_shutdown()
+        await entry.runtime_data.async_shutdown()
 
     # Unregister service when no entries remain
-    if not hass.data.get(DOMAIN):
+    remaining = [
+        e
+        for e in hass.config_entries.async_entries(DOMAIN)
+        if e.entry_id != entry.entry_id
+    ]
+    if not remaining:
         hass.services.async_remove(DOMAIN, SERVICE_WRITE)
 
     return unload_ok
 
 
-async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+async def update_listener(
+    hass: HomeAssistant, config_entry: LuxtronikConfigEntry
+) -> None:
     """Handle options update."""
     await hass.config_entries.async_reload(config_entry.entry_id)
 

--- a/custom_components/luxtronik/binary_sensor.py
+++ b/custom_components/luxtronik/binary_sensor.py
@@ -8,10 +8,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
 from .binary_sensor_entities_predefined import BINARY_SENSORS
 from .common import get_sensor_data, key_exists
-from .const import CONF_COORDINATOR, CONF_HA_SENSOR_PREFIX, DOMAIN, LOGGER, DeviceKey
+from .const import CONF_HA_SENSOR_PREFIX, LOGGER, DeviceKey
 from .coordinator import LuxtronikCoordinator, LuxtronikCoordinatorData
 from .model import LuxtronikBinarySensorEntityDescription
 
@@ -19,19 +20,13 @@ from .model import LuxtronikBinarySensorEntityDescription
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: LuxtronikConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Luxtronik binary sensors dynamically through Luxtronik discovery."""
 
-    data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
-    if not data or CONF_COORDINATOR not in data:
-        return
-
-    coordinator: LuxtronikCoordinator = data[CONF_COORDINATOR]
-
-    # Ensure coordinator has valid data before adding entities
-    if not coordinator.last_update_success:
-        return
+    coordinator = entry.runtime_data
 
     unavailable_keys = [
         i.luxtronik_key

--- a/custom_components/luxtronik/climate.py
+++ b/custom_components/luxtronik/climate.py
@@ -31,13 +31,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 from packaging.version import Version
 
+from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
 from .common import get_sensor_data, key_exists, state_as_number_or_none
 from .const import (
-    CONF_COORDINATOR,
     CONF_HA_SENSOR_INDOOR_TEMPERATURE,
     CONF_HA_SENSOR_PREFIX,
-    DOMAIN,
     LOGGER,
     LUX_STATE_ICON_MAP,
     LUX_STATE_ICON_MAP_COOL,
@@ -172,19 +171,13 @@ THERMOSTATS: list[LuxtronikClimateDescription] = [
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: LuxtronikConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Luxtronik climate entities dynamically through Luxtronik discovery."""
 
-    data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
-    if not data or CONF_COORDINATOR not in data:
-        return
-
-    coordinator: LuxtronikCoordinator = data[CONF_COORDINATOR]
-
-    # Ensure coordinator has valid data before adding entities
-    if not coordinator.last_update_success:
-        return
+    coordinator = entry.runtime_data
 
     unavailable_keys = [
         i.luxtronik_key

--- a/custom_components/luxtronik/date.py
+++ b/custom_components/luxtronik/date.py
@@ -7,12 +7,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
 from .common import get_sensor_data, key_exists
 from .const import (
-    CONF_COORDINATOR,
     CONF_HA_SENSOR_PREFIX,
-    DOMAIN,
     LOGGER,
     DeviceKey,
 )
@@ -22,13 +21,11 @@ from .model import LuxtronikDateEntityDescription
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: LuxtronikConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
-    data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
-    if not data or CONF_COORDINATOR not in data:
-        return
-
-    coordinator: LuxtronikCoordinator = data[CONF_COORDINATOR]
+    coordinator = entry.runtime_data
 
     if not coordinator.last_update_success:
         return

--- a/custom_components/luxtronik/diagnostics.py
+++ b/custom_components/luxtronik/diagnostics.py
@@ -8,13 +8,11 @@ from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
+from . import LuxtronikConfigEntry
 from .common import async_get_mac_address
-from .const import CONF_COORDINATOR, DOMAIN
-from .coordinator import LuxtronikCoordinator
 
 # endregion Imports
 
@@ -22,11 +20,10 @@ TO_REDACT = {CONF_USERNAME, CONF_PASSWORD}
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: LuxtronikConfigEntry
 ) -> Mapping[str, Any]:
     """Return diagnostics for a config entry."""
-    data: dict = hass.data[DOMAIN][entry.entry_id]
-    coordinator: LuxtronikCoordinator = data[CONF_COORDINATOR]
+    coordinator = entry.runtime_data
 
     # Optionally refresh data to ensure it's up to date
     await coordinator.async_request_refresh()

--- a/custom_components/luxtronik/number.py
+++ b/custom_components/luxtronik/number.py
@@ -13,12 +13,11 @@ from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
+from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
 from .common import get_sensor_data, key_exists
 from .const import (
-    CONF_COORDINATOR,
     CONF_HA_SENSOR_PREFIX,
-    DOMAIN,
     LOGGER,
     DeviceKey,
     SensorAttrFormat,
@@ -31,15 +30,13 @@ from .number_entities_predefined import NUMBER_SENSORS
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: LuxtronikConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Luxtronik binary sensors dynamically through Luxtronik discovery."""
 
-    data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
-    if not data or CONF_COORDINATOR not in data:
-        return
-
-    coordinator: LuxtronikCoordinator = data[CONF_COORDINATOR]
+    coordinator = entry.runtime_data
 
     # Ensure coordinator has valid data before adding entities
     if not coordinator.last_update_success:

--- a/custom_components/luxtronik/select.py
+++ b/custom_components/luxtronik/select.py
@@ -6,14 +6,13 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
 from .common import get_sensor_data
 from .const import (
-    CONF_COORDINATOR,
     CONF_HA_SENSOR_PREFIX,
     DAY_NAME_TO_PARAM,
     DAY_SELECTOR_OPTIONS,
-    DOMAIN,
     LOGGER,
     DeviceKey,
     LuxDaySelectorParameter,
@@ -26,15 +25,13 @@ from .model import LuxtronikEntityDescription
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: LuxtronikConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Luxtronik Select entities"""
 
-    data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
-    if not data or CONF_COORDINATOR not in data:
-        return
-
-    coordinator: LuxtronikCoordinator = data[CONF_COORDINATOR]
+    coordinator = entry.runtime_data
 
     # Ensure coordinator has valid data before adding entities
     if not coordinator.last_update_success:

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -16,10 +16,10 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util.dt import dt as dt_util
 
+from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
 from .common import get_sensor_data, key_exists
 from .const import (
-    CONF_COORDINATOR,
     CONF_HA_SENSOR_PREFIX,
     DOMAIN,
     LOGGER,
@@ -42,15 +42,13 @@ from .sensor_entities_predefined import SENSORS, SENSORS_INDEX, SENSORS_STATUS
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: LuxtronikConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Luxtronik sensors dynamically through Luxtronik discovery."""
 
-    data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
-    if not data or CONF_COORDINATOR not in data:
-        return
-
-    coordinator: LuxtronikCoordinator = data[CONF_COORDINATOR]
+    coordinator = entry.runtime_data
 
     # Ensure coordinator has valid data before adding entities
     if not coordinator.last_update_success:

--- a/custom_components/luxtronik/switch.py
+++ b/custom_components/luxtronik/switch.py
@@ -10,9 +10,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
 from .common import get_sensor_data, key_exists
-from .const import CONF_COORDINATOR, CONF_HA_SENSOR_PREFIX, DOMAIN, LOGGER, DeviceKey
+from .const import CONF_HA_SENSOR_PREFIX, LOGGER, DeviceKey
 from .coordinator import LuxtronikCoordinator, LuxtronikCoordinatorData
 from .model import LuxtronikSwitchDescription
 from .switch_entities_predefined import SWITCHES
@@ -21,15 +22,13 @@ from .switch_entities_predefined import SWITCHES
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: LuxtronikConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Luxtronik switches dynamically through Luxtronik discovery."""
 
-    data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
-    if not data or CONF_COORDINATOR not in data:
-        return
-
-    coordinator: LuxtronikCoordinator = data[CONF_COORDINATOR]
+    coordinator = entry.runtime_data
 
     # Ensure coordinator has valid data before adding entities
     if not coordinator.last_update_success:

--- a/custom_components/luxtronik/update.py
+++ b/custom_components/luxtronik/update.py
@@ -16,12 +16,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
 from .const import (
     CHANGELOG_URL,
-    CONF_COORDINATOR,
     CONF_HA_SENSOR_PREFIX,
-    DOMAIN,
     DOWNLOAD_PORTAL_URL,
     FIRMWARE_UPDATE_MANUAL_DE,
     FIRMWARE_UPDATE_MANUAL_EN,
@@ -41,15 +40,13 @@ MIN_TIME_BETWEEN_UPDATES: Final = timedelta(hours=1)
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: LuxtronikConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Luxtronik binary sensors dynamically through Luxtronik discovery."""
 
-    data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
-    if not data or CONF_COORDINATOR not in data:
-        return
-
-    coordinator: LuxtronikCoordinator = data[CONF_COORDINATOR]
+    coordinator = entry.runtime_data
 
     description = LuxtronikUpdateEntityDescription(
         luxtronik_key=LuxCalculation.C0081_FIRMWARE_VERSION,

--- a/custom_components/luxtronik/water_heater.py
+++ b/custom_components/luxtronik/water_heater.py
@@ -21,13 +21,12 @@ from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from packaging.version import Version
 
+from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
 from .common import get_sensor_data, key_exists
 from .const import (
-    CONF_COORDINATOR,
     CONF_HA_SENSOR_PREFIX,
     DEFAULT_DHW_MIN_TEMPERATURE,
-    DOMAIN,
     LOGGER,
     DeviceKey,
     LuxCalculation as LC,
@@ -93,15 +92,13 @@ WATER_HEATERS: list[LuxtronikWaterHeaterDescription] = [
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: LuxtronikConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Initialize DHW device from config entry."""
 
-    data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
-    if not data or CONF_COORDINATOR not in data:
-        return
-
-    coordinator: LuxtronikCoordinator = data[CONF_COORDINATOR]
+    coordinator = entry.runtime_data
 
     # Ensure coordinator has valid data before adding entities
     if not coordinator.last_update_success:


### PR DESCRIPTION
Addresses findings §10, §11 from #561.

## ♻️ Summary

Migrate config entry data storage from `hass.data[DOMAIN]` to typed `entry.runtime_data`.

## 📋 Changes

- 🏷️ **Define `LuxtronikConfigEntry` type alias** — `ConfigEntry[LuxtronikCoordinator]` for type-safe coordinator access
- ♻️ **Replace `hass.data[DOMAIN][entry.entry_id]`** dict-based storage with `entry.runtime_data` across `__init__.py`, all 9 platforms, and `diagnostics.py`
- 🗑️ **Remove unused imports** — `CONF_COORDINATOR`, `DOMAIN`, and `ConfigEntryNotReady` from platform modules where no longer needed

## 📁 Changed Files

- `custom_components/luxtronik/__init__.py`
- `custom_components/luxtronik/binary_sensor.py`
- `custom_components/luxtronik/climate.py`
- `custom_components/luxtronik/date.py`
- `custom_components/luxtronik/diagnostics.py`
- `custom_components/luxtronik/number.py`
- `custom_components/luxtronik/select.py`
- `custom_components/luxtronik/sensor.py`
- `custom_components/luxtronik/switch.py`
- `custom_components/luxtronik/update.py`
- `custom_components/luxtronik/water_heater.py`