### PR TITLE
fix(const): 🩹 remove invalid Final annotations from enum members

### DIFF
--- a/custom_components/luxtronik/const.py
+++ b/custom_components/luxtronik/const.py
@@ -88,19 +88,19 @@ class UnitOfVolumeFlowRateExt(StrEnum):
 class DeviceKey(StrEnum):
     """Device keys."""
 
-    heatpump: Final = "heatpump"
-    heating: Final = "heating"
-    domestic_water: Final = "domestic_water"
-    cooling: Final = "cooling"
+    heatpump = "heatpump"
+    heating = "heating"
+    domestic_water = "domestic_water"
+    cooling = "cooling"
 
 
 class FirmwareVersionMinor(Enum):
     """Firmware minor versions."""
 
-    minor_80: Final = 80
-    minor_88: Final = 88
-    minor_89: Final = 89
-    minor_90: Final = 90
+    minor_80 = 80
+    minor_88 = 88
+    minor_89 = 89
+    minor_90 = 90
 
 
 LUXTRONIK_HA_SIGNAL_UPDATE_ENTITY = "luxtronik_entry_update"
@@ -132,35 +132,33 @@ PRESET_SECOND_HEATSOURCE: Final = "second_heatsource"
 class LuxOperationMode(StrEnum):
     """Lux Operation modes heating, hot water etc."""
 
-    heating: Final = "heating"  # 0
-    domestic_water: Final = "hot_water"  # 1
-    swimming_pool_solar: Final = "swimming_pool_solar"  # 2
-    evu: Final = "evu"  # 3
-    defrost: Final = "defrost"  # 4
-    no_request: Final = "no_request"  # 5
-    heating_external_source: Final = "heating_external_source"  # 6
-    cooling: Final = "cooling"  # 7
+    heating = "heating"  # 0
+    domestic_water = "hot_water"  # 1
+    swimming_pool_solar = "swimming_pool_solar"  # 2
+    evu = "evu"  # 3
+    defrost = "defrost"  # 4
+    no_request = "no_request"  # 5
+    heating_external_source = "heating_external_source"  # 6
+    cooling = "cooling"  # 7
 
 
 class LuxMode(StrEnum):
     """Luxmodes off etc."""
 
-    off: Final = "Off"
-    automatic: Final = "Automatic"
-    second_heatsource: Final = "Second heatsource"
-    party: Final = "Party"
-    holidays: Final = "Holidays"
+    off = "Off"
+    automatic = "Automatic"
+    second_heatsource = "Second heatsource"
+    party = "Party"
+    holidays = "Holidays"
 
 
 class LuxSmartGridStatus(StrEnum):
     """SmartGrid status based on EVU and EVU2 inputs."""
 
-    locked: Final = "evu_locked"  # EVU=1, EVU2=0 - Status 1 - EVU lock
-    reduced: Final = "reduced_operation"  # EVU=0, EVU2=0 - Status 2 - Reduced operation
-    normal: Final = "normal_operation"  # EVU=0, EVU2=1 - Status 3 - Normal operation
-    increased: Final = (
-        "increased_operation"  # EVU=1, EVU2=1 - Status 4 - Increased operation
-    )
+    locked = "evu_locked"  # EVU=1, EVU2=0 - Status 1 - EVU lock
+    reduced = "reduced_operation"  # EVU=0, EVU2=0 - Status 2 - Reduced operation
+    normal = "normal_operation"  # EVU=0, EVU2=1 - Status 3 - Normal operation
+    increased = "increased_operation"  # EVU=1, EVU2=1 - Status 4 - Increased operation
 
 
 class LuxStatus1Option(StrEnum):
@@ -168,57 +166,55 @@ class LuxStatus1Option(StrEnum):
 
     # HA-state : Heatpump_state
 
-    heatpump_running: Final = "heatpump_running"
-    heatpump_idle: Final = "heatpump_idle"
-    heatpump_coming: Final = "heatpump_coming"
-    heatpump_shutdown: Final = "heatpump_shutdown"
-    errorcode_slot_zero: Final = "errorcode_slot_0"
-    defrost: Final = "defrost"
-    waiting_on_lin_connection: Final = "witing_on_lin_connection"
-    compressor_heating_up: Final = "compressor_heating_up"
-    pump_forerun: Final = "pump_forerun"
-    compressor_heater: Final = "compressor_heater"
+    heatpump_running = "heatpump_running"
+    heatpump_idle = "heatpump_idle"
+    heatpump_coming = "heatpump_coming"
+    heatpump_shutdown = "heatpump_shutdown"
+    errorcode_slot_zero = "errorcode_slot_0"
+    defrost = "defrost"
+    waiting_on_lin_connection = "witing_on_lin_connection"
+    compressor_heating_up = "compressor_heating_up"
+    pump_forerun = "pump_forerun"
+    compressor_heater = "compressor_heater"
 
 
 class LuxStatus3Option(StrEnum):
     """LuxStatus3 option heating etc."""
 
-    unknown: Final = "unknown"
-    none: Final = "none"
-    heating: Final = "heating"
-    no_request: Final = "no_request"
-    grid_switch_on_delay: Final = "grid_switch_on_delay"
-    cycle_lock: Final = "cycle_lock"
-    lock_time: Final = "lock_time"
-    domestic_water: Final = "domestic_water"
-    info_bake_out_program: Final = "info_bake_out_program"
-    defrost: Final = "defrost"
-    pump_forerun: Final = "pump_forerun"
-    thermal_desinfection: Final = "thermal_desinfection"
-    cooling: Final = "cooling"
-    swimming_pool_solar: Final = "swimming_pool_solar"
-    heating_external_energy_source: Final = "heating_external_energy_source"
-    domestic_water_external_energy_source: Final = (
-        "domestic_water_external_energy_source"
-    )
-    flow_monitoring: Final = "flow_monitoring"
-    second_heat_generator_1_active: Final = "second_heat_generator_1_active"
+    unknown = "unknown"
+    none = "none"
+    heating = "heating"
+    no_request = "no_request"
+    grid_switch_on_delay = "grid_switch_on_delay"
+    cycle_lock = "cycle_lock"
+    lock_time = "lock_time"
+    domestic_water = "domestic_water"
+    info_bake_out_program = "info_bake_out_program"
+    defrost = "defrost"
+    pump_forerun = "pump_forerun"
+    thermal_desinfection = "thermal_desinfection"
+    cooling = "cooling"
+    swimming_pool_solar = "swimming_pool_solar"
+    heating_external_energy_source = "heating_external_energy_source"
+    domestic_water_external_energy_source = "domestic_water_external_energy_source"
+    flow_monitoring = "flow_monitoring"
+    second_heat_generator_1_active = "second_heat_generator_1_active"
 
 
 class LuxMkTypes(Enum):
     """LuxMkTypes etc."""
 
-    off: Final = 0
-    discharge: Final = 1
-    load: Final = 2
-    cooling: Final = 3
-    heating_cooling: Final = 4
+    off = 0
+    discharge = 1
+    load = 2
+    cooling = 3
+    heating_cooling = 4
 
 
 class LuxRoomThermostatType(Enum):
     """LuxMkTypes etc."""
 
-    none: Final = 0
+    none = 0
     # TODO: Validate types:
     # RFV: Final = 1
     # RFV_K: Final = 2
@@ -230,38 +226,38 @@ class LuxRoomThermostatType(Enum):
 class LuxSwitchoffReason(Enum):
     """LuxSwitchoff reason etc."""
 
