### PR TITLE
chore: 🔧 add PARALLEL_UPDATES to all entity platforms

### DIFF
--- a/custom_components/luxtronik2/binary_sensor.py
+++ b/custom_components/luxtronik2/binary_sensor.py
@@ -18,6 +18,8 @@ from .model import LuxtronikBinarySensorEntityDescription
 
 # endregion Imports
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/luxtronik2/climate.py
+++ b/custom_components/luxtronik2/climate.py
@@ -52,6 +52,8 @@ from .model import LuxtronikClimateDescription
 
 # endregion Imports
 
+PARALLEL_UPDATES = 1
+
 # region Const
 MIN_TEMPERATURE = 8
 MAX_TEMPERATURE = 28

--- a/custom_components/luxtronik2/date.py
+++ b/custom_components/luxtronik2/date.py
@@ -22,6 +22,8 @@ from .coordinator import LuxtronikCoordinator, LuxtronikCoordinatorData
 from .date_entities_predefined import CALENDAR_ENTITIES
 from .model import LuxtronikDateEntityDescription
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(  # pragma: no cover
     hass: HomeAssistant,

--- a/custom_components/luxtronik2/number.py
+++ b/custom_components/luxtronik2/number.py
@@ -30,6 +30,8 @@ from .number_entities_predefined import NUMBER_SENSORS
 
 # endregion Imports
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/luxtronik2/select.py
+++ b/custom_components/luxtronik2/select.py
@@ -29,6 +29,8 @@ from .const import (
 from .coordinator import LuxtronikCoordinator, LuxtronikCoordinatorData
 from .model import LuxtronikSelectEntityDescription
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/luxtronik2/sensor.py
+++ b/custom_components/luxtronik2/sensor.py
@@ -41,6 +41,8 @@ from .sensor_entities_predefined import SENSORS, SENSORS_INDEX, SENSORS_STATUS
 
 # endregion Imports
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/luxtronik2/switch.py
+++ b/custom_components/luxtronik2/switch.py
@@ -20,6 +20,8 @@ from .switch_entities_predefined import SWITCHES
 
 # endregion Imports
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/luxtronik2/update.py
+++ b/custom_components/luxtronik2/update.py
@@ -36,6 +36,8 @@ from .model import LuxtronikUpdateEntityDescription
 
 # endregion Imports
 
+PARALLEL_UPDATES = 0
+
 MIN_TIME_BETWEEN_UPDATES: Final = timedelta(hours=1)
 
 

--- a/custom_components/luxtronik2/water_heater.py
+++ b/custom_components/luxtronik2/water_heater.py
@@ -41,6 +41,8 @@ from .model import LuxtronikWaterHeaterDescription
 
 # endregion Imports
 
+PARALLEL_UPDATES = 1
+
 # region Const
 OPERATION_MAPPING: dict[str, str] = {
     LuxMode.off: STATE_OFF,

--- a/tests/test_platform_imports.py
+++ b/tests/test_platform_imports.py
@@ -58,3 +58,38 @@ class TestConfigFlowModuleImport:
         from custom_components.luxtronik2.config_flow import LuxtronikFlowHandler
 
         assert LuxtronikFlowHandler is not None
+
+
+class TestParallelUpdates:
+    """PARALLEL_UPDATES must be defined on every platform module.
+
+    Read-only platforms (sensor, binary_sensor, update) use 0 (unlimited)
+    because they only read from the coordinator's cached data.
+
+    Writable platforms (number, switch, select, climate, water_heater, date)
+    use 1 (serialized) because writes go through a single TCP socket.
+    """
+
+    def test_read_only_platforms_have_parallel_updates_0(self):
+        from custom_components.luxtronik2.binary_sensor import PARALLEL_UPDATES as bs
+        from custom_components.luxtronik2.sensor import PARALLEL_UPDATES as s
+        from custom_components.luxtronik2.update import PARALLEL_UPDATES as u
+
+        assert s == 0
+        assert bs == 0
+        assert u == 0
+
+    def test_writable_platforms_have_parallel_updates_1(self):
+        from custom_components.luxtronik2.climate import PARALLEL_UPDATES as cl
+        from custom_components.luxtronik2.date import PARALLEL_UPDATES as d
+        from custom_components.luxtronik2.number import PARALLEL_UPDATES as n
+        from custom_components.luxtronik2.select import PARALLEL_UPDATES as sel
+        from custom_components.luxtronik2.switch import PARALLEL_UPDATES as sw
+        from custom_components.luxtronik2.water_heater import PARALLEL_UPDATES as wh
+
+        assert n == 1
+        assert sw == 1
+        assert sel == 1
+        assert cl == 1
+        assert wh == 1
+        assert d == 1

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -81,3 +81,62 @@ class TestSelectDataNone:
         entity.coordinator.data = None
         await entity.async_select_option("Monday")
         # Should return early without error
+
+
+# ===========================================================================
+# select.py — async_update
+# ===========================================================================
+
+
+class TestThermalDesinfectionAsyncUpdate:
+    def _make_entity(self, coord=None):
+        desc = LuxtronikSelectEntityDescription(
+            key=SensorKey.THERMAL_DESINFECTION_DAY,
+            device_key=DeviceKey.domestic_water,
+            luxtronik_key=LuxDaySelectorParameter.MONDAY,  # pyright: ignore[reportArgumentType]
+        )
+        if coord is None:
+            coord = _mock_coordinator()
+        entry = _mock_entry()
+        entity = LuxtronikThermalDesinfectionDaySelector(
+            entry, coord, desc, DeviceKey.domestic_water
+        )
+        _patch_entity(entity)
+        return entity
+
+    @pytest.mark.asyncio
+    async def test_async_update_data_none(self):
+        entity = self._make_entity()
+        entity.coordinator.data = None
+        await entity.async_update()
+        # Should return early, current_option unchanged
+
+    @pytest.mark.asyncio
+    async def test_async_update_no_day_selected(self):
+        coord = _mock_coordinator()
+        entity = self._make_entity(coord)
+        # All day parameters return "0" by default (mock)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.luxtronik2.select.get_sensor_data",
+                lambda data, key: "0",
+            )
+            await entity.async_update()
+        assert entity._attr_current_option == "none"
+
+    @pytest.mark.asyncio
+    async def test_async_update_day_selected(self):
+        coord = _mock_coordinator()
+        entity = self._make_entity(coord)
+        wednesday_param = LuxDaySelectorParameter.WEDNESDAY.value
+
+        def fake_sensor_data(data, key):
+            return "1" if key == wednesday_param else "0"
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "custom_components.luxtronik2.select.get_sensor_data",
+                fake_sensor_data,
+            )
+            await entity.async_update()
+        assert entity._attr_current_option == "wednesday"


### PR DESCRIPTION
## chore: 🔧 add `PARALLEL_UPDATES` to all entity platforms

### 📋 Summary

Adds the `PARALLEL_UPDATES` constant to all 9 entity platform modules, fulfilling the [HA Integration Quality Scale `parallel-updates` rule](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/parallel-updates/) (Silver tier).

### 🔍 Rationale

The `luxtronik` library communicates with the heat pump over a **single raw TCP socket** (synchronous, wrapped via `async_add_executor_job`). The coordinator already serializes access with an `asyncio.Lock`, but the HA platform layer should also declare its concurrency expectations explicitly.

### ⚙️ Values chosen

| Platform        | `PARALLEL_UPDATES` | Reason                                                                         |
| --------------- | ------------------ | ------------------------------------------------------------------------------ |
| `sensor`        | `0` (unlimited)    | Read-only – reads from coordinator cache, no I/O per entity                    |
| `binary_sensor` | `0` (unlimited)    | Read-only – same as sensor                                                     |
| `update`        | `0` (unlimited)    | Read-only – firmware version check is time-throttled independently             |
| `number`        | `1` (serialized)   | Writable – writes go through single TCP socket via `coordinator.async_write()` |
| `switch`        | `1` (serialized)   | Writable – same socket path                                                    |
| `select`        | `1` (serialized)   | Writable – same socket path                                                    |
| `climate`       | `1` (serialized)   | Writable – same socket path                                                    |
| `water_heater`  | `1` (serialized)   | Writable – same socket path                                                    |
| `date`          | `1` (serialized)   | Writable – same socket path                                                    |

**Why `0` for read-only platforms?** All entities inherit from `CoordinatorEntity` — their `_handle_coordinator_update` only reads from the coordinator's in-memory `data` dict. No network call occurs per entity, so there is no benefit to limiting concurrency.

**Why `1` for writable platforms?** Write operations (`async_set_native_value`, `async_turn_on`, `async_set_temperature`, etc.) call `coordinator.async_write()`, which sends data over the single TCP socket to the Luxtronik controller. Serializing writes at the platform level prevents queuing multiple concurrent socket operations, complementing the coordinator's internal `asyncio.Lock`.

### ✅ Changes

- 📄 `sensor.py` — add `PARALLEL_UPDATES = 0`
- 📄 `binary_sensor.py` — add `PARALLEL_UPDATES = 0`
- 📄 `update.py` — add `PARALLEL_UPDATES = 0`
- 📄 `number.py` — add `PARALLEL_UPDATES = 1`
- 📄 `switch.py` — add `PARALLEL_UPDATES = 1`
- 📄 `select.py` — add `PARALLEL_UPDATES = 1`
- 📄 `climate.py` — add `PARALLEL_UPDATES = 1`
- 📄 `water_heater.py` — add `PARALLEL_UPDATES = 1`
- 📄 `date.py` — add `PARALLEL_UPDATES = 1`
- 🧪 `tests/test_platform_imports.py` — add `TestParallelUpdates` with assertions for all platforms

### 🧪 Testing

- All 643 tests pass
- `basedpyright` — 0 errors
- `ruff check` — all passed
- `ruff format --check` — all formatted
