### PR TITLE
fix(config_flow, __init__): 🏷️ fix type errors and remove invalid await

### DIFF
--- a/custom_components/luxtronik/__init__.py
+++ b/custom_components/luxtronik/__init__.py
@@ -133,7 +133,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             coordinator = await connect_and_get_coordinator(hass, config_entry)
             if CONF_HA_SENSOR_PREFIX not in new_data:
                 new_data[CONF_HA_SENSOR_PREFIX] = "luxtronik"
-            await hass.config_entries.async_update_entry(
+            hass.config_entries.async_update_entry(
                 config_entry, data=new_data, version=2, unique_id=coordinator.unique_id
             )
             current_version = 2
@@ -355,7 +355,7 @@ async def _up_many(
             entity_id = f"{platform}.{prefix}_{ident}"
             new_ident = f"{platform}.{prefix}_{new_id}"
             try:
-                await ent_reg.async_update_entity(
+                ent_reg.async_update_entity(
                     entity_id, new_entity_id=new_ident, new_unique_id=new_ident
                 )
             except KeyError as err:
@@ -395,7 +395,7 @@ async def _async_delete_legacy_devices(hass: HomeAssistant, config_entry: Config
     )
     identifiers_list = []
     for device_info in coordinator.device_infos.values():
-        identifiers_list.append(device_info["identifiers"])
+        identifiers_list.append(device_info.get("identifiers", set()))
     for device_entry in devices:
         if not _identifiers_exists(identifiers_list, device_entry.identifiers):
             dr_instance.async_remove_device(device_entry.id)

--- a/custom_components/luxtronik/config_flow.py
+++ b/custom_components/luxtronik/config_flow.py
@@ -48,16 +48,24 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     _sensor_prefix = DOMAIN
     _title = "Luxtronik"
+    _all_devices: list[dict[str, Any]] = []
+    _available_devices: list[dict[str, Any]] = []
 
-    def _build_config(self, host: str, port: int) -> dict[str, Any]:
+    def _build_config(
+        self,
+        host: str,
+        port: int,
+        timeout: float = DEFAULT_TIMEOUT,
+        max_data_length: int = DEFAULT_MAX_DATA_LENGTH,
+    ) -> dict[str, Any]:
         return {
             CONF_HOST: host,
             CONF_PORT: port,
-            CONF_TIMEOUT: DEFAULT_TIMEOUT,
-            CONF_MAX_DATA_LENGTH: DEFAULT_MAX_DATA_LENGTH,
+            CONF_TIMEOUT: timeout,
+            CONF_MAX_DATA_LENGTH: max_data_length,
         }
 
-    async def _discover_devices(self) -> list[tuple[str, int]]:
+    async def _discover_devices(self) -> list[tuple[str, int | None]]:
         """Run device discovery in executor."""
         return await self.hass.async_add_executor_job(discover)
 
@@ -178,6 +186,8 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_user()
 
         device_str = user_input.get(SELECT_DEVICE_LABEL)
+        if device_str is None:
+            return self.async_abort(reason="unknown")
         host, port = device_str.split(":")
         config = self._build_config(host, int(port))
 
@@ -207,7 +217,12 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="manual_entry", data_schema=build_user_data_schema()
             )
 
-        config = self._build_config(user_input[CONF_HOST], int(user_input[CONF_PORT]))
+        config = self._build_config(
+            user_input[CONF_HOST],
+            int(user_input[CONF_PORT]),
+            float(user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT)),
+            int(user_input.get(CONF_MAX_DATA_LENGTH, DEFAULT_MAX_DATA_LENGTH)),
+        )
 
         try:
             coordinator = await connect_and_get_coordinator(self.hass, config)
@@ -246,7 +261,7 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     coord_legacy = await connect_and_get_coordinator(
                         self.hass, legacy_entry
                     )
-                    if self.context["unique_id"] == coord_legacy.unique_id:
+                    if self.context.get("unique_id") == coord_legacy.unique_id:
                         # Match Found! --> Migrate
                         # How to use .INTEGRATION or other instead of .USER?
                         legacy_entry.disabled_by = (
@@ -256,12 +271,13 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         await self.hass.config_entries.async_reload(
                             legacy_entry.entry_id
                         )
-                        self.context["data"][CONF_HA_SENSOR_PREFIX] = "luxtronik2"
+                        ctx_data: dict[str, Any] = self.context.setdefault("data", {})  # pyright: ignore[reportCallIssue, reportArgumentType]
+                        ctx_data[CONF_HA_SENSOR_PREFIX] = "luxtronik2"
                         if (
                             hasattr(legacy_entry, "data")
                             and CONF_HA_SENSOR_INDOOR_TEMPERATURE in legacy_entry.data
                         ):
-                            self.context["data"][CONF_HA_SENSOR_INDOOR_TEMPERATURE] = (
+                            ctx_data[CONF_HA_SENSOR_INDOOR_TEMPERATURE] = (
                                 legacy_entry.data[CONF_HA_SENSOR_INDOOR_TEMPERATURE]
                             )
                         return
@@ -323,7 +339,7 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     DEFAULT_PORT,
                 )
 
-            config = self._build_config(host, int(port))
+            config = self._build_config(host, int(port or DEFAULT_PORT))
 
             try:
                 coordinator = await connect_and_get_coordinator(self.hass, config)
@@ -338,7 +354,7 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             await self.async_set_unique_id(coordinator.unique_id)
             self._abort_if_unique_id_configured(
-                updates={CONF_HOST: host, CONF_PORT: int(port)}
+                updates={CONF_HOST: host, CONF_PORT: int(port or DEFAULT_PORT)}
             )
 
             return self._create_entry(config, coordinator)


### PR DESCRIPTION
## Summary

`config_flow.py` and `__init__.py` had 14 basedpyright errors. 4 of them are `connect_and_get_coordinator` signature mismatches already addressed by #588 (T14). This PR fixes the remaining 10.

Two notable runtime bugs were found and fixed:

- `await hass.config_entries.async_update_entry(...)` — this method is **synchronous** in current HA (returns `bool`), so `await` was a no-op but type-incorrect.
- `await ent_reg.async_update_entity(...)` — also synchronous (returns `RegistryEntry`).

**Findings:** [§T16](https://github.com/BenPru/luxtronik/issues/583)
**Part of:** #583

## Changes

### `config_flow.py`

- **Return type**: `_discover_devices()` → `list[tuple[str, int | None]]` to match `discover()` from `lux_helper`
- **Uninitialized vars**: Add `_all_devices` and `_available_devices` class-level defaults (`[]`)
- **None guard**: Check `device_str` for `None` before calling `.split(":")` in `async_step_select_devices`
- **TypedDict access**: Use `.get("unique_id")` instead of `["unique_id"]` for non-required `ConfigFlowContext` key
- **TypedDict access**: Use `# pyright: ignore` for `self.context.setdefault("data", {})` — `"data"` is not a declared key in `ConfigFlowContext` but is used at runtime as ad-hoc storage
- **Nullable port**: Add `or DEFAULT_PORT` fallback when converting `port` (from discover result) to `int`
- **`_build_config` signature**: Accept `timeout` and `max_data_length` parameters (with defaults) instead of hardcoding `DEFAULT_TIMEOUT` / `DEFAULT_MAX_DATA_LENGTH`; pass user-submitted values from `async_step_manual_entry`

### `__init__.py`

- **Remove await**: `hass.config_entries.async_update_entry()` returns `bool`, not a coroutine
- **Remove await**: `ent_reg.async_update_entity()` returns `RegistryEntry`, not a coroutine
- **TypedDict access**: Use `.get("identifiers", set())` instead of `["identifiers"]` for non-required `DeviceInfo` key

## Impact

- **Errors fixed:** 10 (+ 4 remaining that #588 fixes)
- **Runtime behavior:** Removing `await` from sync calls eliminates silent no-ops. Other changes add safety for edge cases.
- **Breaking changes:** None