-    cycle_lock: Final = 0  # cycle_lock
-    heatpump_error: Final = 1
-    system_error: Final = 2
-    evu_lock: Final = 3
-    operation_mode_second_heat_generator: Final = 4
-    air_defrost: Final = 5
-    maximal_usage_temperature: Final = 6
-    minimal_usage_temperature: Final = 7
-    lower_usage_limit: Final = 8
-    no_request: Final = 9
-    undefined_10: Final = 10  # ???
-    flow_rate: Final = 11  # Durchfluss
-    p0_pause: Final = 12
-    undefined_13: Final = 13  # ???
-    IO_pause: Final = 14
-    undefined_15: Final = 15  # ???
-    undefined_16: Final = 16  # ???
-    undefined_17: Final = 17  # ???
-    undefined_18: Final = 18  # ???
-    PV_max: Final = 19
-    undefined_20: Final = 20  # ???
-    undefined_21: Final = 21  # ???
-    undefined_22: Final = 22  # ???
-    undefined_23: Final = 23  # ???
-    LPC: Final = 24
-    restart: Final = 25
-    undefined_26: Final = 26  # ???
-    undefined_27: Final = 27  # ???
-    undefined_28: Final = 28  # ???
-    undefined_29: Final = 29  # ???
-    undefined_30: Final = 30  # ???
-    undefined_31: Final = 31  # ???
+    cycle_lock = 0  # cycle_lock
+    heatpump_error = 1
+    system_error = 2
+    evu_lock = 3
+    operation_mode_second_heat_generator = 4
+    air_defrost = 5
+    maximal_usage_temperature = 6
+    minimal_usage_temperature = 7
+    lower_usage_limit = 8
+    no_request = 9
+    undefined_10 = 10  # ???
+    flow_rate = 11  # Durchfluss
+    p0_pause = 12
+    undefined_13 = 13  # ???
+    IO_pause = 14
+    undefined_15 = 15  # ???
+    undefined_16 = 16  # ???
+    undefined_17 = 17  # ???
+    undefined_18 = 18  # ???
+    PV_max = 19
+    undefined_20 = 20  # ???
+    undefined_21 = 21  # ???
+    undefined_22 = 22  # ???
+    undefined_23 = 23  # ???
+    LPC = 24
+    restart = 25
+    undefined_26 = 26  # ???
+    undefined_27 = 27  # ???
+    undefined_28 = 28  # ???
+    undefined_29 = 29  # ???
+    undefined_30 = 30  # ???
+    undefined_31 = 31  # ???
 
 
 LUX_STATE_ICON_MAP: Final[dict[StateType | date | datetime | Decimal, str]] = {
@@ -299,13 +295,13 @@ LUX_MODELS_OTHER = ["CB", "CI", "CN", "CS"]
 class LuxDaySelectorParameter(StrEnum):
     """Luxtronik parameters for day selector (TDI activation per weekday)."""
 
-    MONDAY: Final = "parameters.ID_Einst_BwTDI_akt_MO"
-    TUESDAY: Final = "parameters.ID_Einst_BwTDI_akt_DI"
-    WEDNESDAY: Final = "parameters.ID_Einst_BwTDI_akt_MI"
-    THURSDAY: Final = "parameters.ID_Einst_BwTDI_akt_DO"
-    FRIDAY: Final = "parameters.ID_Einst_BwTDI_akt_FR"
-    SATURDAY: Final = "parameters.ID_Einst_BwTDI_akt_SA"
-    SUNDAY: Final = "parameters.ID_Einst_BwTDI_akt_SO"
+    MONDAY = "parameters.ID_Einst_BwTDI_akt_MO"
+    TUESDAY = "parameters.ID_Einst_BwTDI_akt_DI"
+    WEDNESDAY = "parameters.ID_Einst_BwTDI_akt_MI"
+    THURSDAY = "parameters.ID_Einst_BwTDI_akt_DO"
+    FRIDAY = "parameters.ID_Einst_BwTDI_akt_FR"
+    SATURDAY = "parameters.ID_Einst_BwTDI_akt_SA"
+    SUNDAY = "parameters.ID_Einst_BwTDI_akt_SO"
 
 
 DAY_NAME_TO_PARAM: Final[dict[str, LuxDaySelectorParameter]] = {
@@ -335,102 +331,88 @@ DAY_SELECTOR_OPTIONS: Final[list[str]] = [
 class LuxParameter(StrEnum):
     """Luxtronik parameter ids."""
 
-    UNSET: Final = "UNSET"
-    P0001_HEATING_TARGET_CORRECTION: Final = "parameters.ID_Einst_WK_akt"
-    P0002_DHW_TARGET_TEMPERATURE: Final = "parameters.ID_Einst_BWS_akt"
-    P0003_MODE_HEATING: Final = "parameters.ID_Ba_Hz_akt"
-    P0004_MODE_DHW: Final = "parameters.ID_Ba_Bw_akt"
+    UNSET = "UNSET"
+    P0001_HEATING_TARGET_CORRECTION = "parameters.ID_Einst_WK_akt"
+    P0002_DHW_TARGET_TEMPERATURE = "parameters.ID_Einst_BWS_akt"
+    P0003_MODE_HEATING = "parameters.ID_Ba_Hz_akt"
+    P0004_MODE_DHW = "parameters.ID_Ba_Bw_akt"
     # luxtronik*_heating_curve*
-    P0011_HEATING_CURVE_END_TEMPERATURE: Final = "parameters.ID_Einst_HzHwHKE_akt"
-    P0012_HEATING_CURVE_PARALLEL_SHIFT_TEMPERATURE: Final = (
-        "parameters.ID_Einst_HzHKRANH_akt"
-    )
-    P0013_HEATING_CURVE_NIGHT_TEMPERATURE: Final = "parameters.ID_Einst_HzHKRABS_akt"
+    P0011_HEATING_CURVE_END_TEMPERATURE = "parameters.ID_Einst_HzHwHKE_akt"
+    P0012_HEATING_CURVE_PARALLEL_SHIFT_TEMPERATURE = "parameters.ID_Einst_HzHKRANH_akt"
+    P0013_HEATING_CURVE_NIGHT_TEMPERATURE = "parameters.ID_Einst_HzHKRABS_akt"
     # luxtronik*_heating_curve_circuit1*
-    P0014_HEATING_CURVE_CIRCUIT1_END_TEMPERATURE: Final = (
+    P0014_HEATING_CURVE_CIRCUIT1_END_TEMPERATURE = (
         "parameters.ID_Einst_HzMK1E_akt"  # 260
     )
-    P0015_HEATING_CURVE_CIRCUIT1_PARALLEL_SHIFT_TEMPERATURE: Final = (
+    P0015_HEATING_CURVE_CIRCUIT1_PARALLEL_SHIFT_TEMPERATURE = (
         "parameters.ID_Einst_HzMK1ANH_akt"  # 290
     )
-    P0016_HEATING_CURVE_CIRCUIT1_NIGHT_TEMPERATURE: Final = (
+    P0016_HEATING_CURVE_CIRCUIT1_NIGHT_TEMPERATURE = (
         "parameters.ID_Einst_HzMK1ABS_akt"  # 0
     )
     # luxtronik*_heating_curve_circuit2*
-    P0017_HEATING_CURVE_CIRCUIT2_END_TEMPERATURE: Final = (
+    P0017_HEATING_CURVE_CIRCUIT2_END_TEMPERATURE = (
         "parameters.ID_Einst_HzMK2E_akt"  # 260
     )
-    P0018_HEATING_CURVE_CIRCUIT2_PARALLEL_SHIFT_TEMPERATURE: Final = (
+    P0018_HEATING_CURVE_CIRCUIT2_PARALLEL_SHIFT_TEMPERATURE = (
         "parameters.ID_Einst_HzMK2ANH_akt"  # 290
     )
-    P0019_HEATING_CURVE_CIRCUIT2_NIGHT_TEMPERATURE: Final = (
+    P0019_HEATING_CURVE_CIRCUIT2_NIGHT_TEMPERATURE = (
         "parameters.ID_Einst_HzMK2ABS_akt"  # 0
     )
     # luxtronik*_heating_curve_circuit3*
-    P0020_HEATING_CURVE_CIRCUIT3_END_TEMPERATURE: Final = (
+    P0020_HEATING_CURVE_CIRCUIT3_END_TEMPERATURE = (
         "parameters.ID_Einst_HzMK3E_akt"  # 270
     )
-    P0021_HEATING_CURVE_CIRCUIT3_PARALLEL_SHIFT_TEMPERATURE: Final = (
+    P0021_HEATING_CURVE_CIRCUIT3_PARALLEL_SHIFT_TEMPERATURE = (
         "parameters.ID_Einst_HzMK3ANH_akt"  # 290
     )
-    P0022_HEATING_CURVE_CIRCUIT3_NIGHT_TEMPERATURE: Final = (
+    P0022_HEATING_CURVE_CIRCUIT3_NIGHT_TEMPERATURE = (
         "parameters.ID_Einst_HzMK3ABS_akt"  # 0
     )
     # P0036_SECOND_HEAT_GENERATOR: Final = "parameters.ID_Einst_ZWE1Art_akt"  #  = 1 --> Heating and domestic water - Is second heat generator activated 1=electrical heater
-    P0042_MIXING_CIRCUIT1_TYPE: Final = "parameters.ID_Einst_MK1Typ_akt"
-    P0047_DHW_THERMAL_DESINFECTION_TARGET: Final = "parameters.ID_Einst_LGST_akt"
-    P0049_PUMP_OPTIMIZATION: Final = "parameters.ID_Einst_Popt_akt"
+    P0042_MIXING_CIRCUIT1_TYPE = "parameters.ID_Einst_MK1Typ_akt"
+    P0047_DHW_THERMAL_DESINFECTION_TARGET = "parameters.ID_Einst_LGST_akt"
+    P0049_PUMP_OPTIMIZATION = "parameters.ID_Einst_Popt_akt"
     # P0033_ROOM_THERMOSTAT_TYPE: Final = "parameters.ID_Einst_RFVEinb_akt"  # != 0 --> Has_Room_Temp
-    P0074_DHW_HYSTERESIS: Final = "parameters.ID_Einst_BWS_Hyst_akt"
-    P0085_DHW_CHARGING_PUMP: Final = "parameters.ID_Einst_BWZIP_akt"  # has_domestic_water_circulation_pump int() != 1
-    P0088_HEATING_HYSTERESIS: Final = "parameters.ID_Einst_HRHyst_akt"
-    P0089_HEATING_MAX_FLOW_OUT_INCREASE_TEMPERATURE: Final = (
-        "parameters.ID_Einst_TRErhmax_akt"
-    )
-    P0090_RELEASE_SECOND_HEAT_GENERATOR: Final = "parameters.ID_Einst_ZWEFreig_akt"
-    P0093_HEAT_SOURCE_INPUT_TEMPERATURE_MIN: Final = "parameters.ID_Einst_TWQmin_akt"
-    P0105_DHW_TARGET_TEMPERATURE: Final = "parameters.ID_Soll_BWS_akt"
+    P0074_DHW_HYSTERESIS = "parameters.ID_Einst_BWS_Hyst_akt"
+    P0085_DHW_CHARGING_PUMP = "parameters.ID_Einst_BWZIP_akt"  # has_domestic_water_circulation_pump int() != 1
+    P0088_HEATING_HYSTERESIS = "parameters.ID_Einst_HRHyst_akt"
+    P0089_HEATING_MAX_FLOW_OUT_INCREASE_TEMPERATURE = "parameters.ID_Einst_TRErhmax_akt"
+    P0090_RELEASE_SECOND_HEAT_GENERATOR = "parameters.ID_Einst_ZWEFreig_akt"
+    P0093_HEAT_SOURCE_INPUT_TEMPERATURE_MIN = "parameters.ID_Einst_TWQmin_akt"
+    P0105_DHW_TARGET_TEMPERATURE = "parameters.ID_Soll_BWS_akt"
     # MODE_COOLING: Automatic or Off
-    P0108_MODE_COOLING: Final = "parameters.ID_Einst_BA_Kuehl_akt"
-    P0110_COOLING_OUTDOOR_TEMP_THRESHOLD: Final = "parameters.ID_Einst_KuehlFreig_akt"
-    P0111_HEATING_NIGHT_LOWERING_TO_TEMPERATURE: Final = (
-        "parameters.ID_Einst_TAbsMin_akt"
-    )
-    P0122_SOLAR_PUMP_ON_DIFFERENCE_TEMPERATURE: Final = (
-        "parameters.ID_Einst_TDC_Ein_akt"
-    )
-    P0123_SOLAR_PUMP_OFF_DIFFERENCE_TEMPERATURE: Final = (
-        "parameters.ID_Einst_TDC_Aus_akt"
-    )
-    P0130_MIXING_CIRCUIT2_TYPE: Final = "parameters.ID_Einst_MK2Typ_akt"
-    P0132_COOLING_TARGET_TEMPERATURE_MK1: Final = "parameters.ID_Sollwert_KuCft1_akt"
-    P0133_COOLING_TARGET_TEMPERATURE_MK2: Final = "parameters.ID_Sollwert_KuCft2_akt"
-    P0149_FLOW_IN_TEMPERATURE_MAX_ALLOWED: Final = "parameters.ID_Einst_TVLmax_akt"
-    P0155_VENTING_TIME_HOURS: Final = "parameters.ID_Einst_Entl_time_akt"
-    P0158_VENTING_ACTIVE: Final = "parameters.ID_Einst_Entl_akt"
-    P0289_SOLAR_PUMP_OFF_MAX_DIFFERENCE_TEMPERATURE_BOILER: Final = (
+    P0108_MODE_COOLING = "parameters.ID_Einst_BA_Kuehl_akt"
+    P0110_COOLING_OUTDOOR_TEMP_THRESHOLD = "parameters.ID_Einst_KuehlFreig_akt"
+    P0111_HEATING_NIGHT_LOWERING_TO_TEMPERATURE = "parameters.ID_Einst_TAbsMin_akt"
+    P0122_SOLAR_PUMP_ON_DIFFERENCE_TEMPERATURE = "parameters.ID_Einst_TDC_Ein_akt"
+    P0123_SOLAR_PUMP_OFF_DIFFERENCE_TEMPERATURE = "parameters.ID_Einst_TDC_Aus_akt"
+    P0130_MIXING_CIRCUIT2_TYPE = "parameters.ID_Einst_MK2Typ_akt"
+    P0132_COOLING_TARGET_TEMPERATURE_MK1 = "parameters.ID_Sollwert_KuCft1_akt"
+    P0133_COOLING_TARGET_TEMPERATURE_MK2 = "parameters.ID_Sollwert_KuCft2_akt"
+    P0149_FLOW_IN_TEMPERATURE_MAX_ALLOWED = "parameters.ID_Einst_TVLmax_akt"
+    P0155_VENTING_TIME_HOURS = "parameters.ID_Einst_Entl_time_akt"
+    P0158_VENTING_ACTIVE = "parameters.ID_Einst_Entl_akt"
+    P0289_SOLAR_PUMP_OFF_MAX_DIFFERENCE_TEMPERATURE_BOILER = (
         "parameters.ID_Einst_TDC_Max_akt"
     )
-    P0678_VENTING_HUP_ACTIVE: Final = "parameters.ID_Einst_Entl_Typ_0"
-    P0699_HEATING_THRESHOLD: Final = "parameters.ID_Einst_Heizgrenze"
-    P0700_HEATING_THRESHOLD_TEMPERATURE: Final = "parameters.ID_Einst_Heizgrenze_Temp"
-    P0716_0720_SWITCHOFF_REASON: Final = "parameters.ID_Switchoff_file_{ID}_0"  # e.g. ID_Switchoff_file_0_0 - ID_Switchoff_file_4_0
-    P0721_0725_SWITCHOFF_TIMESTAMP: Final = "parameters.ID_Switchoff_file_{ID}_1"  # e.g. ID_Switchoff_file_0_1 - ID_Switchoff_file_4_1
-    P0780_MIXING_CIRCUIT3_TYPE: Final = "parameters.ID_Einst_MK3Typ_akt"
-    P0850_COOLING_START_DELAY_HOURS: Final = "parameters.ID_Einst_Kuhl_Zeit_Ein_akt"
-    P0851_COOLING_STOP_DELAY_HOURS: Final = "parameters.ID_Einst_Kuhl_Zeit_Aus_akt"
-    P0860_REMOTE_MAINTENANCE: Final = "parameters.ID_Einst_Fernwartung_akt"
-    P0864_PUMP_OPTIMIZATION_TIME: Final = "parameters.ID_Einst_Popt_Nachlauf_akt"
-    P0867_EFFICIENCY_PUMP_NOMINAL: Final = (
-        "parameters.ID_Einst_Effizienzpumpe_Nominal_akt"
-    )
-    P0868_EFFICIENCY_PUMP_MINIMAL: Final = (
-        "parameters.ID_Einst_Effizienzpumpe_Minimal_akt"
-    )
-    P0869_EFFICIENCY_PUMP: Final = "parameters.ID_Einst_Effizienzpumpe_akt"
+    P0678_VENTING_HUP_ACTIVE = "parameters.ID_Einst_Entl_Typ_0"
+    P0699_HEATING_THRESHOLD = "parameters.ID_Einst_Heizgrenze"
+    P0700_HEATING_THRESHOLD_TEMPERATURE = "parameters.ID_Einst_Heizgrenze_Temp"
+    P0716_0720_SWITCHOFF_REASON = "parameters.ID_Switchoff_file_{ID}_0"  # e.g. ID_Switchoff_file_0_0 - ID_Switchoff_file_4_0
+    P0721_0725_SWITCHOFF_TIMESTAMP = "parameters.ID_Switchoff_file_{ID}_1"  # e.g. ID_Switchoff_file_0_1 - ID_Switchoff_file_4_1
+    P0780_MIXING_CIRCUIT3_TYPE = "parameters.ID_Einst_MK3Typ_akt"
+    P0850_COOLING_START_DELAY_HOURS = "parameters.ID_Einst_Kuhl_Zeit_Ein_akt"
+    P0851_COOLING_STOP_DELAY_HOURS = "parameters.ID_Einst_Kuhl_Zeit_Aus_akt"
+    P0860_REMOTE_MAINTENANCE = "parameters.ID_Einst_Fernwartung_akt"
+    P0864_PUMP_OPTIMIZATION_TIME = "parameters.ID_Einst_Popt_Nachlauf_akt"
+    P0867_EFFICIENCY_PUMP_NOMINAL = "parameters.ID_Einst_Effizienzpumpe_Nominal_akt"
+    P0868_EFFICIENCY_PUMP_MINIMAL = "parameters.ID_Einst_Effizienzpumpe_Minimal_akt"
+    P0869_EFFICIENCY_PUMP = "parameters.ID_Einst_Effizienzpumpe_akt"
     # P0870_AMOUNT_COUNTER_ACTIVE: Final = "parameters.ID_Einst_Waermemenge_akt"
-    P0874_SERIAL_NUMBER: Final = "parameters.ID_WP_SerienNummer_DATUM"
-    P0875_SERIAL_NUMBER_MODEL: Final = "parameters.ID_WP_SerienNummer_HEX"
+    P0874_SERIAL_NUMBER = "parameters.ID_WP_SerienNummer_DATUM"
+    P0875_SERIAL_NUMBER_MODEL = "parameters.ID_WP_SerienNummer_HEX"
 
     # "852  ID_Waermemenge_Seit                                         ": "2566896",
     # "853  ID_Waermemenge_WQ                                           ": "0",
@@ -440,57 +422,49 @@ class LuxParameter(StrEnum):
     #  "879  ID_Waermemenge_SW                                           ": "0",
     #  "880  ID_Waermemenge_Datum                                        ": "1483648906", <-- Unix timestamp!  5.1.2017
 
-    P0882_SOLAR_OPERATION_HOURS: Final = "parameters.ID_BSTD_Solar"
-    P0883_SOLAR_PUMP_MAX_TEMPERATURE_COLLECTOR: Final = (
-        "parameters.ID_Einst_TDC_Koll_Max_akt"
-    )
+    P0882_SOLAR_OPERATION_HOURS = "parameters.ID_BSTD_Solar"
+    P0883_SOLAR_PUMP_MAX_TEMPERATURE_COLLECTOR = "parameters.ID_Einst_TDC_Koll_Max_akt"
     # P0894_VENTILATION_MODE: Final = "parameters.ID_Einst_BA_Lueftung_akt" # "Automatic", "Party", "Holidays", "Off"
-    P0966_COOLING_TARGET_TEMPERATURE_MK3: Final = "parameters.ID_Sollwert_KuCft3_akt"
-    P0973_MAX_DHW_TEMPERATURE: Final = "parameters.ID_Einst_BW_max"
-    P0979_HEATING_MIN_FLOW_OUT_TEMPERATURE: Final = (
+    P0966_COOLING_TARGET_TEMPERATURE_MK3 = "parameters.ID_Sollwert_KuCft3_akt"
+    P0973_MAX_DHW_TEMPERATURE = "parameters.ID_Einst_BW_max"
+    P0979_HEATING_MIN_FLOW_OUT_TEMPERATURE = (
         "parameters.ID_Einst_Minimale_Ruecklaufsolltemperatur"
     )
-    P0980_HEATING_ROOM_TEMPERATURE_IMPACT_FACTOR: Final = (
+    P0980_HEATING_ROOM_TEMPERATURE_IMPACT_FACTOR = (
         "parameters.ID_RBE_Einflussfaktor_RT_akt"
     )
-    P0992_RELEASE_TIME_SECOND_HEAT_GENERATOR: Final = (
-        "parameters.ID_Einst_Freigabe_Zeit_ZWE"
-    )
-    P1032_HEATING_MAXIMUM_CIRCULATION_PUMP_SPEED: Final = (
+    P0992_RELEASE_TIME_SECOND_HEAT_GENERATOR = "parameters.ID_Einst_Freigabe_Zeit_ZWE"
+    P1032_HEATING_MAXIMUM_CIRCULATION_PUMP_SPEED = (
         "parameters.ID_Einst_P155_PumpHeat_Max"
     )
-    P1030_SMART_GRID_SWITCH: Final = "parameters.ID_Einst_SmartGrid"
-    P1033_PUMP_HEAT_CONTROL: Final = "parameters.ID_Einst_P155_PumpHeatCtrl"
-    P1059_ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER: Final = (
-        "parameters.ID_Waermemenge_ZWE"
-    )
+    P1030_SMART_GRID_SWITCH = "parameters.ID_Einst_SmartGrid"
+    P1033_PUMP_HEAT_CONTROL = "parameters.ID_Einst_P155_PumpHeatCtrl"
+    P1059_ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER = "parameters.ID_Waermemenge_ZWE"
     # "1060 ID_Waermemenge_Reset                                        ": "535051",
     # "1061 ID_Waermemenge_Reset_2                                      ": "0",
-    P1087_SILENT_MODE: Final = "parameters.Unknown_Parameter_1087"  # Silent mode On/Off
-    P1119_LAST_DEFROST_TIMESTAMP: Final = (
+    P1087_SILENT_MODE = "parameters.Unknown_Parameter_1087"  # Silent mode On/Off
+    P1119_LAST_DEFROST_TIMESTAMP = (
         "parameters.Unknown_Parameter_1119"  # 1685073431 -> 26.5.23 05:57
     )
-    P1136_HEAT_ENERGY_INPUT: Final = "parameters.Unknown_Parameter_1136"
-    P1137_DHW_ENERGY_INPUT: Final = "parameters.Unknown_Parameter_1137"
+    P1136_HEAT_ENERGY_INPUT = "parameters.Unknown_Parameter_1136"
+    P1137_DHW_ENERGY_INPUT = "parameters.Unknown_Parameter_1137"
     # ? P1138_SWIMMING_POOL_ENERGY_INPUT: Final = "parameters.Unknown_Parameter_1138" -->
-    P1139_COOLING_ENERGY_INPUT: Final = "parameters.Unknown_Parameter_1139"
-    P1140_SECOND_HEAT_GENERATOR_AMOUNT_COUNTER: Final = (
-        "parameters.Unknown_Parameter_1140"
-    )
-    P1148_HEATING_TARGET_TEMP_ROOM_THERMOSTAT: Final = (
+    P1139_COOLING_ENERGY_INPUT = "parameters.Unknown_Parameter_1139"
+    P1140_SECOND_HEAT_GENERATOR_AMOUNT_COUNTER = "parameters.Unknown_Parameter_1140"
+    P1148_HEATING_TARGET_TEMP_ROOM_THERMOSTAT = (
         "parameters.HEATING_TARGET_TEMP_ROOM_THERMOSTAT"
     )
-    P1158_POWER_LIMIT_SWITCH: Final = "parameters.Unknown_Parameter_1158"
-    P1159_POWER_LIMIT_VALUE: Final = "parameters.Unknown_Parameter_1159"
-    P1175_THERMAL_POWER_LIMIT_SWITCH: Final = "parameters.Unknown_Parameter_1175"
-    P1176_THERMAL_POWER_LIMIT_HEATING: Final = "parameters.Unknown_Parameter_1176"
-    P1177_THERMAL_POWER_LIMIT_WATER: Final = "parameters.Unknown_Parameter_1177"
-    P1178_THERMAL_POWER_LIMIT_COOLING: Final = "parameters.Unknown_Parameter_1178"
+    P1158_POWER_LIMIT_SWITCH = "parameters.Unknown_Parameter_1158"
+    P1159_POWER_LIMIT_VALUE = "parameters.Unknown_Parameter_1159"
+    P1175_THERMAL_POWER_LIMIT_SWITCH = "parameters.Unknown_Parameter_1175"
+    P1176_THERMAL_POWER_LIMIT_HEATING = "parameters.Unknown_Parameter_1176"
+    P1177_THERMAL_POWER_LIMIT_WATER = "parameters.Unknown_Parameter_1177"
+    P1178_THERMAL_POWER_LIMIT_COOLING = "parameters.Unknown_Parameter_1178"
 
-    P0731_AWAY_HEATING_STARTDATE: Final = "parameters.ID_SU_FstdHz"
-    P0006_AWAY_HEATING_ENDDATE: Final = "parameters.ID_SU_FrkdHz"
-    P0732_AWAY_DHW_STARTDATE: Final = "parameters.ID_SU_FstdBw"
-    P0007_AWAY_DHW_ENDDATE: Final = "parameters.ID_SU_FrkdBw"
+    P0731_AWAY_HEATING_STARTDATE = "parameters.ID_SU_FstdHz"
+    P0006_AWAY_HEATING_ENDDATE = "parameters.ID_SU_FrkdHz"
+    P0732_AWAY_DHW_STARTDATE = "parameters.ID_SU_FstdBw"
+    P0007_AWAY_DHW_ENDDATE = "parameters.ID_SU_FrkdBw"
 
 
 # endregion Lux parameters
@@ -506,130 +480,118 @@ LUX_PARAMETER_MK_SENSORS: Final = [
 class LuxCalculation(StrEnum):
     """Luxtronik calculation ids."""
 
-    UNSET: Final = "UNSET"
-    C0010_FLOW_IN_TEMPERATURE: Final = "calculations.ID_WEB_Temperatur_TVL"
-    C0011_FLOW_OUT_TEMPERATURE: Final = "calculations.ID_WEB_Temperatur_TRL"
-    C0012_FLOW_OUT_TEMPERATURE_TARGET: Final = "calculations.ID_WEB_Sollwert_TRL_HZ"
-    C0013_FLOW_OUT_TEMPERATURE_EXTERNAL: Final = (
-        "calculations.ID_WEB_Temperatur_TRL_ext"
-    )
-    C0014_HOT_GAS_TEMPERATURE: Final = "calculations.ID_WEB_Temperatur_THG"
-    C0015_OUTDOOR_TEMPERATURE: Final = "calculations.ID_WEB_Temperatur_TA"
-    C0016_OUTDOOR_TEMPERATURE_AVERAGE: Final = "calculations.ID_WEB_Mitteltemperatur"
-    C0017_DHW_TEMPERATURE: Final = "calculations.ID_WEB_Temperatur_TBW"
-    C0018_FLOW_IN_CIRCUIT1_TEMPERATURE: Final = "calculations.ID_WEB_Temperatur_TFB1"
-    C0019_FLOW_IN_CIRCUIT2_TEMPERATURE: Final = "calculations.ID_WEB_Temperatur_TFB2"
-    C0020_FLOW_IN_CIRCUIT3_TEMPERATURE: Final = "calculations.ID_WEB_Temperatur_TFB3"
-    C0021_FLOW_IN_CIRCUIT1_TARGET_TEMPERATURE: Final = (
-        "calculations.ID_WEB_Sollwert_TVL_MK1"
-    )
-    C0022_FLOW_IN_CIRCUIT2_TARGET_TEMPERATURE: Final = (
-        "calculations.ID_WEB_Sollwert_TVL_MK2"
-    )
-    C0023_FLOW_IN_CIRCUIT3_TARGET_TEMPERATURE: Final = (
-        "calculations.ID_WEB_Sollwert_TVL_MK3"
-    )
-    C0024_HEAT_SOURCE_OUTPUT_TEMPERATURE: Final = "calculations.ID_WEB_Temperatur_TWA"
-    C0026_SOLAR_COLLECTOR_TEMPERATURE: Final = "calculations.ID_WEB_Temperatur_TSK"
-    C0027_SOLAR_BUFFER_TEMPERATURE: Final = "calculations.ID_WEB_Temperatur_TSS"
-    C0029_DEFROST_END_FLOW_OKAY: Final = "calculations.ID_WEB_ASDin"
-    C0031_EVU_UNLOCKED: Final = "calculations.ID_WEB_EVUin"
+    UNSET = "UNSET"
+    C0010_FLOW_IN_TEMPERATURE = "calculations.ID_WEB_Temperatur_TVL"
+    C0011_FLOW_OUT_TEMPERATURE = "calculations.ID_WEB_Temperatur_TRL"
+    C0012_FLOW_OUT_TEMPERATURE_TARGET = "calculations.ID_WEB_Sollwert_TRL_HZ"
+    C0013_FLOW_OUT_TEMPERATURE_EXTERNAL = "calculations.ID_WEB_Temperatur_TRL_ext"
+    C0014_HOT_GAS_TEMPERATURE = "calculations.ID_WEB_Temperatur_THG"
+    C0015_OUTDOOR_TEMPERATURE = "calculations.ID_WEB_Temperatur_TA"
+    C0016_OUTDOOR_TEMPERATURE_AVERAGE = "calculations.ID_WEB_Mitteltemperatur"
+    C0017_DHW_TEMPERATURE = "calculations.ID_WEB_Temperatur_TBW"
+    C0018_FLOW_IN_CIRCUIT1_TEMPERATURE = "calculations.ID_WEB_Temperatur_TFB1"
+    C0019_FLOW_IN_CIRCUIT2_TEMPERATURE = "calculations.ID_WEB_Temperatur_TFB2"
+    C0020_FLOW_IN_CIRCUIT3_TEMPERATURE = "calculations.ID_WEB_Temperatur_TFB3"
+    C0021_FLOW_IN_CIRCUIT1_TARGET_TEMPERATURE = "calculations.ID_WEB_Sollwert_TVL_MK1"
+    C0022_FLOW_IN_CIRCUIT2_TARGET_TEMPERATURE = "calculations.ID_WEB_Sollwert_TVL_MK2"
+    C0023_FLOW_IN_CIRCUIT3_TARGET_TEMPERATURE = "calculations.ID_WEB_Sollwert_TVL_MK3"
+    C0024_HEAT_SOURCE_OUTPUT_TEMPERATURE = "calculations.ID_WEB_Temperatur_TWA"
+    C0026_SOLAR_COLLECTOR_TEMPERATURE = "calculations.ID_WEB_Temperatur_TSK"
+    C0027_SOLAR_BUFFER_TEMPERATURE = "calculations.ID_WEB_Temperatur_TSS"
+    C0029_DEFROST_END_FLOW_OKAY = "calculations.ID_WEB_ASDin"
+    C0031_EVU_UNLOCKED = "calculations.ID_WEB_EVUin"
     # C0032_HIGH_PRESSURE_OKAY: Final = "calculations.ID_WEB_HDin"  # True/False -> Hochdruck OK
-    C0034_MOTOR_PROTECTION: Final = "calculations.ID_WEB_MOTin"
-    C0037_DEFROST_VALVE: Final = "calculations.ID_WEB_AVout"
-    C0038_DHW_RECIRCULATION_PUMP: Final = "calculations.ID_WEB_BUPout"
-    C0039_CIRCULATION_PUMP_HEATING: Final = "calculations.ID_WEB_HUPout"
+    C0034_MOTOR_PROTECTION = "calculations.ID_WEB_MOTin"
+    C0037_DEFROST_VALVE = "calculations.ID_WEB_AVout"
+    C0038_DHW_RECIRCULATION_PUMP = "calculations.ID_WEB_BUPout"
+    C0039_CIRCULATION_PUMP_HEATING = "calculations.ID_WEB_HUPout"
     # C0040_MIXER1_OPENED: Final = "calculations.ID_WEB_MA1out"  # True/False -> Mischer 1 auf
     # C0041_MIXER1_CLOSED: Final = "calculations.ID_WEB_MZ1out"  # True/False -> Mischer 1 zu
-    C0043_PUMP_FLOW: Final = "calculations.ID_WEB_VBOout"
-    C0044_COMPRESSOR: Final = "calculations.ID_WEB_VD1out"
-    C0045_COMPRESSOR2: Final = "calculations.ID_WEB_VD2out"
-    C0046_DHW_CIRCULATION_PUMP: Final = "calculations.ID_WEB_ZIPout"
-    C0047_ADDITIONAL_CIRCULATION_PUMP: Final = "calculations.ID_WEB_ZUPout"
-    C0048_ADDITIONAL_HEAT_GENERATOR: Final = "calculations.ID_WEB_ZW1out"
-    C0049_DISTURBANCE_OUTPUT: Final = "calculations.ID_WEB_ZW2SSTout"
+    C0043_PUMP_FLOW = "calculations.ID_WEB_VBOout"
+    C0044_COMPRESSOR = "calculations.ID_WEB_VD1out"
+    C0045_COMPRESSOR2 = "calculations.ID_WEB_VD2out"
+    C0046_DHW_CIRCULATION_PUMP = "calculations.ID_WEB_ZIPout"
+    C0047_ADDITIONAL_CIRCULATION_PUMP = "calculations.ID_WEB_ZUPout"
+    C0048_ADDITIONAL_HEAT_GENERATOR = "calculations.ID_WEB_ZW1out"
+    C0049_DISTURBANCE_OUTPUT = "calculations.ID_WEB_ZW2SSTout"
     # C0051: Final = "calculations.ID_WEB_FP2out"  # True/False -> FBH Umwälzpumpe 2
-    C0052_SOLAR_PUMP: Final = "calculations.ID_WEB_SLPout"
+    C0052_SOLAR_PUMP = "calculations.ID_WEB_SLPout"
     # C0054_MIXER2_CLOSED: Final = "calculations.ID_WEB_MZ2out"  # True/False -> Mischer 2 zu
     # C0055_MIXER2_OPENED: Final = "calculations.ID_WEB_MA2out"  # True/False -> Mischer 2 auf
-    C0056_COMPRESSOR1_OPERATION_HOURS: Final = "calculations.ID_WEB_Zaehler_BetrZeitVD1"
-    C0057_COMPRESSOR1_IMPULSES: Final = "calculations.ID_WEB_Zaehler_BetrZeitImpVD1"
-    C0058_COMPRESSOR2_OPERATION_HOURS: Final = "calculations.ID_WEB_Zaehler_BetrZeitVD2"
-    C0059_COMPRESSOR2_IMPULSES: Final = "calculations.ID_WEB_Zaehler_BetrZeitImpVD2"
-    C0060_ADDITIONAL_HEAT_GENERATOR_OPERATION_HOURS: Final = (
+    C0056_COMPRESSOR1_OPERATION_HOURS = "calculations.ID_WEB_Zaehler_BetrZeitVD1"
+    C0057_COMPRESSOR1_IMPULSES = "calculations.ID_WEB_Zaehler_BetrZeitImpVD1"
+    C0058_COMPRESSOR2_OPERATION_HOURS = "calculations.ID_WEB_Zaehler_BetrZeitVD2"
+    C0059_COMPRESSOR2_IMPULSES = "calculations.ID_WEB_Zaehler_BetrZeitImpVD2"
+    C0060_ADDITIONAL_HEAT_GENERATOR_OPERATION_HOURS = (
         "calculations.ID_WEB_Zaehler_BetrZeitZWE1"
     )
-    C0061_ADDITIONAL_HEAT_GENERATOR2_OPERATION_HOURS: Final = (
+    C0061_ADDITIONAL_HEAT_GENERATOR2_OPERATION_HOURS = (
         "calculations.ID_WEB_Zaehler_BetrZeitZWE2"
     )
-    C0063_OPERATION_HOURS: Final = "calculations.ID_WEB_Zaehler_BetrZeitWP"
-    C0064_OPERATION_HOURS_HEATING: Final = "calculations.ID_WEB_Zaehler_BetrZeitHz"
-    C0065_OPERATION_HOURS_DHW: Final = "calculations.ID_WEB_Zaehler_BetrZeitBW"
-    C0066_OPERATION_HOURS_COOLING: Final = "calculations.ID_WEB_Zaehler_BetrZeitKue"
-    C0067_TIMER_HEATPUMP_ON: Final = "calculations.ID_WEB_Time_WPein_akt"
-    C0068_TIMER_ADD_HEAT_GENERATOR_ON: Final = "calculations.ID_WEB_Time_ZWE1_akt"
-    C0069_TIMER_SEC_HEAT_GENERATOR_ON: Final = "calculations.ID_WEB_Time_ZWE2_akt"
-    C0070_TIMER_NET_INPUT_DELAY: Final = "calculations.ID_WEB_Timer_EinschVerz"
-    C0071_TIMER_SCB_OFF: Final = "calculations.ID_WEB_Time_SSPAUS_akt"
-    C0072_TIMER_SCB_ON: Final = "calculations.ID_WEB_Time_SSPEIN_akt"
-    C0073_TIMER_COMPRESSOR_OFF: Final = "calculations.ID_WEB_Time_VDStd_akt"
-    C0074_TIMER_HC_ADD: Final = "calculations.ID_WEB_Time_HRM_akt"
-    C0075_TIMER_HC_LESS: Final = "calculations.ID_WEB_Time_HRW_akt"
-    C0076_TIMER_TDI: Final = "calculations.ID_WEB_Time_LGS_akt"
-    C0077_TIMER_BLOCK_DHW: Final = "calculations.ID_WEB_Time_SBW_akt"
-    C0078_MODEL_CODE: Final = "calculations.ID_WEB_Code_WP_akt"
-    C0080_STATUS: Final = "calculations.ID_WEB_WP_BZ_akt"
-    C0081_FIRMWARE_VERSION: Final = "calculations.ID_WEB_SoftStand"
-    C0095_ERROR_TIME: Final = "calculations.ID_WEB_ERROR_Time0"
-    C0100_ERROR_REASON: Final = "calculations.ID_WEB_ERROR_Nr0"
+    C0063_OPERATION_HOURS = "calculations.ID_WEB_Zaehler_BetrZeitWP"
+    C0064_OPERATION_HOURS_HEATING = "calculations.ID_WEB_Zaehler_BetrZeitHz"
+    C0065_OPERATION_HOURS_DHW = "calculations.ID_WEB_Zaehler_BetrZeitBW"
+    C0066_OPERATION_HOURS_COOLING = "calculations.ID_WEB_Zaehler_BetrZeitKue"
+    C0067_TIMER_HEATPUMP_ON = "calculations.ID_WEB_Time_WPein_akt"
+    C0068_TIMER_ADD_HEAT_GENERATOR_ON = "calculations.ID_WEB_Time_ZWE1_akt"
+    C0069_TIMER_SEC_HEAT_GENERATOR_ON = "calculations.ID_WEB_Time_ZWE2_akt"
+    C0070_TIMER_NET_INPUT_DELAY = "calculations.ID_WEB_Timer_EinschVerz"
+    C0071_TIMER_SCB_OFF = "calculations.ID_WEB_Time_SSPAUS_akt"
+    C0072_TIMER_SCB_ON = "calculations.ID_WEB_Time_SSPEIN_akt"
+    C0073_TIMER_COMPRESSOR_OFF = "calculations.ID_WEB_Time_VDStd_akt"
+    C0074_TIMER_HC_ADD = "calculations.ID_WEB_Time_HRM_akt"
+    C0075_TIMER_HC_LESS = "calculations.ID_WEB_Time_HRW_akt"
+    C0076_TIMER_TDI = "calculations.ID_WEB_Time_LGS_akt"
+    C0077_TIMER_BLOCK_DHW = "calculations.ID_WEB_Time_SBW_akt"
+    C0078_MODEL_CODE = "calculations.ID_WEB_Code_WP_akt"
+    C0080_STATUS = "calculations.ID_WEB_WP_BZ_akt"
+    C0081_FIRMWARE_VERSION = "calculations.ID_WEB_SoftStand"
+    C0095_ERROR_TIME = "calculations.ID_WEB_ERROR_Time0"
+    C0100_ERROR_REASON = "calculations.ID_WEB_ERROR_Nr0"
     # TODO: !
     # C0105_ERROR_COUNTER: Final = "calculations.ID_WEB_AnzahlFehlerInSpeicher"
-    C0117_STATUS_LINE_1: Final = "calculations.ID_WEB_HauptMenuStatus_Zeile1"
-    C0118_STATUS_LINE_2: Final = "calculations.ID_WEB_HauptMenuStatus_Zeile2"
-    C0119_STATUS_LINE_3: Final = "calculations.ID_WEB_HauptMenuStatus_Zeile3"
-    C0120_STATUS_TIME: Final = "calculations.ID_WEB_HauptMenuStatus_Zeit"
-    C0141_TIMER_DEFROST: Final = "calculations.ID_WEB_Time_AbtIn"
-    C0146_APPROVAL_COOLING: Final = "calculations.ID_WEB_FreigabKuehl"
-    C0151_HEAT_AMOUNT_HEATING: Final = "calculations.ID_WEB_WMZ_Heizung"
-    C0152_DHW_HEAT_AMOUNT: Final = "calculations.ID_WEB_WMZ_Brauchwasser"
-    C0154_HEAT_AMOUNT_COUNTER: Final = "calculations.ID_WEB_WMZ_Seit"  # 25668.9
-    C0155_HEAT_AMOUNT_FLOW_RATE: Final = "calculations.ID_WEB_WMZ_Durchfluss"
-    C0156_ANALOG_OUT1: Final = "calculations.ID_WEB_AnalogOut1"
-    C0157_ANALOG_OUT2: Final = "calculations.ID_WEB_AnalogOut2"
-    C0158_TIMER_HOT_GAS: Final = "calculations.ID_WEB_Time_Heissgas"
-    C0173_HEAT_SOURCE_FLOW_RATE: Final = "calculations.ID_WEB_Durchfluss_WQ"
-    C0175_SUCTION_EVAPORATOR_TEMPERATURE: Final = (
-        "calculations.ID_WEB_LIN_ANSAUG_VERDAMPFER"
-    )
-    C0176_SUCTION_COMPRESSOR_TEMPERATURE: Final = (
-        "calculations.ID_WEB_LIN_ANSAUG_VERDICHTER"
-    )
-    C0177_COMPRESSOR_HEATING_TEMPERATURE: Final = "calculations.ID_WEB_LIN_VDH"
-    C0178_OVERHEATING_TEMPERATURE: Final = "calculations.ID_WEB_LIN_UH"
-    C0179_OVERHEATING_TARGET_TEMPERATURE: Final = "calculations.ID_WEB_LIN_UH_Soll"
-    C0180_HIGH_PRESSURE: Final = "calculations.ID_WEB_LIN_HD"
-    C0181_LOW_PRESSURE: Final = "calculations.ID_WEB_LIN_ND"
-    C0182_COMPRESSOR_HEATER: Final = "calculations.ID_WEB_LIN_VDH_out"
-    C0185_EVU2: Final = "calculations.ID_WEB_HZIO_EVU2"
+    C0117_STATUS_LINE_1 = "calculations.ID_WEB_HauptMenuStatus_Zeile1"
+    C0118_STATUS_LINE_2 = "calculations.ID_WEB_HauptMenuStatus_Zeile2"
+    C0119_STATUS_LINE_3 = "calculations.ID_WEB_HauptMenuStatus_Zeile3"
+    C0120_STATUS_TIME = "calculations.ID_WEB_HauptMenuStatus_Zeit"
+    C0141_TIMER_DEFROST = "calculations.ID_WEB_Time_AbtIn"
+    C0146_APPROVAL_COOLING = "calculations.ID_WEB_FreigabKuehl"
+    C0151_HEAT_AMOUNT_HEATING = "calculations.ID_WEB_WMZ_Heizung"
+    C0152_DHW_HEAT_AMOUNT = "calculations.ID_WEB_WMZ_Brauchwasser"
+    C0154_HEAT_AMOUNT_COUNTER = "calculations.ID_WEB_WMZ_Seit"  # 25668.9
+    C0155_HEAT_AMOUNT_FLOW_RATE = "calculations.ID_WEB_WMZ_Durchfluss"
+    C0156_ANALOG_OUT1 = "calculations.ID_WEB_AnalogOut1"
+    C0157_ANALOG_OUT2 = "calculations.ID_WEB_AnalogOut2"
+    C0158_TIMER_HOT_GAS = "calculations.ID_WEB_Time_Heissgas"
+    C0173_HEAT_SOURCE_FLOW_RATE = "calculations.ID_WEB_Durchfluss_WQ"
+    C0175_SUCTION_EVAPORATOR_TEMPERATURE = "calculations.ID_WEB_LIN_ANSAUG_VERDAMPFER"
+    C0176_SUCTION_COMPRESSOR_TEMPERATURE = "calculations.ID_WEB_LIN_ANSAUG_VERDICHTER"
+    C0177_COMPRESSOR_HEATING_TEMPERATURE = "calculations.ID_WEB_LIN_VDH"
+    C0178_OVERHEATING_TEMPERATURE = "calculations.ID_WEB_LIN_UH"
+    C0179_OVERHEATING_TARGET_TEMPERATURE = "calculations.ID_WEB_LIN_UH_Soll"
+    C0180_HIGH_PRESSURE = "calculations.ID_WEB_LIN_HD"
+    C0181_LOW_PRESSURE = "calculations.ID_WEB_LIN_ND"
+    C0182_COMPRESSOR_HEATER = "calculations.ID_WEB_LIN_VDH_out"
+    C0185_EVU2 = "calculations.ID_WEB_HZIO_EVU2"
     # C0187_CURRENT_OUTPUT: Final = "calculations.ID_WEB_SEC_Qh_Soll"
     # C0188_CURRENT_OUTPUT: Final = "calculations.ID_WEB_SEC_Qh_Ist"
-    C0204_HEAT_SOURCE_INPUT_TEMPERATURE: Final = "calculations.ID_WEB_Temperatur_TWE"
-    C0227_ROOM_THERMOSTAT_TEMPERATURE: Final = "calculations.ID_WEB_RBE_RT_Ist"
-    C0228_ROOM_THERMOSTAT_TEMPERATURE_TARGET: Final = "calculations.ID_WEB_RBE_RT_Soll"
-    C0231_PUMP_FREQUENCY: Final = "calculations.ID_WEB_Freq_VD"
-    C0239_PUMP_FLOW_DELTA_TARGET: Final = "calculations.Unknown_Calculation_239"
+    C0204_HEAT_SOURCE_INPUT_TEMPERATURE = "calculations.ID_WEB_Temperatur_TWE"
+    C0227_ROOM_THERMOSTAT_TEMPERATURE = "calculations.ID_WEB_RBE_RT_Ist"
+    C0228_ROOM_THERMOSTAT_TEMPERATURE_TARGET = "calculations.ID_WEB_RBE_RT_Soll"
+    C0231_PUMP_FREQUENCY = "calculations.ID_WEB_Freq_VD"
+    C0239_PUMP_FLOW_DELTA_TARGET = "calculations.Unknown_Calculation_239"
     # 239: Kelvin("VBO_Temp_Spread_Soll"), / 10, measurement, delta - ait_hup_vbo_calculated
-    C0240_PUMP_FLOW_DELTA: Final = "calculations.Unknown_Calculation_240"
+    C0240_PUMP_FLOW_DELTA = "calculations.Unknown_Calculation_240"
     # 240: Kelvin("VBO_Temp_Spread_Ist"), / 10, measurement, delta - ait_vbo_delta
     # 241: Percent2("HUP_PWM"),
-    C0242_CIRCULATION_PUMP_DELTA_TARGET: Final = "calculations.Unknown_Calculation_242"
+    C0242_CIRCULATION_PUMP_DELTA_TARGET = "calculations.Unknown_Calculation_242"
     # 242: Kelvin("HUP_Temp_Spread_Soll"), / 10, measurement, delta - ait_hup_delta_calculated
-    C0243_CIRCULATION_PUMP_DELTA: Final = "calculations.Unknown_Calculation_243"
+    C0243_CIRCULATION_PUMP_DELTA = "calculations.Unknown_Calculation_243"
     # 243: Kelvin("HUP_Temp_Spread_Ist"), / 10, measurement, delta - ait_hup_delta
     # 254 Flow Rate
-    C0257_CURRENT_HEAT_OUTPUT: Final = "calculations.Heat_Output"
+    C0257_CURRENT_HEAT_OUTPUT = "calculations.Heat_Output"
     # 258 RBE Version
-    C0268_CURRENT_POWER_CONSUMPTION: Final = "calculations.Unknown_Calculation_268"
+    C0268_CURRENT_POWER_CONSUMPTION = "calculations.Unknown_Calculation_268"
 
 
 # endregion Lux calculations
@@ -639,70 +601,58 @@ class LuxCalculation(StrEnum):
 class LuxVisibility(StrEnum):
     """Luxtronik visibility ids."""
 
-    UNSET: Final = "UNSET"
-    V0005_COOLING: Final = "visibilities.ID_Visi_Kuhlung"
-    V0007_MK1: Final = "visibilities.ID_Visi_MK1"
-    V0008_MK2: Final = "visibilities.ID_Visi_MK2"
-    V0009_MK3: Final = "visibilities.ID_Visi_MK3"
-    V0023_FLOW_IN_TEMPERATURE: Final = "visibilities.ID_Visi_Temp_Vorlauf"
-    V0024_FLOW_OUT_TEMPERATURE_EXTERNAL: Final = "visibilities.ID_Visi_Temp_Rucklauf"
-    V0027_HOT_GAS_TEMPERATURE: Final = "visibilities.ID_Visi_Temp_Heissgas"
-    V0029_DHW_TEMPERATURE: Final = "visibilities.ID_Visi_Temp_BW_Ist"
-    V0038_SOLAR_COLLECTOR: Final = "visibilities.ID_Visi_Temp_Solarkoll"
-    V0039_SOLAR_BUFFER: Final = "visibilities.ID_Visi_Temp_Solarsp"
-    V0041_DEFROST_END_FLOW_OKAY: Final = "visibilities.ID_Visi_IN_ASD"
-    V0043_EVU_IN: Final = "visibilities.ID_Visi_IN_EVU"
-    V0045_MOTOR_PROTECTION: Final = "visibilities.ID_Visi_IN_MOT"
-    V0049_DEFROST_VALVE: Final = "visibilities.ID_Visi_OUT_Abtauventil"
-    V0050_DHW_RECIRCULATION_PUMP: Final = "visibilities.ID_Visi_OUT_BUP"
-    V0052_CIRCULATION_PUMP_HEATING: Final = "visibilities.ID_Visi_OUT_HUP"
-    V0059_DHW_CIRCULATION_PUMP: Final = "visibilities.ID_Visi_OUT_ZIP"
-    V0059A_DHW_CHARGING_PUMP: Final = "V0059A_DHW_CHARGING_PUMP"
-    V0060_ADDITIONAL_CIRCULATION_PUMP: Final = "visibilities.ID_Visi_OUT_ZUP"
-    V0061_SECOND_HEAT_GENERATOR: Final = "visibilities.ID_Visi_OUT_ZWE1"
-    V0080_COMPRESSOR1_OPERATION_HOURS: Final = "visibilities.ID_Visi_Bst_BStdVD1"
-    V0081_COMPRESSOR1_IMPULSES: Final = "visibilities.ID_Visi_Bst_ImpVD1"
-    V0083_COMPRESSOR2_OPERATION_HOURS: Final = "visibilities.ID_Visi_Bst_BStdVD2"
-    V0084_COMPRESSOR2_IMPULSES: Final = "visibilities.ID_Visi_Bst_ImpVD2"
-    V0086_ADDITIONAL_HEAT_GENERATOR_OPERATION_HOURS: Final = (
+    UNSET = "UNSET"
+    V0005_COOLING = "visibilities.ID_Visi_Kuhlung"
+    V0007_MK1 = "visibilities.ID_Visi_MK1"
+    V0008_MK2 = "visibilities.ID_Visi_MK2"
+    V0009_MK3 = "visibilities.ID_Visi_MK3"
+    V0023_FLOW_IN_TEMPERATURE = "visibilities.ID_Visi_Temp_Vorlauf"
+    V0024_FLOW_OUT_TEMPERATURE_EXTERNAL = "visibilities.ID_Visi_Temp_Rucklauf"
+    V0027_HOT_GAS_TEMPERATURE = "visibilities.ID_Visi_Temp_Heissgas"
+    V0029_DHW_TEMPERATURE = "visibilities.ID_Visi_Temp_BW_Ist"
+    V0038_SOLAR_COLLECTOR = "visibilities.ID_Visi_Temp_Solarkoll"
+    V0039_SOLAR_BUFFER = "visibilities.ID_Visi_Temp_Solarsp"
+    V0041_DEFROST_END_FLOW_OKAY = "visibilities.ID_Visi_IN_ASD"
+    V0043_EVU_IN = "visibilities.ID_Visi_IN_EVU"
+    V0045_MOTOR_PROTECTION = "visibilities.ID_Visi_IN_MOT"
+    V0049_DEFROST_VALVE = "visibilities.ID_Visi_OUT_Abtauventil"
+    V0050_DHW_RECIRCULATION_PUMP = "visibilities.ID_Visi_OUT_BUP"
+    V0052_CIRCULATION_PUMP_HEATING = "visibilities.ID_Visi_OUT_HUP"
+    V0059_DHW_CIRCULATION_PUMP = "visibilities.ID_Visi_OUT_ZIP"
+    V0059A_DHW_CHARGING_PUMP = "V0059A_DHW_CHARGING_PUMP"
+    V0060_ADDITIONAL_CIRCULATION_PUMP = "visibilities.ID_Visi_OUT_ZUP"
+    V0061_SECOND_HEAT_GENERATOR = "visibilities.ID_Visi_OUT_ZWE1"
+    V0080_COMPRESSOR1_OPERATION_HOURS = "visibilities.ID_Visi_Bst_BStdVD1"
+    V0081_COMPRESSOR1_IMPULSES = "visibilities.ID_Visi_Bst_ImpVD1"
+    V0083_COMPRESSOR2_OPERATION_HOURS = "visibilities.ID_Visi_Bst_BStdVD2"
+    V0084_COMPRESSOR2_IMPULSES = "visibilities.ID_Visi_Bst_ImpVD2"
+    V0086_ADDITIONAL_HEAT_GENERATOR_OPERATION_HOURS = (
         "visibilities.ID_Visi_Bst_BStdZWE1"
     )
-    V0087_ADDITIONAL_HEAT_GENERATOR2_OPERATION_HOURS: Final = (
+    V0087_ADDITIONAL_HEAT_GENERATOR2_OPERATION_HOURS = (
         "visibilities.ID_Visi_Bst_BStdZWE2"
     )
-    V0105_HEAT_SOURCE_INPUT_TEMPERATURE_MIN: Final = (
-        "visibilities.ID_Visi_EinstTemp_TWQmin"
-    )
-    V0121_EVU_LOCKED: Final = "visibilities.ID_Visi_SysEin_EVUSperre"
-    V0122_ROOM_THERMOSTAT: Final = "visibilities.ID_Visi_SysEin_Raumstation"
-    V0144_PUMP_OPTIMIZATION: Final = "visibilities.ID_Visi_SysEin_Pumpenoptim"
-    V0163_PUMP_VENT_HUP: Final = "visibilities.ID_Visi_Enlt_HUP"
-    V0175_PUMP_VENT_TIMER_H: Final = "visibilities.ID_Visi_Enlt_Laufzeit"
-    V0211_MK3: Final = "visibilities.ID_Visi_MK3"
-    V0239_EFFICIENCY_PUMP_NOMINAL: Final = (
-        "visibilities.ID_Visi_SysEin_EffizienzpumpeNom"
-    )
-    V0240_EFFICIENCY_PUMP_MINIMAL: Final = (
-        "visibilities.ID_Visi_SysEin_EffizienzpumpeMin"
-    )
-    V0248_ANALOG_OUT1: Final = "visibilities.ID_Visi_OUT_Analog_1"
-    V0249_ANALOG_OUT2: Final = "visibilities.ID_Visi_OUT_Analog_2"
-    V0250_SOLAR: Final = "visibilities.ID_Visi_Solar"
-    V0289_SUCTION_COMPRESSOR_TEMPERATURE: Final = (
-        "visibilities.ID_Visi_LIN_ANSAUG_VERDICHTER"
-    )
-    V0290_COMPRESSOR_HEATING: Final = "visibilities.ID_Visi_LIN_VDH"
-    V0291_OVERHEATING_TEMPERATURE: Final = "visibilities.ID_Visi_LIN_UH"
-    V0292_LIN_PRESSURE: Final = "visibilities.ID_Visi_LIN_Druck"
-    V0310_SUCTION_EVAPORATOR_TEMPERATURE: Final = (
-        "visibilities.ID_Visi_LIN_ANSAUG_VERDAMPFER"
-    )
-    V0324_ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER: Final = (
+    V0105_HEAT_SOURCE_INPUT_TEMPERATURE_MIN = "visibilities.ID_Visi_EinstTemp_TWQmin"
+    V0121_EVU_LOCKED = "visibilities.ID_Visi_SysEin_EVUSperre"
+    V0122_ROOM_THERMOSTAT = "visibilities.ID_Visi_SysEin_Raumstation"
+    V0144_PUMP_OPTIMIZATION = "visibilities.ID_Visi_SysEin_Pumpenoptim"
+    V0163_PUMP_VENT_HUP = "visibilities.ID_Visi_Enlt_HUP"
+    V0175_PUMP_VENT_TIMER_H = "visibilities.ID_Visi_Enlt_Laufzeit"
+    V0211_MK3 = "visibilities.ID_Visi_MK3"
+    V0239_EFFICIENCY_PUMP_NOMINAL = "visibilities.ID_Visi_SysEin_EffizienzpumpeNom"
+    V0240_EFFICIENCY_PUMP_MINIMAL = "visibilities.ID_Visi_SysEin_EffizienzpumpeMin"
+    V0248_ANALOG_OUT1 = "visibilities.ID_Visi_OUT_Analog_1"
+    V0249_ANALOG_OUT2 = "visibilities.ID_Visi_OUT_Analog_2"
+    V0250_SOLAR = "visibilities.ID_Visi_Solar"
+    V0289_SUCTION_COMPRESSOR_TEMPERATURE = "visibilities.ID_Visi_LIN_ANSAUG_VERDICHTER"
+    V0290_COMPRESSOR_HEATING = "visibilities.ID_Visi_LIN_VDH"
+    V0291_OVERHEATING_TEMPERATURE = "visibilities.ID_Visi_LIN_UH"
+    V0292_LIN_PRESSURE = "visibilities.ID_Visi_LIN_Druck"
+    V0310_SUCTION_EVAPORATOR_TEMPERATURE = "visibilities.ID_Visi_LIN_ANSAUG_VERDAMPFER"
+    V0324_ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER = (
         "visibilities.ID_Visi_Waermemenge_ZWE"
     )
-    V0357_ELECTRICAL_POWER_LIMITATION_SWITCH: Final = (
-        "visibilities.Unknown_Parameter_357"
-    )
+    V0357_ELECTRICAL_POWER_LIMITATION_SWITCH = "visibilities.Unknown_Parameter_357"
 
 
 # endregion visibilities


### PR DESCRIPTION
# Remove invalid `: Final` type annotations from enum members

Part of #583. Resolves §T1 from the Pylance type-check review.

## Problem

All enum classes in `const.py` annotate their members with `: Final`:

```python
class LuxMode(StrEnum):
    off: Final = "Off"
    automatic: Final = "Automatic"
```

Pyright/Pylance rejects `: Final` on enum members — type annotations are not allowed for enum members per Python typing spec. Enum members are inherently immutable, so `Final` is redundant.

This single issue cascades into **1102 errors** across the codebase because Pyright doesn't recognize the members as proper enum instances, which breaks:
- `.value` access on enum members
- Literal-to-enum assignment (e.g., `Literal['heating']` → `DeviceKey`)
- Parameter type matching throughout all platform modules

## Fix

Remove `: Final` from all 317 enum member definitions across 13 enum classes:

```python
class LuxMode(StrEnum):
    off = "Off"
    automatic = "Automatic"
```

Module-level constants (e.g., `DOMAIN: Final = "luxtronik2"`) are **not affected** — `Final` is correct and expected there.

## Affected enums

| Enum class | Members |
|---|---|
| `DeviceKey` | 4 |
| `FirmwareVersionMinor` | 4 |
| `LuxOperationMode` | 8 |
| `LuxMode` | 5 |
| `LuxSmartGridStatus` | 4 |
| `LuxStatus1Option` | 10 |
| `LuxStatus3Option` | 20 |
| `LuxMkTypes` | 5 |
| `LuxRoomThermostatType` | 2 |
| `LuxSwitchoffReason` | 32 |
| `LuxDaySelectorParameter` | 7 |
| `LuxParameter` | ~150 |
| `LuxCalculation` | ~65 |
| `LuxVisibility` | ~11 |

## Impact

- **Zero runtime behavior change** — purely syntactic fix
- **Pyright errors: 1348 → 246** (82% reduction)
- No changes outside `const.py`