### PR TITLE
chore: ⬆️ update runtime dependencies

### DIFF
--- a/custom_components/luxtronik2/manifest.json
+++ b/custom_components/luxtronik2/manifest.json
@@ -43,8 +43,8 @@
   ],
   "requirements": [
     "luxtronik==0.3.14",
-    "getmac~=0.9.0",
-    "packaging>=24.2"
+    "getmac~=0.9.5",
+    "packaging>=26.2"
   ],
   "version": "2026.05.19"
 }


### PR DESCRIPTION
## chore: ⬆️ update runtime dependencies

### 📦 Changes

- ⬆️ Bump `getmac` from `~=0.9.0` to `~=0.9.5`
- ⬆️ Bump `packaging` from `>=24.2` to `>=26.2`

### 🔗 Context

Aligns `manifest.json` runtime dependency versions with the versions already updated by Dependabot in `tests/requirements-dev.txt`.