### PR TITLE
refactor(evu): ♻️ replace heterogeneous cache dict with typed attributes

### DIFF
--- a/custom_components/luxtronik/evu_helper.py
+++ b/custom_components/luxtronik/evu_helper.py
@@ -13,13 +13,11 @@ class LuxtronikEVUTracker:
 
     def __init__(self):
         self._last_state = None
-        self._cache = {
-            SA.EVU_FIRST_START_TIME: time.min,
-            SA.EVU_FIRST_END_TIME: time.min,
-            SA.EVU_SECOND_START_TIME: time.min,
-            SA.EVU_SECOND_END_TIME: time.min,
-            SA.EVU_DAYS: [],
-        }
+        self._evu_first_start: time = time.min
+        self._evu_first_end: time = time.min
+        self._evu_second_start: time = time.min
+        self._evu_second_end: time = time.min
+        self._evu_days: list[int] = []
 
     def update(self, current_value: str | None):
         """Update EVU state based on current value."""
@@ -33,26 +31,26 @@ class LuxtronikEVUTracker:
             return
 
         if current_value == evu and self._last_state != evu:
-            if weekday not in self._cache[SA.EVU_DAYS]:
-                self._cache[SA.EVU_DAYS].append(weekday)
+            if weekday not in self._evu_days:
+                self._evu_days.append(weekday)
             if self._should_use_first_slot(time_now):
-                self._cache[SA.EVU_FIRST_START_TIME] = time_now
+                self._evu_first_start = time_now
             else:
-                self._cache[SA.EVU_SECOND_START_TIME] = time_now
+                self._evu_second_start = time_now
 
         elif current_value != evu and self._last_state == evu:
             if self._should_use_first_slot(time_now):
-                self._cache[SA.EVU_FIRST_END_TIME] = time_now
+                self._evu_first_end = time_now
             else:
-                self._cache[SA.EVU_SECOND_END_TIME] = time_now
+                self._evu_second_end = time_now
 
         self._last_state = current_value
 
     def _should_use_first_slot(self, time_now: time) -> bool:
         return (
-            self._cache[SA.EVU_FIRST_START_TIME] == time.min
-            or time_now <= self._cache[SA.EVU_FIRST_START_TIME]
-            or time_now <= self._cache[SA.EVU_FIRST_END_TIME]
+            self._evu_first_start == time.min
+            or time_now <= self._evu_first_start
+            or time_now <= self._evu_first_end
         )
 
     def get_next_event_minutes(self) -> int | None:
@@ -67,12 +65,12 @@ class LuxtronikEVUTracker:
         evu_hours = (24 if evu_time < time_now else 0) + evu_time.hour
         evu_pause = 0
 
-        if self._cache[SA.EVU_DAYS] and weekday not in self._cache[SA.EVU_DAYS]:
+        if self._evu_days and weekday not in self._evu_days:
             evu_pause += (24 - now.hour) * 60 - now.minute
-            evu_time = self._cache[SA.EVU_FIRST_START_TIME]
+            evu_time = self._evu_first_start
             for i in range(1, 7):
                 next_day = (weekday + i) % 7
-                if next_day in self._cache[SA.EVU_DAYS]:
+                if next_day in self._evu_days:
                     return evu_time.hour * 60 + evu_time.minute + evu_pause
                 evu_pause += 1440
         else:
@@ -80,10 +78,10 @@ class LuxtronikEVUTracker:
 
     def _get_next_event_time(self, time_now: time) -> time:
         candidates = [
-            self._cache[SA.EVU_FIRST_START_TIME],
-            self._cache[SA.EVU_FIRST_END_TIME],
-            self._cache[SA.EVU_SECOND_START_TIME],
-            self._cache[SA.EVU_SECOND_END_TIME],
+            self._evu_first_start,
+            self._evu_first_end,
+            self._evu_second_start,
+            self._evu_second_end,
         ]
         future_events = [t for t in candidates if t > time_now and t != time.min]
         return (
@@ -98,19 +96,11 @@ class LuxtronikEVUTracker:
 
     def get_attributes(self) -> dict[str, str]:
         return {
-            SA.EVU_FIRST_START_TIME: self._format_time(
-                self._cache[SA.EVU_FIRST_START_TIME]
-            ),
-            SA.EVU_FIRST_END_TIME: self._format_time(
-                self._cache[SA.EVU_FIRST_END_TIME]
-            ),
-            SA.EVU_SECOND_START_TIME: self._format_time(
-                self._cache[SA.EVU_SECOND_START_TIME]
-            ),
-            SA.EVU_SECOND_END_TIME: self._format_time(
-                self._cache[SA.EVU_SECOND_END_TIME]
-            ),
-            SA.EVU_DAYS: self._format_days(self._cache[SA.EVU_DAYS]),
+            SA.EVU_FIRST_START_TIME: self._format_time(self._evu_first_start),
+            SA.EVU_FIRST_END_TIME: self._format_time(self._evu_first_end),
+            SA.EVU_SECOND_START_TIME: self._format_time(self._evu_second_start),
+            SA.EVU_SECOND_END_TIME: self._format_time(self._evu_second_end),
+            SA.EVU_DAYS: self._format_days(self._evu_days),
             SA.EVU_MINUTES_UNTIL_NEXT_EVENT: str(self.get_next_event_minutes() or ""),
         }
 


### PR DESCRIPTION
## Summary

`LuxtronikEVUTracker` stored all EVU schedule state in a single `self._cache` dict keyed by string constants (`SA.EVU_FIRST_START_TIME`, etc.). The dict mixed `time` and `list[int]` values, forcing basedpyright to infer a `time | list[Unknown]` union for every access — causing 16 type errors across the file.

This PR replaces the heterogeneous dict with five dedicated, typed instance attributes.

**Findings:** [§T13](https://github.com/BenPru/luxtronik/issues/583)
**Part of:** #583

## Changes

### `evu_helper.py`

- Remove `self._cache` dict initialization with mixed `time` / `list[int]` values
- Add five typed instance attributes:
  - `self._evu_first_start: time`
  - `self._evu_first_end: time`
  - `self._evu_second_start: time`
  - `self._evu_second_end: time`
  - `self._evu_days: list[int]`
- Replace all `self._cache[SA.EVU_*]` accesses with the corresponding attribute
- Simplify `get_attributes()` — no more multi-line `self._format_time(self._cache[...])` wrapping

## Impact

- **Errors fixed:** 16
- **Runtime behavior:** Identical — same values, same logic, same dict keys in `get_attributes()` output
- **Breaking changes:** None — `_cache` was a private implementation detail