### PR TITLE
fix: 🐛 add None guards to prevent runtime crashes

### DIFF
--- a/custom_components/luxtronik/base.py
+++ b/custom_components/luxtronik/base.py
@@ -163,7 +163,7 @@ class LuxtronikEntity(CoordinatorEntity[LuxtronikCoordinator], RestoreEntity):
         else:
             self._attr_icon = descr.icon
 
-        if hasattr(self, "_attr_current_operation"):
+        if hasattr(self, "_attr_current_operation") and self._attr_icon is not None:
             if self._attr_current_operation == STATE_OFF:
                 self._attr_icon += "-off"
             elif self._attr_current_operation == STATE_HEAT_PUMP:

--- a/custom_components/luxtronik/common.py
+++ b/custom_components/luxtronik/common.py
@@ -111,6 +111,7 @@ def correct_key_value(
     # prevent dealing with None value, and skip unnecessary processing
     if (
         value is None
+        or coordinator is None
         or sensor_id is None
         or sensor_id
         not in [


### PR DESCRIPTION
# Add `None` guards to prevent runtime crashes

Part of #583. Resolves §T10 from the Pylance type-check review. (partial — addresses runtime-crashing cases).

## Problem 1: `correct_key_value()` crashes when coordinator is `None`

**File:** `common.py`  
**Risk:** Runtime `AttributeError`

```python
def correct_key_value(
    value: Any,
    coordinator: LuxtronikCoordinatorData | None,  # ← can be None
    sensor_id: str | LP | LC | LV,
) -> Any:
    ...
    # Passes coordinator to get_sensor_data() which expects non-None:
    int(get_sensor_data(coordinator, LC.C0072_TIMER_SCB_ON))  # 💥 if coordinator is None
```

**Fix:** Added `or coordinator is None` to the early-return guard that already checks `value` and `sensor_id`.

## Problem 2: `_attr_icon += "-off"` crashes when icon is `None`

**File:** `base.py`  
**Risk:** Runtime `TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'`

```python
if hasattr(self, "_attr_current_operation"):
    if self._attr_current_operation == STATE_OFF:
        self._attr_icon += "-off"   # 💥 if _attr_icon is None
```

`_attr_icon` can be `None` when `icon_by_state.get()` returns `None` or when no icon is configured.

**Fix:** Added `and self._attr_icon is not None` to the outer condition.

## Files changed

| File        | Lines                             |
| ----------- | --------------------------------- |
| `common.py` | +1 (early return guard)           |
| `base.py`   | 1 line changed (added None check) |

## Note

Remaining T10 items (e.g., `float()`/`int()` on `_get_value()` results in `base.py:formatted_data()`) are design-level issues — `_get_value` returns `Any`, and Pyright can't narrow the type. These require broader refactoring and are deferred.