### PR TITLE
fix(lux_overrides): 🐛 Isolate library instance data for multi-hub support

### DIFF
--- a/custom_components/luxtronik/coordinator.py
+++ b/custom_components/luxtronik/coordinator.py
@@ -39,7 +39,11 @@ from .const import (
     LuxVisibility as LV,
 )
 from .lux_helper import Luxtronik, get_manufacturer_by_model
-from .lux_overrides import update_Luxtronik_HeatpumpCodes, update_Luxtronik_Parameters
+from .lux_overrides import (
+    isolate_instance_data,
+    update_Luxtronik_HeatpumpCodes,
+    update_Luxtronik_Parameters,
+)
 from .model import LuxtronikCoordinatorData, LuxtronikEntityDescription
 
 # endregion Imports
@@ -518,11 +522,16 @@ async def connect_and_get_coordinator(
 ) -> LuxtronikCoordinator:
     """Try to connect to a Luxtronik device and return coordinator."""
     global _OVERRIDES_APPLIED
+    # No lock needed: all override calls are synchronous (no await),
+    # so the event loop cannot preempt between the guard check and flag set.
     if not _OVERRIDES_APPLIED:
         update_Luxtronik_HeatpumpCodes()
         update_Luxtronik_Parameters()
-        LOGGER.info("Custom HeatpumpCode and Parameters overrides applied.")
+        isolate_instance_data()
         _OVERRIDES_APPLIED = True
+        LOGGER.info(
+            "Library overrides applied (HeatpumpCodes, Parameters, instance data isolation)."
+        )
 
     if isinstance(config, ConfigEntry):
         config = config.data

--- a/custom_components/luxtronik/lux_overrides.py
+++ b/custom_components/luxtronik/lux_overrides.py
@@ -1,5 +1,9 @@
+from copy import deepcopy
+
+from luxtronik.calculations import Calculations
 from luxtronik.datatypes import Celsius, HeatpumpCode, Percent, Percent2, Timestamp
 from luxtronik.parameters import Parameters
+from luxtronik.visibilities import Visibilities
 
 # Define your new/updated custom parameters in a dictionary
 parameters_to_add_update = {
@@ -17,6 +21,53 @@ parameters_to_add_update = {
 
 def update_Luxtronik_Parameters():
     Parameters.parameters.update(parameters_to_add_update)
+
+
+_INSTANCE_DATA_ISOLATED = False
+
+
+def isolate_instance_data():
+    """Patch library classes to use instance-level data dicts.
+
+    The upstream luxtronik library stores parameter/calculation/visibility
+    data in class-level dicts shared across all instances.  When multiple
+    heat pumps are configured, ``parse()`` on one instance overwrites
+    values read by another, causing data mixing (see issue #515).
+
+    This patches ``__init__`` so every new instance gets its own deep copy
+    of the class-level dict.
+    """
+    # No lock needed: called only from synchronous code path (no await),
+    # so the event loop cannot preempt between the guard check and flag set.
+    global _INSTANCE_DATA_ISOLATED
+    if _INSTANCE_DATA_ISOLATED:
+        return
+
+    _orig_params_init = Parameters.__init__
+
+    def _params_init(self, *args, **kwargs):
+        _orig_params_init(self, *args, **kwargs)
+        self.parameters = deepcopy(self.parameters)
+
+    Parameters.__init__ = _params_init
+
+    _orig_calcs_init = Calculations.__init__
+
+    def _calcs_init(self, *args, **kwargs):
+        _orig_calcs_init(self, *args, **kwargs)
+        self.calculations = deepcopy(self.calculations)
+
+    Calculations.__init__ = _calcs_init
+
+    _orig_vis_init = Visibilities.__init__
+
+    def _vis_init(self, *args, **kwargs):
+        _orig_vis_init(self, *args, **kwargs)
+        self.visibilities = deepcopy(self.visibilities)
+
+    Visibilities.__init__ = _vis_init
+
+    _INSTANCE_DATA_ISOLATED = True
 
 
 def update_Luxtronik_HeatpumpCodes():


### PR DESCRIPTION
## Problem

The upstream `luxtronik` library (v0.3.14) stores parameter, calculation, and visibility data in **class-level dicts** shared across all instances:

```python
class Parameters:
    parameters = {          # ← class-level, shared between ALL instances
        0: Unknown("ID_Transfert_LuxNet"),
        1: Celsius("ID_Einst_WK_akt", True),
        ...
    }

    def parse(self, raw_data):
        for index, data in enumerate(raw_data):
            parameter = self.parameters.get(index, False)
            if parameter is not False:
                parameter.value = parameter.from_heatpump(data)  # ← writes to shared object!
```

The same pattern exists in `Calculations` and `Visibilities`.

When multiple heat pumps are configured (multi-hub setup), `parse()` on one instance **overwrites** `.value` on the shared parameter objects, causing data mixing between heat pumps — values from heat pump A appear on heat pump B's entities and vice versa.

This is the root cause of **issue #515**.

## Solution

Patch `__init__` of `Parameters`, `Calculations`, and `Visibilities` via the existing `lux_overrides.py` module (which already exists for patching upstream library behavior). Each new instance now gets its own `deepcopy` of the class-level dict, ensuring complete data isolation between heat pumps.

The patch is applied once via `isolate_instance_data()`, called alongside existing overrides in `connect_and_get_coordinator()`. Both guards (`_OVERRIDES_APPLIED`, `_INSTANCE_DATA_ISOLATED`) are set **after** successful completion for exception safety. No lock is needed — all override calls are synchronous (no `await`), so the event loop cannot preempt between the guard check and flag set.

The patched `__init__` wrappers use `*args, **kwargs` forwarding and deep copy from `self` (instance attribute) rather than the class attribute, making them robust against upstream signature or initialization changes.

### Ordering

```
update_Luxtronik_HeatpumpCodes()   # 1. Override heatpump codes
update_Luxtronik_Parameters()      # 2. Add custom parameters to class-level dict
isolate_instance_data()            # 3. Patch __init__ to deep copy (includes custom params)
_OVERRIDES_APPLIED = True          # 4. Set flag after successful completion
```

## Verification

Tested with the actual `luxtronik==0.3.14` library:

```python
p1 = Parameters(safe=False)
p2 = Parameters(safe=False)

p1.parameters[1].value = 22.5
p2.parameters[1].value = 18.0

assert p1.parameters is not p2.parameters     # ✅ separate dicts
assert p1.parameters[1] is not p2.parameters[1]  # ✅ separate objects (deep copy)
assert p1.parameters[1].value == 22.5          # ✅ no data mixing
assert p2.parameters[1].value == 18.0          # ✅ isolated
```

## Changes

- **`lux_overrides.py`**: Added `isolate_instance_data()` — patches `__init__` of `Parameters`, `Calculations`, `Visibilities` using `*args, **kwargs` forwarding and `deepcopy(self.<attr>)`; guarded by `_INSTANCE_DATA_ISOLATED` flag (set after completion) for idempotency
- **`coordinator.py`**: Call `isolate_instance_data()` in `connect_and_get_coordinator()` alongside existing overrides; `_OVERRIDES_APPLIED` flag set after completion for exception safety; log message updated to reflect all applied overrides

## Impact

- **Backward compatible** — no entity_id or unique_id changes, no history loss
- **Single-hub setups** — no functional change (each instance simply gets its own copy)
- **Multi-hub setups** — fixes data mixing between heat pumps
- **No upstream library changes required**

Resolves #515
