### PR TITLE
fix(select): 🐛 add migration to fix duplicate select entities

### DIFF
--- a/custom_components/luxtronik/__init__.py
+++ b/custom_components/luxtronik/__init__.py
@@ -200,6 +200,11 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             await _async_update_config_entry(hass, config_entry, new_data, 8)
             current_version = 8
 
+        elif current_version == 8:
+            await _fix_select_entity_unique_ids(hass, config_entry)
+            await _async_update_config_entry(hass, config_entry, new_data, 9)
+            current_version = 9
+
     LOGGER.info("Migration to version %s successful", current_version)
     return True
 
@@ -367,6 +372,43 @@ async def _rename_curve_entities(hass: HomeAssistant, config_entry: ConfigEntry)
             ]
         },
     )
+
+
+async def _fix_select_entity_unique_ids(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
+    """Fix select entity unique_ids incorrectly using binary_sensor prefix.
+
+    PR #563 fixed ENTITY_ID_FORMAT import in select.py from
+    homeassistant.components.binary_sensor to homeassistant.components.select,
+    changing unique_ids from binary_sensor.{prefix}_xxx to select.{prefix}_xxx.
+    Migrate old unique_ids to prevent duplicate entities.
+    """
+    prefix = config_entry.data[CONF_HA_SENSOR_PREFIX]
+    ent_reg = async_get(hass)
+    select_keys = [
+        SK.THERMAL_DESINFECTION_DAY,
+        SK.DOMESTIC_WATER_MODE_SELECTOR,
+        SK.HEATING_MODE_SELECTOR,
+    ]
+    for key in select_keys:
+        old_unique_id = f"binary_sensor.{prefix}_{key}"
+        new_unique_id = f"select.{prefix}_{key}"
+        entity_id = ent_reg.async_get_entity_id(P.SELECT, DOMAIN, old_unique_id)
+        if entity_id is not None:
+            try:
+                ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
+                LOGGER.info(
+                    "Migrated select entity unique_id: %s -> %s",
+                    old_unique_id,
+                    new_unique_id,
+                )
+            except ValueError as err:
+                LOGGER.warning(
+                    "Could not migrate select entity %s: %s",
+                    old_unique_id,
+                    err,
+                )
 
 
 async def _up_many(

--- a/custom_components/luxtronik/const.py
+++ b/custom_components/luxtronik/const.py
@@ -16,7 +16,7 @@ import voluptuous as vol
 
 # region Constants Main
 DOMAIN: Final = "luxtronik2"
-CONFIG_ENTRY_VERSION: Final = 8
+CONFIG_ENTRY_VERSION: Final = 9
 NICKNAME_PREFIX: Final = "Home Assistant"
 
 LOGGER: Final[logging.Logger] = logging.getLogger(__package__)
@@ -210,12 +210,14 @@ class LuxMkTypes(Enum):
     cooling = 3
     heating_cooling = 4
 
+
 class LuxHeatingControlModeTypes(StrEnum):
     """LuxHeatingControlModeTypes etc."""
 
     heating_curve_control = "0"
     fixed_temperature = "1"
     analog_in = "2"
+
 
 class LuxRoomThermostatType(Enum):
     """LuxMkTypes etc."""
@@ -376,9 +378,7 @@ class LuxParameter(StrEnum):
     P0022_HEATING_CURVE_CIRCUIT3_NIGHT_TEMPERATURE = (
         "parameters.ID_Einst_HzMK3ABS_akt"  # 0
     )
-    P0017_HEATING_FLOW_OUT_TEMPERATURE_TARGET = (
-        "parameters.ID_Einst_HzFtRl_akt"  # Heizung feste Temperature Rücklauf Soll --> Einstellung 103
-    )
+    P0017_HEATING_FLOW_OUT_TEMPERATURE_TARGET = "parameters.ID_Einst_HzFtRl_akt"  # Heizung feste Temperature Rücklauf Soll --> Einstellung 103
     # P0036_SECOND_HEAT_GENERATOR: Final = "parameters.ID_Einst_ZWE1Art_akt"  #  = 1 --> Heating and domestic water - Is second heat generator activated 1=electrical heater
     P0042_MIXING_CIRCUIT1_TYPE = "parameters.ID_Einst_MK1Typ_akt"
     P0047_DHW_THERMAL_DESINFECTION_TARGET = "parameters.ID_Einst_LGST_akt"

--- a/custom_components/luxtronik/model.py
+++ b/custom_components/luxtronik/model.py
@@ -228,6 +228,7 @@ class LuxtronikDateEntityDescription(
 
     platform = Platform.DATE
 
+
 class LuxtronikSelectEntityDescription(
     LuxtronikEntityDescription,
     SelectEntityDescription,

--- a/custom_components/luxtronik/select.py
+++ b/custom_components/luxtronik/select.py
@@ -97,7 +97,6 @@ async def async_setup_entry(
         entity_registry_enabled_default=False,
     )
 
-
     mode_options = [
         LuxMode.off,
         LuxMode.automatic,

--- a/custom_components/luxtronik/update.py
+++ b/custom_components/luxtronik/update.py
@@ -122,7 +122,9 @@ class LuxtronikUpdateEntity(  # type: ignore  # pyright: ignore[reportIncompatib
             return re.sub(r"^[^\d]+", "", version)
 
         try:
-            return Version(normalize(latest_version)) > Version(normalize(installed_version))
+            return Version(normalize(latest_version)) > Version(
+                normalize(installed_version)
+            )
         except Exception:
             return False
 


### PR DESCRIPTION
### 🐛 Problem

After PR #563 (`fix/select-entity-id-format`), some users report **duplicate select entities** appearing in Home Assistant (e.g. @dajupp in #515). The three affected entities are:

- `thermal_desinfection_day`
- `dhw_mode`
- `heating_mode`

### 🔍 Root Cause

PR #563 correctly fixed the `ENTITY_ID_FORMAT` import in `select.py` — it was importing from `homeassistant.components.binary_sensor` instead of `homeassistant.components.select`.

However, since `unique_id` is derived from `entity_id` (via `ENTITY_ID_FORMAT`), this changed the unique IDs:

| Before (wrong)                                    | After (correct)                            |
| ------------------------------------------------- | ------------------------------------------ |
| `binary_sensor.{prefix}_dhw_mode`                 | `select.{prefix}_dhw_mode`                 |
| `binary_sensor.{prefix}_heating_mode`             | `select.{prefix}_heating_mode`             |
| `binary_sensor.{prefix}_thermal_desinfection_day` | `select.{prefix}_thermal_desinfection_day` |

Home Assistant identifies entities by `unique_id`. When it changes, HA creates a **new** entity while the old one remains as an orphan → users see duplicates.

### ✅ Fix

- Add config entry **migration step v8 → v9** that renames old `unique_id` values from `binary_sensor.{prefix}_xxx` to `select.{prefix}_xxx` in the entity registry
- Migration runs **before** platform setup, so the select platform finds the existing (now correctly named) entity instead of creating a duplicate
- Bump `CONFIG_ENTRY_VERSION` from `8` to `9`

### 📝 Notes

- Users who **already have duplicates** will need to manually remove the orphaned old entities from the entity registry (the ones that are unavailable / have no state)
- Users upgrading for the first time (from version ≤ 8) will get the migration automatically — no duplicates will appear

### 📦 Changes

- `custom_components/luxtronik/__init__.py` — add `_fix_select_entity_unique_ids()` migration helper and v8→v9 migration step
- `custom_components/luxtronik/const.py` — bump `CONFIG_ENTRY_VERSION` to `9`
