### PR TITLE
fix(ci): 🐛 fix release zip structure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           VERSION=$(date +'%Y.%m.%d')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          
+
       - name: Update manifest.json
         run: |
           MANIFEST_PATH="custom_components/luxtronik2/manifest.json"
@@ -37,14 +37,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add custom_components/luxtronik2/manifest.json
-          
+
           git diff --quiet && git diff --staged --quiet || git commit -m "chore: bump version to ${{ env.VERSION }}"
           git push
 
       - name: Zip integration
         run: |
-          cd custom_components
-          zip -r ../luxtronik2.zip luxtronik2/
+          cd custom_components/luxtronik2
+          zip -r ../../luxtronik2.zip .
 
       # UPDATED: Create the release as a pre-release
       - name: Create GitHub Release


### PR DESCRIPTION
## fix(ci): 🐛 fix release zip structure

### 🐛 Problem

After upgrading to the latest release (`2026.05.20`), the integration fails to load in Home Assistant. HACS downloads the `luxtronik2.zip` release asset and extracts it into `custom_components/luxtronik2/`, but the zip was built with a wrapping `luxtronik2/` directory inside. This results in files being extracted to `custom_components/luxtronik2/luxtronik2/` — a nested directory that Home Assistant does not recognize as a valid integration.

### ✅ Fix

Changed the zip step to package the **contents** of `custom_components/luxtronik2/` directly (flat structure) instead of wrapping them in a subdirectory:

```diff
- cd custom_components
- zip -r ../luxtronik2.zip luxtronik2/
+ cd custom_components/luxtronik2
+ zip -r ../../luxtronik2.zip .
```


Resolves: #617