### PR TITLE
fix: import EntityCategory from homeassistant.const

### DIFF
--- a/custom_components/luxtronik/date_entities_predefined.py
+++ b/custom_components/luxtronik/date_entities_predefined.py
@@ -1,4 +1,4 @@
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import EntityCategory
 
 from .const import (
     DeviceKey,

--- a/custom_components/luxtronik/number_entities_predefined.py
+++ b/custom_components/luxtronik/number_entities_predefined.py
@@ -5,12 +5,12 @@ from homeassistant.components.number import NumberMode
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     PERCENTAGE,
+    EntityCategory,
     UnitOfElectricPotential,
     UnitOfPower,
     UnitOfTemperature,
     UnitOfTime,
 )
-from homeassistant.helpers.entity import EntityCategory
 from packaging.version import Version
 
 from .const import (

--- a/custom_components/luxtronik/select.py
+++ b/custom_components/luxtronik/select.py
@@ -2,8 +2,8 @@
 
 from homeassistant.components.select import ENTITY_ID_FORMAT, SelectEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base import LuxtronikEntity

--- a/custom_components/luxtronik/sensor_entities_predefined.py
+++ b/custom_components/luxtronik/sensor_entities_predefined.py
@@ -3,6 +3,7 @@
 # region Imports
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
+    EntityCategory,
     UnitOfElectricPotential,
     UnitOfEnergy,
     UnitOfFrequency,
@@ -11,7 +12,6 @@ from homeassistant.const import (
     UnitOfTemperature,
     UnitOfTime,
 )
-from homeassistant.helpers.entity import EntityCategory
 
 from .const import (
     LUX_SMART_GRID_ICON_MAP,

--- a/custom_components/luxtronik/switch_entities_predefined.py
+++ b/custom_components/luxtronik/switch_entities_predefined.py
@@ -1,6 +1,6 @@
 """Luxtronik switch definitions."""
 
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.const import EntityCategory
 
 from .const import (
     UPDATE_INTERVAL_NORMAL,

--- a/custom_components/luxtronik/update.py
+++ b/custom_components/luxtronik/update.py
@@ -10,10 +10,9 @@ from typing import Final
 from awesomeversion import AwesomeVersion
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import EntityCategory, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base import LuxtronikEntity


### PR DESCRIPTION
# Import `EntityCategory` from `homeassistant.const`

Resolves [§T5](pylance_type_errors.md#type-5) from the Pylance type-check review.

## Problem

6 files import `EntityCategory` from the deprecated path:

```python
from homeassistant.helpers.entity import EntityCategory  # ❌ deprecated
```

`EntityCategory` was relocated to `homeassistant.const` in HA 2023.x. The old path still works at runtime but is flagged by Pyright as `reportPrivateImportUsage`.

## Fix

```python
from homeassistant.const import EntityCategory  # ✅ canonical path
```

## Files changed

| File | Change |
|---|---|
| `date_entities_predefined.py` | Replaced import |
| `number_entities_predefined.py` | Merged into existing `homeassistant.const` import |
| `sensor_entities_predefined.py` | Merged into existing `homeassistant.const` import |
| `switch_entities_predefined.py` | Replaced import |
| `select.py` | Replaced import |
| `update.py` | Merged into existing `homeassistant.const` import |
