### PR TITLE
fix(translations): 🐛 remove unsupported placeholders from state translations

### DIFF
--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -268,14 +268,6 @@
                     "heating_external_source": "Vyt\u00e1p\u011bn\u00ed z extern\u00edho zdroje",
                     "cooling": "Chlazen\u00ed",
                     "no_request": "Klidov\u00fd re\u017eim"
-                },
-                "state_attributes": {
-                    "evu_text": {
-                        "state": {
-                            "evu_until": "Zb\u00fdv\u00e1 {evu_time} minut do konce HDO blokace.",
-                            "evu_in": "HDO blokovace za {evu_time} minut."
-                        }
-                    }
                 }
             },
             "smart_grid_status": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -265,14 +265,6 @@
                     "heating_external_source": "Heizt aus externer Quelle",
                     "cooling": "K\u00fchlen",
                     "no_request": "Leerlauf (keine Anforderung)"
-                },
-                "state_attributes": {
-                    "evu_text": {
-                        "state": {
-                            "evu_until": "Noch {evu_time} Minuten Netzsperre.",
-                            "evu_in": "Netzsperre in {evu_time} Minuten."
-                        }
-                    }
                 }
             },
             "smart_grid_status": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -269,14 +269,6 @@
                     "heating_external_source": "Heating external source",
                     "cooling": "Cooling",
                     "no_request": "Idle (no request)"
-                },
-                "state_attributes": {
-                    "evu_text": {
-                        "state": {
-                            "evu_until": "{evu_time} minutes more locktime.",
-                            "evu_in": "Locktime in {evu_time} minutes."
-                        }
-                    }
                 }
             },
             "smart_grid_status": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -263,14 +263,6 @@
                     "heating_external_source": "Warmte van externe bron",
                     "cooling": "Koelen",
                     "no_request": "Inactief (geen verzoek)"
-                },
-                "state_attributes": {
-                    "evu_text": {
-                        "state": {
-                            "evu_until": "Er zijn nog {evu_time} minuten netwerksluiting.",
-                            "evu_in": "Netwerksluiting over {evu_time} minuten."
-                        }
-                    }
                 }
             },
             "smart_grid_status": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -256,14 +256,6 @@
                     "heating_external_source": "Zewn\u0119trzne \u017ar\u00f3d\u0142o ogrzewania",
                     "cooling": "Ch\u0142odzenie",
                     "no_request": "Brak zapotrzebowania"
-                },
-                "state_attributes": {
-                    "evu_text": {
-                        "state": {
-                            "evu_until": "Czas blokady d\u0142u\u017cszy o {evu_time} minut.2",
-                            "evu_in": "Czas blokady za {evu_time} minut."
-                        }
-                    }
                 }
             },
             "smart_grid_status": {


### PR DESCRIPTION
## fix(translations): 🐛 remove unsupported placeholders from state translations

### 🐛 Problem

Hassfest validation fails with:

```
Error: placeholders are not supported in this value for dictionary value
@ data['entity']['sensor']['status']['state_attributes']['evu_text']['state']['evu_in']
@ data['entity']['sensor']['status']['state_attributes']['evu_text']['state']['evu_until']
```

### 🔍 Root cause

The `evu_text` state attribute translations contained `{evu_time}` placeholders in `state` values, which Home Assistant does not support. Additionally, `evu_text` was **not referenced anywhere in the Python code** — it was dead translation data.

### ✅ Fix

- 🗑️ Remove the entire `evu_text` `state_attributes` block from all 5 translation files (`en`, `de`, `cs`, `pl`, `nl`)
- 🩹 Fix a duplicate closing brace in `cs.json` introduced by the removal

### 📁 Changed files

| File | Change |
|------|--------|
| `translations/en.json` | removed `evu_text` state_attributes block |
| `translations/de.json` | removed `evu_text` state_attributes block |
| `translations/cs.json` | removed `evu_text` state_attributes block + fixed syntax |
| `translations/nl.json` | removed `evu_text` state_attributes block |
| `translations/pl.json` | removed `evu_text` state_attributes block |

### 🧪 Validation

- ✅ All 5 JSON files pass `json.load()` validation
- ✅ No remaining `{...}` placeholders in `state` translation values