### PR TITLE
ci: 👷 add ruff auto-fix job to linter workflow

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,8 +11,49 @@ permissions:
   contents: read
 
 jobs:
+  ruff-fix:
+    name: Ruff Auto-fix
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install Ruff
+        run: pip install --upgrade ruff
+
+      - name: Run ruff check --fix
+        run: ruff check --fix custom_components/luxtronik tests
+
+      - name: Run ruff format
+        run: ruff format custom_components/luxtronik tests
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "style: 🎨 auto-fix ruff format and lint"
+            git push
+          fi
+
   ruff:
     name: Ruff
+    needs: ruff-fix
+    if: always()
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false # complete all jobs


### PR DESCRIPTION
## Summary

Adds a Ruff auto-fix job to the existing **Linter** workflow that automatically fixes formatting and lint issues on PR branches.

Requested by @rhammen in #546.

## How it works

```
PR opened/updated (same-repo branch)
    |
    v
[Ruff Auto-fix]
  ruff check --fix + ruff format
  commit if changed
    |
    v
[Ruff]  (re-checks on fresh checkout)
  ruff format --check + ruff check
    |
[CodeSpell]  (runs independently)
```

1. **Ruff Auto-fix** job runs first on PRs **from same-repo branches only** (not forks)
   - Runs `ruff check --fix` and `ruff format`
   - If any files changed, commits them as `github-actions[bot]`
2. **Ruff** check job waits for auto-fix to finish, then re-checkouts and verifies
3. **CodeSpell** runs independently as before

### Fork PRs

Auto-fix cannot push to fork branches (GitHub token limitation). For fork PRs, the Ruff check job still runs and reports errors - contributors fix them locally.

**Recommended VS Code setup** to avoid this:

```json
{
  "[python]": {
    "editor.defaultFormatter": "charliermarsh.ruff",
    "editor.formatOnSave": true,
    "editor.codeActionsOnSave": {
      "source.organizeImports.ruff": "always"
    }
  }
}
```

## Files Changed

| File | Description |
|------|-------------|
| `.github/workflows/linter.yml` | Added `ruff-fix` job with same-repo guard |
