### PR TITLE
fix(base): 🐛 align _handle_coordinator_update base signature with overrides

### DIFF
--- a/custom_components/luxtronik/base.py
+++ b/custom_components/luxtronik/base.py
@@ -28,7 +28,11 @@ from .const import (
     SensorAttrKey as SA,
 )
 from .coordinator import LuxtronikCoordinator
-from .model import LuxtronikEntityAttributeDescription, LuxtronikEntityDescription
+from .model import (
+    LuxtronikCoordinatorData,
+    LuxtronikEntityAttributeDescription,
+    LuxtronikEntityDescription,
+)
 
 # endregion Imports
 
@@ -142,8 +146,16 @@ class LuxtronikEntity(CoordinatorEntity[LuxtronikCoordinator], RestoreEntity):
         self._handle_coordinator_update()
 
     @callback
-    def _handle_coordinator_update(self, force: bool = False) -> None:
-        """Handle updated data from the coordinator."""
+    def _handle_coordinator_update(
+        self, data: LuxtronikCoordinatorData | None = None
+    ) -> None:
+        """Handle updated data from the coordinator.
+
+        The data parameter is used by subclass overrides to pass freshly
+        written coordinator data (e.g. after async_write). The base
+        implementation always reads from self.coordinator.data via
+        _get_value. Subclasses may call super() with or without data.
+        """
         descr = self.entity_description
         value = self._get_value(descr.luxtronik_key)
 


### PR DESCRIPTION
# Align `_handle_coordinator_update` base signature with overrides

Part of #583. Resolves §T4 from the Pylance type-check review.

## Problem

The base class `LuxtronikEntity._handle_coordinator_update` is defined with:

```python
def _handle_coordinator_update(self, force: bool = False) -> None:
```

But:
- **All 12 subclass overrides** use `data: LuxtronikCoordinatorData | None = None`
- The base class **itself** calls it with `self.coordinator.data` (a `LuxtronikCoordinatorData`) at line 124
- The `force` parameter is **never used** in the method body

This causes Pyright `reportIncompatibleMethodOverride` in every entity subclass.

## Fix

Change the base class signature to match the actual usage:

```python
def _handle_coordinator_update(self, data: LuxtronikCoordinatorData | None = None) -> None:
```

Added `LuxtronikCoordinatorData` to the imports from `.model`.

## Files changed

- `base.py` — 2 lines: import + signature fix