### PR TITLE
fix: 🩹 reduce missing Luxtronik key log level from warning to debug

### DIFF
--- a/custom_components/luxtronik/binary_sensor.py
+++ b/custom_components/luxtronik/binary_sensor.py
@@ -39,7 +39,9 @@ async def async_setup_entry(
         if not key_exists(coordinator.data, i.luxtronik_key)
     ]
     if unavailable_keys:
-        LOGGER.warning("Not present in Luxtronik data, skipping: %s", unavailable_keys)
+        # Not all models/firmware versions support every parameter;
+        # missing keys are expected and not an error.
+        LOGGER.debug("Not present in Luxtronik data, skipping: %s", unavailable_keys)
 
     async_add_entities(
         [

--- a/custom_components/luxtronik/climate.py
+++ b/custom_components/luxtronik/climate.py
@@ -192,7 +192,9 @@ async def async_setup_entry(
         if not key_exists(coordinator.data, i.luxtronik_key)
     ]
     if unavailable_keys:
-        LOGGER.warning("Not present in Luxtronik data, skipping: %s", unavailable_keys)
+        # Not all models/firmware versions support every parameter;
+        # missing keys are expected and not an error.
+        LOGGER.debug("Not present in Luxtronik data, skipping: %s", unavailable_keys)
 
     async_add_entities(
         [

--- a/custom_components/luxtronik/date.py
+++ b/custom_components/luxtronik/date.py
@@ -39,7 +39,9 @@ async def async_setup_entry(
         if not key_exists(coordinator.data, i.luxtronik_key)
     ]
     if unavailable_keys:
-        LOGGER.warning("Not present in Luxtronik data, skipping: %s", unavailable_keys)
+        # Not all models/firmware versions support every parameter;
+        # missing keys are expected and not an error.
+        LOGGER.debug("Not present in Luxtronik data, skipping: %s", unavailable_keys)
 
     async_add_entities(
         [

--- a/custom_components/luxtronik/number.py
+++ b/custom_components/luxtronik/number.py
@@ -51,7 +51,9 @@ async def async_setup_entry(
         if not key_exists(coordinator.data, i.luxtronik_key)
     ]
     if unavailable_keys:
-        LOGGER.warning("Not present in Luxtronik data, skipping: %s", unavailable_keys)
+        # Not all models/firmware versions support every parameter;
+        # missing keys are expected and not an error.
+        LOGGER.debug("Not present in Luxtronik data, skipping: %s", unavailable_keys)
 
     async_add_entities(
         [

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -63,7 +63,9 @@ async def async_setup_entry(
         and i.luxtronik_key != LC.UNSET
     ]
     if unavailable_keys:
-        LOGGER.warning("Not present in Luxtronik data, skipping: %s", unavailable_keys)
+        # Not all models/firmware versions support every parameter;
+        # missing keys are expected and not an error.
+        LOGGER.debug("Not present in Luxtronik data, skipping: %s", unavailable_keys)
 
     async_add_entities(
         [

--- a/custom_components/luxtronik/switch.py
+++ b/custom_components/luxtronik/switch.py
@@ -41,7 +41,9 @@ async def async_setup_entry(
         if not key_exists(coordinator.data, i.luxtronik_key)
     ]
     if unavailable_keys:
-        LOGGER.warning("Not present in Luxtronik data, skipping: %s", unavailable_keys)
+        # Not all models/firmware versions support every parameter;
+        # missing keys are expected and not an error.
+        LOGGER.debug("Not present in Luxtronik data, skipping: %s", unavailable_keys)
 
     async_add_entities(
         [

--- a/custom_components/luxtronik/water_heater.py
+++ b/custom_components/luxtronik/water_heater.py
@@ -113,7 +113,9 @@ async def async_setup_entry(
         if not key_exists(coordinator.data, i.luxtronik_key)
     ]
     if unavailable_keys:
-        LOGGER.warning("Not present in Luxtronik data, skipping: %s", unavailable_keys)
+        # Not all models/firmware versions support every parameter;
+        # missing keys are expected and not an error.
+        LOGGER.debug("Not present in Luxtronik data, skipping: %s", unavailable_keys)
 
     async_add_entities(
         [


### PR DESCRIPTION
fix: 🩹 reduce missing Luxtronik key log level from warning to debug

🩹 **What:** Change "Not present in Luxtronik data, skipping" log level from `warning` to `debug`.

📋 **Changes:**
- Downgrade log level in 7 platform files: `binary_sensor`, `climate`, `date`, `number`, `sensor`, `switch`, `water_heater`
- Add explanatory comment at each occurrence

💡 **Why:** Not all heat pump models/firmware versions support every parameter or calculation. Missing keys (e.g. `P1158`, `P1175–P1178`, `C0268`) are expected on many setups and not an error condition. Logging them as `warning` causes unnecessary log spam on every integration setup.