### PR TITLE
fix(typing): 🛡️ add type safety guards and narrow types

### DIFF
--- a/custom_components/luxtronik/base.py
+++ b/custom_components/luxtronik/base.py
@@ -208,6 +208,8 @@ class LuxtronikEntity(CoordinatorEntity[LuxtronikCoordinator], RestoreEntity):
             # Ensure timezone:
             time_zone = dt_util.get_time_zone(self.hass.config.time_zone)
             value = value.replace(tzinfo=time_zone)
+        if isinstance(value, datetime):
+            return str(value)
         if attr.format is None:
             return str(value)
         if attr.format == SensorAttrFormat.HOUR_MINUTE:

--- a/custom_components/luxtronik/number.py
+++ b/custom_components/luxtronik/number.py
@@ -163,6 +163,7 @@ class LuxtronikNumberEntity(LuxtronikEntity, NumberEntity):
             return str(value)
         if (
             self._attr_state is not None
+            and self.entity_description.factor is not None
             and float(value)
             >= float(self._attr_state) * float(self.entity_description.factor)
             and (

--- a/custom_components/luxtronik/select.py
+++ b/custom_components/luxtronik/select.py
@@ -43,7 +43,7 @@ async def async_setup_entry(
     thermal_desinfection_description = LuxtronikEntityDescription(
         key=SK.THERMAL_DESINFECTION_DAY,
         device_key=DeviceKey.domestic_water,
-        luxtronik_key=LuxDaySelectorParameter.MONDAY,
+        luxtronik_key=LuxDaySelectorParameter.MONDAY,  # pyright: ignore[reportArgumentType]  # LuxDaySelectorParameter not in LuxParameter|LuxCalculation union; widening requires updating _get_value/get_sensor_data signatures
     )
 
     dhw_description = LuxtronikEntityDescription(

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -14,7 +14,6 @@ from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.util.dt import dt as dt_util
 
 from .base import LuxtronikEntity
 from .common import get_sensor_data, key_exists
@@ -173,11 +172,11 @@ class LuxtronikSensorEntity(LuxtronikEntity, SensorEntity):
         if data is None:
             return
 
-        value = get_sensor_data(data, self.entity_description.luxtronik_key.value)
+        value = get_sensor_data(data, self.entity_description.luxtronik_key)
 
         if value is None:
             self._attr_native_value = None
-        elif self.entity_description.key.value == SensorKey.ERROR_REASON:
+        elif self.entity_description.key == SensorKey.ERROR_REASON:
             self._attr_native_value = value
         elif isinstance(value, (float, int)):
             factor = self.entity_description.factor or 1
@@ -240,7 +239,11 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
         # For normal status sensors, use the parent's update logic
         super()._handle_coordinator_update(data)
 
-        self._evu_tracker.update(self._attr_native_value)
+        self._evu_tracker.update(
+            str(self._attr_native_value)
+            if self._attr_native_value is not None
+            else None
+        )
 
         if self._attr_native_value is None or self._last_state is None:
             pass
@@ -334,7 +337,11 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
             f"component.{DOMAIN}.entity.sensor.status_line_2.state.{line_2_state}"
         )
         # Show evu end time if available
-        suffix = self._evu_tracker.get_evu_status_suffix(self._attr_native_value)
+        suffix = self._evu_tracker.get_evu_status_suffix(
+            str(self._attr_native_value)
+            if self._attr_native_value is not None
+            else None
+        )
         return (
             f"{line_1} {line_2} {status_time}. {suffix}"
             if suffix
@@ -426,13 +433,6 @@ class LuxtronikIndexSensor(LuxtronikSensorEntity, SensorEntity):
         self.async_write_ha_state()
 
     def format_time(self, value_timestamp: int | None) -> datetime | None:
-        if value_timestamp is not None and isinstance(value_timestamp, int):
-            value_timestamp = datetime.fromtimestamp(value_timestamp, UTC)
-        if (
-            value_timestamp is not None
-            and isinstance(value_timestamp, datetime)
-            and value_timestamp.tzinfo is None
-        ):
-            time_zone = dt_util.get_time_zone(self.hass.config.time_zone)
-            value_timestamp = value_timestamp.replace(tzinfo=time_zone)
-        return value_timestamp
+        if value_timestamp is None:
+            return None
+        return datetime.fromtimestamp(value_timestamp, UTC)

--- a/custom_components/luxtronik/update.py
+++ b/custom_components/luxtronik/update.py
@@ -152,6 +152,8 @@ class LuxtronikUpdateEntity(LuxtronikEntity, UpdateEntity):
     def release_notes(self) -> str | None:
         """Build release notes HTML."""
         download_id = get_firmware_download_id(self.installed_version)
+        if download_id is None:
+            return None
         release_url = get_manufacturer_firmware_url_by_model(
             self.coordinator.model, download_id
         )


### PR DESCRIPTION
## Summary

~14 basedpyright errors remain after other type-fix PRs, caused by missing `None` guards, redundant `.value` access on `StrEnum` keys, dead code, and a type mismatch in `select.py`.

**Part of:** #583

## Changes

### `base.py` — early return for `datetime` values (5 errors fixed)

The `_handle_coordinator_update` method passes the value through numeric formatting (`attr.format`, rounding, factor) after a timezone adjustment. When the value is a `datetime`, those numeric paths are unreachable and basedpyright flags type mismatches. An early `return str(value)` after the timezone block skips the inapplicable formatting.

### `number.py` — `None` guard for `factor` (2 errors fixed)

`float(self.entity_description.factor)` fails if `factor` is `None`. Added an explicit `is not None` check in the condition.

### `sensor.py` — StrEnum key access + `str()` casts + `format_time` refactor (5 errors fixed)

- Removed redundant `.value` on `luxtronik_key` and `key` comparisons — `StrEnum` members already compare as `str`
- Added `str()` cast for `self._attr_native_value` passed to `evu_tracker.update()` and `get_evu_status_suffix()` which expect `str | None`
- Refactored `format_time()`: `datetime.fromtimestamp(..., UTC)` always returns tz-aware datetime, so the `if result.tzinfo is None` branch was dead code — removed it along with the unused `dt_util` import

### `select.py` — suppress `LuxDaySelectorParameter` type mismatch (1 error)

`LuxtronikEntityDescription.luxtronik_key` is typed as `LuxParameter | LuxCalculation`, but `LuxDaySelectorParameter` is used here. Widening the union would require updating `_get_value`/`get_sensor_data` signatures throughout the codebase — out of scope. Suppressed with `# pyright: ignore[reportArgumentType]` and justification comment.

### `update.py` — `None` guard for `download_id` (1 error fixed)

`get_firmware_download_id()` can return `None`, but `release_notes()` passed it directly to URL builder. Added early `return None` guard.

## Files Changed

| File | Type | Errors fixed |
|------|------|-------------|
| `base.py` | code fix | 5 |
| `number.py` | code fix | 2 |
| `sensor.py` | code fix | 5 |
| `select.py` | suppress | 1 |
| `update.py` | code fix | 1 |

## Impact

- **14 basedpyright errors eliminated** (13 code fixes + 1 targeted suppress)
- Combined with all other PRs: contributes to reaching **0 errors**
- No functional behavior change
- **Note:** When merged alongside #592 (suppress PR), there is a trivial merge conflict on the `dt_util` import in `sensor.py` — resolve by keeping the deletion (this PR removes the import, #592 adds a suppress on it)