### PR TITLE
Add RoomThermostat detection and differentiates Climate thermostats based on this

### DIFF
--- a/custom_components/luxtronik2/climate.py
+++ b/custom_components/luxtronik2/climate.py
@@ -114,8 +114,6 @@ THERMOSTATS_SMART: list[LuxtronikClimateDescription] = [
         luxtronik_key_target_temperature=LuxParameter.P1148_HEATING_TARGET_TEMP_ROOM_THERMOSTAT,
         luxtronik_key_current_action=LuxCalculation.C0080_STATUS,
         luxtronik_action_active=LuxOperationMode.heating,
-        # luxtronik_key_target_temperature_high=LuxParameter,
-        # luxtronik_key_target_temperature_low=LuxParameter,
         icon_by_state=LUX_STATE_ICON_MAP,
         temperature_unit=UnitOfTemperature.CELSIUS,
         translation_key_name="heating_controller",
@@ -135,8 +133,6 @@ THERMOSTATS_SMART: list[LuxtronikClimateDescription] = [
         luxtronik_key_target_temperature=LuxParameter.P1148_HEATING_TARGET_TEMP_ROOM_THERMOSTAT,
         luxtronik_key_current_action=LuxCalculation.C0080_STATUS,
         luxtronik_action_active=LuxOperationMode.cooling,
-        # luxtronik_key_target_temperature_high=LuxParameter,
-        # luxtronik_key_target_temperature_low=LuxParameter,
         icon_by_state=LUX_STATE_ICON_MAP_COOL,
         temperature_unit=UnitOfTemperature.CELSIUS,
         translation_key_name="cooling_controller",
@@ -166,7 +162,7 @@ THERMOSTATS_OTHER: list[LuxtronikClimateDescription] = [
         temperature_unit=UnitOfTemperature.CELSIUS,
         min_temp=-5.0,
         max_temp=5.0,
-        translation_key_name="cooling_controller",
+        translation_key_name="heating_controller",
         # visibility=LuxVisibility.V0023_FLOW_IN_TEMPERATURE,
         device_key=DeviceKey.heating,
     ),
@@ -183,8 +179,6 @@ THERMOSTATS_OTHER: list[LuxtronikClimateDescription] = [
         luxtronik_key_target_temperature=LuxParameter.P0110_COOLING_OUTDOOR_TEMP_THRESHOLD,
         luxtronik_key_current_action=LuxCalculation.C0080_STATUS,
         luxtronik_action_active=LuxOperationMode.cooling,
-        # luxtronik_key_target_temperature_high=LuxParameter,
-        # luxtronik_key_target_temperature_low=LuxParameter,
         icon_by_state=LUX_STATE_ICON_MAP_COOL,
         temperature_unit=UnitOfTemperature.CELSIUS,
         translation_key_name="cooling_controller",
@@ -211,8 +205,6 @@ async def async_setup_entry(
     is_smart_thermostat = False
     if isinstance(rt, LuxRoomThermostatType):
         is_smart_thermostat = rt == LuxRoomThermostatType.smart
-    elif isinstance(rt, int):
-        is_smart_thermostat = rt == LuxRoomThermostatType.smart.value
 
     LOGGER.info(
         "Detected room thermostat type: %s (smart=%s)",

--- a/custom_components/luxtronik2/climate.py
+++ b/custom_components/luxtronik2/climate.py
@@ -29,7 +29,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import ExtraStoredData
-from packaging.version import Version
 
 from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
@@ -45,6 +44,7 @@ from .const import (
     LuxMode,
     LuxOperationMode,
     LuxParameter,
+    LuxRoomThermostatType,
     SensorKey,
 )
 from .coordinator import LuxtronikCoordinator, LuxtronikCoordinatorData
@@ -99,7 +99,7 @@ HVAC_PRESET_MAPPING: dict[str, str] = {
     LuxMode.holidays: PRESET_AWAY,
 }
 
-THERMOSTATS: list[LuxtronikClimateDescription] = [
+THERMOSTATS_SMART: list[LuxtronikClimateDescription] = [
     LuxtronikClimateDescription(
         key=SensorKey.HEATING,
         hvac_modes=[HVACMode.HEAT, HVACMode.OFF],
@@ -121,8 +121,31 @@ THERMOSTATS: list[LuxtronikClimateDescription] = [
         translation_key_name="heating_controller",
         # visibility=LuxVisibility.V0023_FLOW_IN_TEMPERATURE,
         device_key=DeviceKey.heating,
-        min_firmware_version=Version("3.90.1"),
     ),
+    LuxtronikClimateDescription(
+        key=SensorKey.COOLING,
+        hvac_modes=[HVACMode.COOL, HVACMode.OFF],
+        hvac_mode_mapping=HVAC_MODE_MAPPING_COOL,
+        hvac_action_mapping=HVAC_ACTION_MAPPING_COOL,
+        preset_modes=[PRESET_NONE],
+        supported_features=ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TARGET_TEMPERATURE,
+        luxtronik_key=LuxParameter.P0108_MODE_COOLING,
+        luxtronik_key_target_temperature=LuxParameter.P1148_HEATING_TARGET_TEMP_ROOM_THERMOSTAT,
+        luxtronik_key_current_action=LuxCalculation.C0080_STATUS,
+        luxtronik_action_active=LuxOperationMode.cooling,
+        # luxtronik_key_target_temperature_high=LuxParameter,
+        # luxtronik_key_target_temperature_low=LuxParameter,
+        icon_by_state=LUX_STATE_ICON_MAP_COOL,
+        temperature_unit=UnitOfTemperature.CELSIUS,
+        translation_key_name="cooling_controller",
+        # visibility=LuxVisibility.V0005_COOLING,
+        device_key=DeviceKey.cooling,
+    ),
+]
+
+THERMOSTATS_OTHER: list[LuxtronikClimateDescription] = [
     LuxtronikClimateDescription(
         key=SensorKey.HEATING,
         hvac_modes=[HVACMode.HEAT, HVACMode.OFF],
@@ -134,19 +157,18 @@ THERMOSTATS: list[LuxtronikClimateDescription] = [
         | ClimateEntityFeature.TURN_ON
         | ClimateEntityFeature.TARGET_TEMPERATURE,
         luxtronik_key=LuxParameter.P0003_MODE_HEATING,
-        luxtronik_key_target_temperature=LuxCalculation.C0228_ROOM_THERMOSTAT_TEMPERATURE_TARGET,
+        luxtronik_key_target_temperature=LuxParameter.P0001_HEATING_TARGET_CORRECTION,
         luxtronik_key_current_action=LuxCalculation.C0080_STATUS,
         luxtronik_action_active=LuxOperationMode.heating,
-        # luxtronik_key_target_temperature_high=LuxParameter,
-        # luxtronik_key_target_temperature_low=LuxParameter,
         luxtronik_key_correction_factor=LuxParameter.P0980_HEATING_ROOM_TEMPERATURE_IMPACT_FACTOR,
         luxtronik_key_correction_target=LuxParameter.P0001_HEATING_TARGET_CORRECTION,
         icon_by_state=LUX_STATE_ICON_MAP,
         temperature_unit=UnitOfTemperature.CELSIUS,
+        min_temp=-5.0,
+        max_temp=5.0,
         translation_key_name="cooling_controller",
         # visibility=LuxVisibility.V0023_FLOW_IN_TEMPERATURE,
         device_key=DeviceKey.heating,
-        max_firmware_version=Version("3.90.0"),
     ),
     LuxtronikClimateDescription(
         key=SensorKey.COOLING,
@@ -170,6 +192,8 @@ THERMOSTATS: list[LuxtronikClimateDescription] = [
         device_key=DeviceKey.cooling,
     ),
 ]
+
+THERMOSTATS: list[LuxtronikClimateDescription] = THERMOSTATS_SMART + THERMOSTATS_OTHER
 # endregion Const
 
 
@@ -181,6 +205,22 @@ async def async_setup_entry(
     """Set up Luxtronik climate entities dynamically through Luxtronik discovery."""
 
     coordinator = entry.runtime_data
+
+    # Determine room thermostat type from coordinator (enum or raw int)
+    rt = getattr(coordinator, "room_thermostat_type", None)
+    is_smart_thermostat = False
+    if isinstance(rt, LuxRoomThermostatType):
+        is_smart_thermostat = rt == LuxRoomThermostatType.smart
+    elif isinstance(rt, int):
+        is_smart_thermostat = rt == LuxRoomThermostatType.smart.value
+
+    LOGGER.info(
+        "Detected room thermostat type: %s (smart=%s)",
+        rt,
+        is_smart_thermostat,
+    )
+
+    THERMOSTATS = THERMOSTATS_SMART if is_smart_thermostat else THERMOSTATS_OTHER
 
     unavailable_keys = [
         i.luxtronik_key
@@ -294,6 +334,12 @@ class LuxtronikThermostat(LuxtronikEntity[LuxtronikClimateDescription], ClimateE
         self._attr_temperature_unit = description.temperature_unit
         self._attr_hvac_modes = description.hvac_modes
         self._attr_preset_modes = description.preset_modes
+        min_temp = getattr(description, "min_temp", None)
+        if min_temp is not None:
+            self._attr_min_temp = min_temp
+        max_temp = getattr(description, "max_temp", None)
+        if max_temp is not None:
+            self._attr_max_temp = max_temp
         self._enable_turn_on_off_backwards_compatibility = False
         self._attr_supported_features = description.supported_features
 
@@ -337,7 +383,9 @@ class LuxtronikThermostat(LuxtronikEntity[LuxtronikClimateDescription], ClimateE
             self._attr_current_temperature = None
         elif key.startswith("sensor."):
             temp = self.hass.states.get(key)
-            self._attr_current_temperature = state_as_number_or_none(temp, 0.0)
+            self._attr_current_temperature = (
+                state_as_number_or_none(temp, 0.0) if temp is not None else None
+            )
         elif key != LuxCalculation.UNSET:
             self._attr_current_temperature = get_sensor_data(data, key)
 

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -375,6 +375,7 @@ class LuxParameter(StrEnum):
         "parameters.ID_Einst_HzMK3ABS_akt"  # 0
     )
     P0017_HEATING_FLOW_OUT_TEMPERATURE_TARGET = "parameters.ID_Einst_HzFtRl_akt"  # Heizung feste Temperature Rücklauf Soll --> Einstellung 103
+    P0033_ROOM_THERMOSTAT_TYPE = "parameters.ID_Einst_RFVEinb_akt"  # 0 = none, 1=RFV, 2=RFV-K, 3=RFV-DK, 4=RBE, 5=Smart
     # P0036_SECOND_HEAT_GENERATOR: Final = "parameters.ID_Einst_ZWE1Art_akt"  #  = 1 --> Heating and domestic water - Is second heat generator activated 1=electrical heater
     P0042_MIXING_CIRCUIT1_TYPE = "parameters.ID_Einst_MK1Typ_akt"
     P0047_DHW_THERMAL_DESINFECTION_TARGET = "parameters.ID_Einst_LGST_akt"
@@ -387,7 +388,6 @@ class LuxParameter(StrEnum):
     P0090_RELEASE_SECOND_HEAT_GENERATOR = "parameters.ID_Einst_ZWEFreig_akt"
     P0093_HEAT_SOURCE_INPUT_TEMPERATURE_MIN = "parameters.ID_Einst_TWQmin_akt"
     P0103_HEATING_CONTROL_CIRCUIT_MODE = "parameters.ID_Einst_RTyp_akt"
-    P0033_ROOM_THERMOSTAT_TYPE = "parameters.ID_Einst_RFVEinb_akt"
     P0105_DHW_TARGET_TEMPERATURE = "parameters.ID_Soll_BWS_akt"
     # MODE_COOLING: Automatic or Off
     P0108_MODE_COOLING = "parameters.ID_Einst_BA_Kuehl_akt"

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -224,11 +224,11 @@ class LuxRoomThermostatType(Enum):
 
     none = 0
     # TODO: Validate types:
-    # RFV: Final = 1
-    # RFV_K: Final = 2
-    # RFV_DK: Final = 3
-    # RBE: Final = 4
-    # Smart: Final = 5
+    rfv = 1
+    rfv_k = 2
+    rfv_dk = 3
+    rbe = 4
+    smart = 5
 
 
 class LuxSwitchoffReason(Enum):
@@ -387,6 +387,7 @@ class LuxParameter(StrEnum):
     P0090_RELEASE_SECOND_HEAT_GENERATOR = "parameters.ID_Einst_ZWEFreig_akt"
     P0093_HEAT_SOURCE_INPUT_TEMPERATURE_MIN = "parameters.ID_Einst_TWQmin_akt"
     P0103_HEATING_CONTROL_CIRCUIT_MODE = "parameters.ID_Einst_RTyp_akt"
+    P0033_ROOM_THERMOSTAT_TYPE = "parameters.ID_Einst_RFVEinb_akt"
     P0105_DHW_TARGET_TEMPERATURE = "parameters.ID_Soll_BWS_akt"
     # MODE_COOLING: Automatic or Off
     P0108_MODE_COOLING = "parameters.ID_Einst_BA_Kuehl_akt"
@@ -834,6 +835,7 @@ class SensorKey(StrEnum):
     APPROVAL_COOLING = "approval_cooling"
     ROOM_THERMOSTAT_TEMPERATURE = "room_thermostat_temperature"
     ROOM_THERMOSTAT_TEMPERATURE_TARGET = "room_thermostat_temperature_target"
+    ROOM_THERMOSTAT_TYPE = "room_thermostat_type"
     COOLING_START_DELAY_HOURS = "cooling_start_delay_hours"
     COOLING_STOP_DELAY_HOURS = "cooling_stop_delay_hours"
     COOLING_OUTDOOR_TEMP_THRESHOLD = "cooling_threshold_temperature"

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -88,8 +88,6 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         self._lock = asyncio.Lock()
         self.client = client
         self._config = config
-        # Room thermostat type derived from parameters.ID_Einst_RFVEinb_akt
-        self.room_thermostat_type: LuxRoomThermostatType | int | None = None
         self.device_infos = dict[str, DeviceInfo]()
         self.update_reason_write = False
         super().__init__(
@@ -110,26 +108,7 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
                     calculations=self.client.calculations,
                     visibilities=self.client.visibilities,
                 )
-                # Derived runtime config: room thermostat type
-                try:
-                    raw = self.get_value(LP.P0033_ROOM_THERMOSTAT_TYPE)
-                    if raw is None:
-                        self.room_thermostat_type = None
-                    else:
-                        try:
-                            num = int(raw)
-                        except Exception:
-                            num = None
-                        if num is None:
-                            self.room_thermostat_type = None
-                        else:
-                            try:
-                                self.room_thermostat_type = LuxRoomThermostatType(num)
-                            except Exception:
-                                # Unknown numeric type - keep raw int for callers
-                                self.room_thermostat_type = num
-                except Exception:  # don't break update on this
-                    self.room_thermostat_type = None
+
                 return self.data
             except Exception as err:
                 raise UpdateFailed(f"Error fetching data: {err}") from err
@@ -371,6 +350,28 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         minor = rel[1] if len(rel) > 1 else 0
         patch = rel[2] if len(rel) > 2 else 0
         return Version(f"{minor}.{patch}")
+
+    @property
+    def room_thermostat_type(self) -> LuxRoomThermostatType | int | None:
+        """Derived runtime room thermostat type from parameter P0033.
+
+        Returns LuxRoomThermostatType enum when recognized, raw int when
+        unknown numeric, or None when not set or on error.
+        """
+        try:
+            raw = self.get_value(LP.P0033_ROOM_THERMOSTAT_TYPE)
+            if raw is None:
+                return None
+            try:
+                num = int(raw)
+            except Exception:
+                return None
+            try:
+                return LuxRoomThermostatType(num)
+            except Exception:
+                return num
+        except Exception:
+            return None
 
     def entity_visible(self, description: LuxtronikEntityDescription) -> bool:
         """Is description visible."""

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -243,12 +243,9 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
     ) -> str:
         if platform is None:
             return str(key.value)
-        return (
-            platform.platform_data.platform_translations.get(
-                f"component.{DOMAIN}.entity.device.{key.value}.name"
-            )
-            or str(key.value)
-        )
+        return platform.platform_data.platform_translations.get(
+            f"component.{DOMAIN}.entity.device.{key.value}.name"
+        ) or str(key.value)
 
     def _build_device_info(
         self,

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -36,6 +36,7 @@ from .const import (
     LuxCalculation as LC,
     LuxMkTypes,
     LuxParameter as LP,
+    LuxRoomThermostatType,
     LuxVisibility as LV,
 )
 from .lux_helper import Luxtronik, get_manufacturer_by_model
@@ -87,6 +88,8 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         self._lock = asyncio.Lock()
         self.client = client
         self._config = config
+        # Room thermostat type derived from parameters.ID_Einst_RFVEinb_akt
+        self.room_thermostat_type: LuxRoomThermostatType | int | None = None
         self.device_infos = dict[str, DeviceInfo]()
         self.update_reason_write = False
         super().__init__(
@@ -107,6 +110,26 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
                     calculations=self.client.calculations,
                     visibilities=self.client.visibilities,
                 )
+                # Derived runtime config: room thermostat type
+                try:
+                    raw = self.get_value(LP.P0033_ROOM_THERMOSTAT_TYPE)
+                    if raw is None:
+                        self.room_thermostat_type = None
+                    else:
+                        try:
+                            num = int(raw)
+                        except Exception:
+                            num = None
+                        if num is None:
+                            self.room_thermostat_type = None
+                        else:
+                            try:
+                                self.room_thermostat_type = LuxRoomThermostatType(num)
+                            except Exception:
+                                # Unknown numeric type - keep raw int for callers
+                                self.room_thermostat_type = num
+                except Exception:  # don't break update on this
+                    self.room_thermostat_type = None
                 return self.data
             except Exception as err:
                 raise UpdateFailed(f"Error fetching data: {err}") from err
@@ -220,8 +243,11 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
     ) -> str:
         if platform is None:
             return str(key.value)
-        return platform.platform_data.platform_translations.get(
-            f"component.{DOMAIN}.entity.device.{key.value}.name"
+        return (
+            platform.platform_data.platform_translations.get(
+                f"component.{DOMAIN}.entity.device.{key.value}.name"
+            )
+            or str(key.value)
         )
 
     def _build_device_info(

--- a/custom_components/luxtronik2/model.py
+++ b/custom_components/luxtronik2/model.py
@@ -175,6 +175,8 @@ class LuxtronikClimateDescription(
     luxtronik_key_target_temperature: LuxParameter | LuxCalculation = LuxParameter.UNSET
     luxtronik_key_correction_factor: LuxParameter = LuxParameter.UNSET
     luxtronik_key_correction_target: LuxParameter = LuxParameter.UNSET
+    min_temp: float | None = None
+    max_temp: float | None = None
     temperature_unit: str = UnitOfTemperature.CELSIUS
 
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -26,6 +26,8 @@ from custom_components.luxtronik2.climate import (
     MAX_TEMPERATURE,
     MIN_TEMPERATURE,
     THERMOSTATS,
+    THERMOSTATS_OTHER,
+    THERMOSTATS_SMART,
     LuxtronikClimateExtraStoredData,
     LuxtronikThermostat,
 )
@@ -104,21 +106,6 @@ class TestHVACPresetMapping:
 
     def test_second_heatsource_preset(self):
         assert HVAC_PRESET_MAPPING[LuxMode.second_heatsource] == PRESET_BOOST
-
-
-from custom_components.luxtronik2.climate import (
-    HVAC_ACTION_MAPPING_COOL,
-    HVAC_ACTION_MAPPING_HEAT,
-    HVAC_MODE_MAPPING_COOL,
-    HVAC_MODE_MAPPING_HEAT,
-    HVAC_PRESET_MAPPING,
-    MAX_TEMPERATURE,
-    MIN_TEMPERATURE,
-    THERMOSTATS_OTHER,
-    THERMOSTATS_SMART,
-    LuxtronikClimateExtraStoredData,
-    LuxtronikThermostat,
-)
 
 
 class TestThermostats:

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -106,16 +106,42 @@ class TestHVACPresetMapping:
         assert HVAC_PRESET_MAPPING[LuxMode.second_heatsource] == PRESET_BOOST
 
 
+from custom_components.luxtronik2.climate import (
+    HVAC_ACTION_MAPPING_COOL,
+    HVAC_ACTION_MAPPING_HEAT,
+    HVAC_MODE_MAPPING_COOL,
+    HVAC_MODE_MAPPING_HEAT,
+    HVAC_PRESET_MAPPING,
+    MAX_TEMPERATURE,
+    MIN_TEMPERATURE,
+    THERMOSTATS_OTHER,
+    THERMOSTATS_SMART,
+    LuxtronikClimateExtraStoredData,
+    LuxtronikThermostat,
+)
+
+
 class TestThermostats:
-    def test_thermostat_count(self):
-        assert len(THERMOSTATS) >= 3  # heating new, heating old, cooling
+    def test_smart_thermostat_count(self):
+        assert len(THERMOSTATS_SMART) == 2  # 1 heating + 1 cooling
 
-    def test_heating_thermostat_exists(self):
-        heating = [t for t in THERMOSTATS if t.device_key == DeviceKey.heating]
-        assert len(heating) >= 1
+    def test_other_thermostat_count(self):
+        assert len(THERMOSTATS_OTHER) == 2  # 1 heating + 1 cooling
 
-    def test_cooling_thermostat_exists(self):
-        cooling = [t for t in THERMOSTATS if t.device_key == DeviceKey.cooling]
+    def test_heating_thermostat_exists_smart(self):
+        heating = [t for t in THERMOSTATS_SMART if t.device_key == DeviceKey.heating]
+        assert len(heating) == 1
+
+    def test_cooling_thermostat_exists_smart(self):
+        cooling = [t for t in THERMOSTATS_SMART if t.device_key == DeviceKey.cooling]
+        assert len(cooling) == 1
+
+    def test_heating_thermostat_exists_other(self):
+        heating = [t for t in THERMOSTATS_OTHER if t.device_key == DeviceKey.heating]
+        assert len(heating) == 1
+
+    def test_cooling_thermostat_exists_other(self):
+        cooling = [t for t in THERMOSTATS_OTHER if t.device_key == DeviceKey.cooling]
         assert len(cooling) == 1
 
     def test_temperature_bounds(self):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -18,6 +18,7 @@ from custom_components.luxtronik2.const import (
     LuxCalculation as LC,
     LuxMkTypes,
     LuxParameter as LP,
+    LuxRoomThermostatType,
     LuxVisibility as LV,
 )
 from custom_components.luxtronik2.coordinator import (
@@ -163,6 +164,15 @@ class TestCoordinatorProperties:
         sn = coord.serial_number
         assert "20230101" in sn
         assert "ff" in sn.lower()  # hex(255) = 0xff
+
+    def test_room_thermostat_type(self):
+        coord = _make_coordinator(parameters={"ID_Einst_RFVEinb_akt": 4})
+        thermostat_type = coord.room_thermostat_type
+        assert thermostat_type == LuxRoomThermostatType.rbe
+
+        coord = _make_coordinator(parameters={"ID_Einst_RFVEinb_akt": 5})
+        thermostat_type = coord.room_thermostat_type
+        assert thermostat_type == LuxRoomThermostatType.smart
 
 
 # ===========================================================================

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -176,7 +176,7 @@ class TestCoordinatorProperties:
 
         coord = _make_coordinator(parameters={"ID_Einst_RFVEinb_akt": 99})
         thermostat_type = coord.room_thermostat_type
-        assert thermostat_type is None
+        assert thermostat_type == 99  # Unknown but returned as int
 
         coord = _make_coordinator(parameters={"ID_Einst_RFVEinb_akt": "unknown"})
         thermostat_type = coord.room_thermostat_type

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -174,6 +174,14 @@ class TestCoordinatorProperties:
         thermostat_type = coord.room_thermostat_type
         assert thermostat_type == LuxRoomThermostatType.smart
 
+        coord = _make_coordinator(parameters={"ID_Einst_RFVEinb_akt": 99})
+        thermostat_type = coord.room_thermostat_type
+        assert thermostat_type is None
+
+        coord = _make_coordinator(parameters={"ID_Einst_RFVEinb_akt": "unknown"})
+        thermostat_type = coord.room_thermostat_type
+        assert thermostat_type is None
+
 
 # ===========================================================================
 # device_key_active


### PR DESCRIPTION
- Add Room thermostat type detection. Type is for now logged in logging.
- Differentiates thermostats based on this:

Thermostat == Smart:
- Heating changes P1148 as before
- Cooling now also changes P1148, instead of outside temperature threshold. This addressed #541

Thermostat != Smart:
- Heating: now changes the traget temperature correction factor [-5.0C , +5.0C] , because changing P1148 only seems to work for smart thermostats, see #491
- Cooling still changes outside temperature threshold.