### PR TITLE
fix: 🩹 update FlowResult to ConfigFlowResult and aiohttp timeout type

### DIFF
--- a/custom_components/luxtronik/config_flow.py
+++ b/custom_components/luxtronik/config_flow.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import AbortFlow, FlowResult
+from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers import selector
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 import voluptuous as vol
@@ -75,7 +76,7 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _create_entry(
         self, config: dict[str, Any], coordinator: LuxtronikCoordinator
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         if CONF_HA_SENSOR_PREFIX not in config:
             config[CONF_HA_SENSOR_PREFIX] = f"luxtronik_{coordinator.unique_id}"
 
@@ -93,7 +94,7 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle a flow initiated by the user."""
         try:
             LOGGER.info("Starting async_step_user")
@@ -171,7 +172,7 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_select_devices(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle user selection of a discovered device."""
         if user_input is None:
             return await self.async_step_user()
@@ -198,7 +199,7 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_manual_entry(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle manual entry of host and port."""
         if user_input is None:
             LOGGER.info("Showing manual entry form")
@@ -272,7 +273,9 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 exc_info=err,
             )
 
-    async def async_step_dhcp(self, discovery_info: DhcpServiceInfo) -> FlowResult:
+    async def async_step_dhcp(
+        self, discovery_info: DhcpServiceInfo
+    ) -> ConfigFlowResult:
         """Prepare configuration for a DHCP discovered Luxtronik heatpump."""
         try:
             LOGGER.info(
@@ -366,13 +369,13 @@ class LuxtronikOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Start the options flow."""
         return await self.async_step_user(user_input)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the user options step."""
         errors: dict[str, str] = {}
 

--- a/custom_components/luxtronik/update.py
+++ b/custom_components/luxtronik/update.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 import re
 from typing import Final
 
+from aiohttp import ClientTimeout
 from awesomeversion import AwesomeVersion
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
 from homeassistant.config_entries import ConfigEntry
@@ -191,7 +192,7 @@ class LuxtronikUpdateEntity(LuxtronikEntity, UpdateEntity):
         try:
             session = async_get_clientsession(self.hass)
             async with session.get(
-                f"{DOWNLOAD_PORTAL_URL}{download_id}", timeout=30
+                f"{DOWNLOAD_PORTAL_URL}{download_id}", timeout=ClientTimeout(total=30)
             ) as response:
                 if response.status != 200:
                     raise Exception(f"HTTP error: {response.status}")
@@ -211,7 +212,7 @@ class LuxtronikUpdateEntity(LuxtronikEntity, UpdateEntity):
                 )
 
             async with session.get(
-                f"{CHANGELOG_URL}{download_id}", timeout=30
+                f"{CHANGELOG_URL}{download_id}", timeout=ClientTimeout(total=30)
             ) as response:
                 if response.status != 200:
                     raise Exception(f"HTTP error: {response.status}")


### PR DESCRIPTION
# fix: update FlowResult to ConfigFlowResult and aiohttp timeout type

Part of #583. Resolves §T7+T8 from the Pylance type-check review.

**Branch:** `fix/flowresult-and-aiohttp-timeout`

## Problem

### T7: Deprecated `FlowResult` type (~7 errors)

`config_flow.py` uses `FlowResult` imported from `homeassistant.data_entry_flow`. This type is deprecated in favor of `ConfigFlowResult` from `homeassistant.config_entries`, which provides more specific typing for config flow methods.

### T8: Wrong `timeout` parameter type (2 errors)

`update.py` passes `timeout=30` (an `int`) to `aiohttp.ClientSession.get()`. Since aiohttp 3.x, the `timeout` parameter expects a `ClientTimeout` object, not a bare number.

## Solution

### T7

- Import `ConfigFlowResult` from `homeassistant.config_entries`
- Remove `FlowResult` import from `homeassistant.data_entry_flow` (keep `AbortFlow`)
- Update all 7 method return type annotations: `FlowResult` → `ConfigFlowResult`

### T8

- Import `ClientTimeout` from `aiohttp`
- Replace `timeout=30` → `timeout=ClientTimeout(total=30)` in both `session.get()` calls

## Files Changed

| File | Change |
|------|--------|
| `config_flow.py` | `FlowResult` → `ConfigFlowResult` (import + 7 annotations) |
| `update.py` | Add `ClientTimeout` import, wrap timeout values (2 occurrences) |

## Impact

- **~9 pyright errors resolved**
- No runtime behavior change — `ConfigFlowResult` is a type alias compatible with `FlowResult`; `ClientTimeout(total=30)` is functionally equivalent to the deprecated bare int