### PR TITLE
feat(config_flow): ✨ add reconfigure flow and simplify options flow

### DIFF
--- a/custom_components/luxtronik2/config_flow.py
+++ b/custom_components/luxtronik2/config_flow.py
@@ -367,6 +367,58 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             LOGGER.error("Unhandled DHCP discovery error", exc_info=err)
             return self.async_abort(reason="unknown")
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the integration."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            entry_data = reconfigure_entry.data
+            config = self._build_config(
+                user_input[CONF_HOST],
+                int(user_input[CONF_PORT]),
+                float(
+                    user_input.get(
+                        CONF_TIMEOUT,
+                        entry_data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+                    )
+                ),
+                int(
+                    user_input.get(
+                        CONF_MAX_DATA_LENGTH,
+                        entry_data.get(CONF_MAX_DATA_LENGTH, DEFAULT_MAX_DATA_LENGTH),
+                    )
+                ),
+            )
+
+            try:
+                coordinator = await connect_and_get_coordinator(self.hass, config)
+            except LuxtronikConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                await self.async_set_unique_id(coordinator.unique_id)
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    data_updates=config,
+                )
+
+        form_defaults = {**reconfigure_entry.data, **(user_input or {})}
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=build_user_data_schema(
+                host=form_defaults.get(CONF_HOST, DEFAULT_HOST),
+                port=form_defaults.get(CONF_PORT, DEFAULT_PORT),
+                timeout=form_defaults.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+                max_data_length=form_defaults.get(
+                    CONF_MAX_DATA_LENGTH, DEFAULT_MAX_DATA_LENGTH
+                ),
+            ),
+            errors=errors,
+        )
+
     @staticmethod
     @callback
     def async_get_options_flow(  # pragma: no cover
@@ -397,67 +449,28 @@ class LuxtronikOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the user options step."""
-        errors: dict[str, str] = {}
-
-        current_host = self.config_entry.data.get(CONF_HOST, DEFAULT_HOST)
-        current_port = self.config_entry.data.get(CONF_PORT, DEFAULT_PORT)
-        current_indoor_temp = self._get_value(CONF_HA_SENSOR_INDOOR_TEMPERATURE)
-
         try:
             if user_input is not None:
-                host = user_input.get(CONF_HOST, current_host)
-                port = int(user_input.get(CONF_PORT, current_port))
+                new_options = dict(self.options)
+                value = user_input.get(CONF_HA_SENSOR_INDOOR_TEMPERATURE)
+                if value:
+                    new_options[CONF_HA_SENSOR_INDOOR_TEMPERATURE] = value
+                elif (
+                    CONF_HA_SENSOR_INDOOR_TEMPERATURE in new_options
+                    or CONF_HA_SENSOR_INDOOR_TEMPERATURE in self.config_entry.data
+                ):
+                    new_options[CONF_HA_SENSOR_INDOOR_TEMPERATURE] = None
 
-                config = {
-                    CONF_HOST: host,
-                    CONF_PORT: port,
-                    CONF_TIMEOUT: self.config_entry.data.get(
-                        CONF_TIMEOUT, DEFAULT_TIMEOUT
-                    ),
-                    CONF_MAX_DATA_LENGTH: self.config_entry.data.get(
-                        CONF_MAX_DATA_LENGTH, DEFAULT_MAX_DATA_LENGTH
-                    ),
-                }
+                return self.async_create_entry(title="", data=new_options)
 
-                try:
-                    await connect_and_get_coordinator(self.hass, config)
-                except LuxtronikConnectionError:
-                    errors["base"] = "cannot_connect"
-                else:
-                    new_options = dict(self.options)
-                    value = user_input.get(CONF_HA_SENSOR_INDOOR_TEMPERATURE)
-                    if value:
-                        new_options[CONF_HA_SENSOR_INDOOR_TEMPERATURE] = value
-                    elif CONF_HA_SENSOR_INDOOR_TEMPERATURE in new_options:
-                        new_options[CONF_HA_SENSOR_INDOOR_TEMPERATURE] = None
+            current_indoor_temp = self._get_value(CONF_HA_SENSOR_INDOOR_TEMPERATURE)
 
-                    self.hass.config_entries.async_update_entry(
-                        self.config_entry,
-                        data=self.config_entry.data | user_input,
-                        options=new_options,
-                    )
-                    await self.hass.config_entries.async_reload(
-                        self.config_entry.entry_id
-                    )
-                    return self.async_create_entry(title="", data={})
-
-                # Connection failed — keep user's input for re-display
-                current_host = host
-                current_port = port
-                current_indoor_temp = user_input.get(
-                    CONF_HA_SENSOR_INDOOR_TEMPERATURE, current_indoor_temp
-                )
-
-            name = f"{current_host}:{current_port}"
             return self.async_show_form(
                 step_id="user",
                 data_schema=build_options_schema(
-                    host=current_host,
-                    port=current_port,
                     current_value=current_indoor_temp,
                 ),
-                description_placeholders={"name": name},
-                errors=errors,
+                description_placeholders={"name": self.config_entry.title},
             )
 
         except Exception as err:

--- a/custom_components/luxtronik2/schema_helper.py
+++ b/custom_components/luxtronik2/schema_helper.py
@@ -29,14 +29,10 @@ def build_user_data_schema(
 
 
 def build_options_schema(
-    host: str = DEFAULT_HOST,
-    port: int = DEFAULT_PORT,
     current_value: str | None = None,
 ) -> vol.Schema:
     return vol.Schema(
         {
-            vol.Required(CONF_HOST, default=host): str,
-            vol.Required(CONF_PORT, default=port): int,
             vol.Optional(
                 CONF_HA_SENSOR_INDOOR_TEMPERATURE,
                 default=current_value,

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -929,6 +929,8 @@
         "abort": {
             "cannot_connect": "Nepoda\u0159ilo se p\u0159ipojit k Luxtronik na adrese {host}.\\nChyba: {connect_error}",
             "already_configured": "Toto za\u0159\u00edzen\u00ed je ji\u017e nakonfigurov\u00e1no.",
+            "reconfigure_successful": "Konfigurace \u00fasp\u011b\u0161n\u011b aktualizov\u00e1na.",
+            "unique_id_mismatch": "Za\u0159\u00edzen\u00ed na nov\u00e9 adrese m\u00e1 jinou identitu ne\u017e aktu\u00e1ln\u011b nakonfigurovan\u00e9 za\u0159\u00edzen\u00ed.",
             "already_in_progress": "Konfigura\u010dn\u00ed proces ji\u017e prob\u00edh\u00e1.",
             "devices_configured": "V\u0161echna vybran\u00e1 za\u0159\u00edzen\u00ed jsou ji\u017e nakonfigurov\u00e1na.",
             "options_error": "P\u0159i na\u010d\u00edt\u00e1n\u00ed mo\u017enost\u00ed do\u0161lo k chyb\u011b.",
@@ -939,6 +941,7 @@
         "error": {
             "address": "Neplatn\u00e1 vzd\u00e1len\u00e1 adresa. Adresa mus\u00ed b\u00fdt IP adresa nebo rozpoznateln\u00fd n\u00e1zev hostitele.",
             "address_in_use": "Zvolen\u00fd port je ji\u017e v tomto syst\u00e9mu pou\u017e\u00edv\u00e1n.",
+            "cannot_connect": "P\u0159ipojen\u00ed se nezda\u0159ilo. Zkontrolujte pros\u00edm host a port.",
             "unknown": "Neo\u010dek\u00e1van\u00e1 chyba"
         },
         "step": {
@@ -981,6 +984,22 @@
                     "control_mode_home_assistant": "Kdy\u017e je termostat Home Assistant v ne\u010dinn\u00e9m stavu, stav vypnut\u00ed je hl\u00e1\u0161en Luxtroniku a Luxtronik nem\u016f\u017ee tento prvek spustit.",
                     "ha_sensor_prefix": "D\u016fle\u017eit\u00e9 p\u0159i pou\u017eit\u00ed v\u00edce tepeln\u00fdch \u010derpadel. V p\u0159\u00edpad\u011b jednoho lze jednodu\u0161e pou\u017e\u00edt 'luxtronik'."
                 }
+            },
+            "reconfigure": {
+                "title": "P\u0159ekonfigurovat p\u0159ipojen\u00ed Luxtronik",
+                "description": "Aktualizujte nastaven\u00ed p\u0159ipojen\u00ed pro tepeln\u00e9 \u010derpadlo Luxtronik.",
+                "data": {
+                    "host": "Host",
+                    "port": "S\u00ed\u0165ov\u00fd port",
+                    "timeout": "\u010casov\u00fd limit s\u00ed\u0165ov\u00e9ho socketu (s)",
+                    "max_data_length": "Maxim\u00e1ln\u00ed d\u00e9lka datov\u00e9ho paketu"
+                },
+                "data_description": {
+                    "host": "N\u00e1zev hostitele nebo IP adresa",
+                    "port": "Obvykle 8889 nebo 8888",
+                    "timeout": "Pokud je s\u00ed\u0165 nebo tepeln\u00e9 \u010derpadlo pomal\u00e9, m\u016f\u017eete upravit timeout.",
+                    "max_data_length": "Pokud je s\u00ed\u0165 nebo tepeln\u00e9 \u010derpadlo pomal\u00e9, m\u016f\u017eete upravit d\u00e9lku datov\u00e9ho paketu."
+                }
             }
         }
     },
@@ -990,23 +1009,12 @@
                 "title": "Nakonfigurujte mo\u017enosti pro {name}",
                 "description": "Nastaven\u00ed pro tepeln\u00e9 \u010derpadlo Luxtronik {name}.",
                 "data": {
-                    "host": "Adresa",
-                    "port": "S\u00ed\u0165ov\u00fd port",
-                    "ha_sensor_indoor_temperature": "ID senzoru vnit\u0159n\u00ed teploty",
-                    "control_mode_home_assistant": "Experiment\u00e1ln\u00ed!: \u0158\u00edzen\u00ed stavu termostatu pomoc\u00ed Home Assistant.",
-                    "ha_sensor_prefix": "P\u0159edpona pro ID entit"
+                    "ha_sensor_indoor_temperature": "ID senzoru vnit\u0159n\u00ed teploty"
                 },
                 "data_description": {
-                    "host": "N\u00e1zev hostitele nebo IP adresa",
-                    "port": "Obvykle 8889 nebo 8888",
-                    "ha_sensor_indoor_temperature": "Termostat pro \u0159\u00edzen\u00ed vyt\u00e1p\u011bn\u00ed je vytvo\u0159en v Home Assistant. Skute\u010dn\u00e1 teplota je nastavena senzorem Home Assistant.\nPokud je Luxtronik p\u0159ipojen k hardwarov\u00e9mu pokojov\u00e9mu termostatu, ponechte toto pole pr\u00e1zdn\u00e9.",
-                    "control_mode_home_assistant": "Kdy\u017e je termostat Home Assistant v ne\u010dinn\u00e9m stavu, stav vypnut\u00ed je hl\u00e1\u0161en Luxtroniku a Luxtronik nem\u016f\u017ee tento prvek spustit.",
-                    "ha_sensor_prefix": "D\u016fle\u017eit\u00e9 p\u0159i pou\u017eit\u00ed v\u00edce tepeln\u00fdch \u010derpadel. V p\u0159\u00edpad\u011b jednoho lze jednodu\u0161e pou\u017e\u00edt 'luxtronik'."
+                    "ha_sensor_indoor_temperature": "Termostat pro \u0159\u00edzen\u00ed vyt\u00e1p\u011bn\u00ed je vytvo\u0159en v Home Assistant. Skute\u010dn\u00e1 teplota je nastavena senzorem Home Assistant.\nPokud je Luxtronik p\u0159ipojen k hardwarov\u00e9mu pokojov\u00e9mu termostatu, ponechte toto pole pr\u00e1zdn\u00e9."
                 }
             }
-        },
-        "error": {
-            "cannot_connect": "Nepoda\u0159ilo se p\u0159ipojit k tepeln\u00e9mu \u010derpadlu Luxtronik. Zkontrolujte pros\u00edm hostitele a port."
         }
     },
     "exceptions": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -915,6 +915,8 @@
         "abort": {
             "cannot_connect": "Verbindung zu Luxtronik unter {host} fehlgeschlagen.\\nFehler: {connect_error}",
             "already_configured": "Dieses Ger\u00e4t ist bereits konfiguriert.",
+            "reconfigure_successful": "Konfiguration erfolgreich aktualisiert.",
+            "unique_id_mismatch": "Das Ger\u00e4t an der neuen Adresse hat eine andere Identit\u00e4t als das aktuell konfigurierte Ger\u00e4t.",
             "already_in_progress": "Der Konfigurationsvorgang ist bereits aktiv.",
             "devices_configured": "Alle ausgew\u00e4hlten Ger\u00e4te sind bereits konfiguriert.",
             "options_error": "Beim Laden der Optionen ist ein Fehler aufgetreten.",
@@ -925,6 +927,7 @@
         "error": {
             "address": "Ung\u00fcltige Remote-Adresse. Die Adresse muss eine IP-Adresse oder ein aufl\u00f6sbarer Hostname sein.",
             "address_in_use": "Der gew\u00e4hlte Port wird bereits auf diesem System verwendet.",
+            "cannot_connect": "Verbindung fehlgeschlagen. Bitte Host und Port \u00fcberpr\u00fcfen.",
             "unknown": "Unerwarteter Fehler"
         },
         "step": {
@@ -967,6 +970,22 @@
                     "control_mode_home_assistant": "Wenn sich das Home Assistant-Thermostat im Leerlauf befindet, wird der Aus-Zustand an Luxtronik gemeldet und Luxtronik kann dieses Element nicht starten.",
                     "ha_sensor_prefix": "Wichtig bei Verwendung mehrerer W\u00e4rmepumpen. Bei einer einzelnen kann einfach 'luxtronik' verwendet werden."
                 }
+            },
+            "reconfigure": {
+                "title": "Luxtronik-Verbindung neu konfigurieren",
+                "description": "Aktualisieren Sie die Verbindungseinstellungen f\u00fcr die Luxtronik-W\u00e4rmepumpe.",
+                "data": {
+                    "host": "Host",
+                    "port": "Netzwerk-Port",
+                    "timeout": "Netzwerk-Socket-Timeout (Sek.)",
+                    "max_data_length": "Maximale Datenpaketl\u00e4nge"
+                },
+                "data_description": {
+                    "host": "Hostname oder IP-Adresse",
+                    "port": "Normalerweise 8889 oder 8888",
+                    "timeout": "Wenn das Netzwerk oder die W\u00e4rmepumpe langsam ist, k\u00f6nnen Sie den Timeout anpassen.",
+                    "max_data_length": "Wenn das Netzwerk oder die W\u00e4rmepumpe langsam ist, k\u00f6nnen Sie die Datenpaketl\u00e4nge anpassen."
+                }
             }
         }
     },
@@ -976,23 +995,12 @@
                 "title": "Optionen f\u00fcr {name} konfigurieren",
                 "description": "Einstellungen f\u00fcr die Luxtronik-W\u00e4rmepumpe {name}.",
                 "data": {
-                    "host": "Host",
-                    "port": "Netzwerk-Port",
-                    "ha_sensor_indoor_temperature": "Sensor-ID f\u00fcr die Raumtemperatur",
-                    "control_mode_home_assistant": "Experimentell!: Thermostatstatus \u00fcber Home Assistant steuern.",
-                    "ha_sensor_prefix": "Pr\u00e4fix f\u00fcr Entity-IDs"
+                    "ha_sensor_indoor_temperature": "Sensor-ID f\u00fcr die Raumtemperatur"
                 },
                 "data_description": {
-                    "host": "Hostname oder IP-Adresse",
-                    "port": "Normalerweise 8889 oder 8888",
-                    "ha_sensor_indoor_temperature": "Ein Thermostat zur Heizungssteuerung wird in Home Assistant erstellt. Die tats\u00e4chliche Temperatur wird von einem Home Assistant-Sensor gesetzt.\nWenn Luxtronik mit einem Hardware-Raumthermostat verbunden ist, sollte dieses Feld leer bleiben.",
-                    "control_mode_home_assistant": "Wenn sich das Home Assistant-Thermostat im Leerlauf befindet, wird der Aus-Zustand an Luxtronik gemeldet und Luxtronik kann dieses Element nicht starten.",
-                    "ha_sensor_prefix": "Wichtig bei Verwendung mehrerer W\u00e4rmepumpen. Bei einer einzelnen kann einfach 'luxtronik' verwendet werden."
+                    "ha_sensor_indoor_temperature": "Ein Thermostat zur Heizungssteuerung wird in Home Assistant erstellt. Die tats\u00e4chliche Temperatur wird von einem Home Assistant-Sensor gesetzt.\nWenn Luxtronik mit einem Hardware-Raumthermostat verbunden ist, sollte dieses Feld leer bleiben."
                 }
             }
-        },
-        "error": {
-            "cannot_connect": "Verbindung zur Luxtronik-W\u00e4rmepumpe fehlgeschlagen. Bitte Host und Port \u00fcberpr\u00fcfen."
         }
     },
     "exceptions": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -663,6 +663,8 @@
         "abort": {
             "cannot_connect": "Failed to connect to Luxtronik at {host}.\\nError: {connect_error}",
             "already_configured": "This device is already configured.",
+            "reconfigure_successful": "Configuration updated successfully.",
+            "unique_id_mismatch": "The device at the new address has a different identity than the currently configured device.",
             "already_in_progress": "The configuration flow is already in progress.",
             "devices_configured": "All selected devices are already configured.",
             "options_error": "An error occurred while loading the options.",
@@ -673,6 +675,7 @@
         "error": {
             "address": "Invalid remote-address insert. The address has to be an IP address or a resolvable hostname.",
             "address_in_use": "The chosen listen port is already in use on this system.",
+            "cannot_connect": "Failed to connect. Please check the host and port.",
             "unknown": "Unexpected error"
         },
         "step": {
@@ -715,6 +718,22 @@
                     "control_mode_home_assistant": "When the Home Assistant Thermostat is in the Idle state, the Off state is reported to Luxtronik and Luxtronik cannot start this item.",
                     "ha_sensor_prefix": "Important if several heat pumps are used.\nIn the case of a single one, 'luxtronik' can simply be used."
                 }
+            },
+            "reconfigure": {
+                "title": "Reconfigure Luxtronik connection",
+                "description": "Update the connection settings for the Luxtronik heat pump.",
+                "data": {
+                    "host": "Host",
+                    "port": "Network Port",
+                    "timeout": "Network socket timeout (Sec.)",
+                    "max_data_length": "Max data package length"
+                },
+                "data_description": {
+                    "host": "Hostname or IP address",
+                    "port": "Normally 8889 or 8888",
+                    "timeout": "If the network or the heatpump is slow, you can fine-tune the timeout.",
+                    "max_data_length": "If the network or the heatpump is slow, you can fine-tune the data package length."
+                }
             }
         }
     },
@@ -724,23 +743,12 @@
                 "title": "Configure options for {name}",
                 "description": "Settings for the Luxtronik heat pump {name}.",
                 "data": {
-                    "host": "Host",
-                    "port": "Network Port",
-                    "ha_sensor_indoor_temperature": "Sensor ID for the indoor temperature",
-                    "control_mode_home_assistant": "Experimental!: Control thermostat on/off status by Home Assistant.",
-                    "ha_sensor_prefix": "Prefix entity IDs"
+                    "ha_sensor_indoor_temperature": "Sensor ID for the indoor temperature"
                 },
                 "data_description": {
-                    "host": "Hostname or IP address",
-                    "port": "Normally 8889 or 8888",
-                    "ha_sensor_indoor_temperature": "A thermostat for heating control is created in Home Assistant. The actual temperature for this is set by a Home Assistant sensor.\nIf Luxtronik is connected to a hardware room thermostat, then this field should be left empty.",
-                    "control_mode_home_assistant": "When the Home Assistant Thermostat is in the Idle state, the Off state is reported to Luxtronik and Luxtronik cannot start this item.",
-                    "ha_sensor_prefix": "Important if several heat pumps are used.\nIn the case of a single one, 'luxtronik' can simply be used."
+                    "ha_sensor_indoor_temperature": "A thermostat for heating control is created in Home Assistant. The actual temperature for this is set by a Home Assistant sensor.\nIf Luxtronik is connected to a hardware room thermostat, then this field should be left empty."
                 }
             }
-        },
-        "error": {
-            "cannot_connect": "Failed to connect to the Luxtronik heat pump. Please check the host and port."
         }
     },
     "exceptions": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -897,6 +897,8 @@
         "abort": {
             "cannot_connect": "De verbinding met Luxtronik op {host} is mislukt.\nFout: {connect_error}",
             "already_configured": "Dit apparaat is al geconfigureerd.",
+            "reconfigure_successful": "Configuratie succesvol bijgewerkt.",
+            "unique_id_mismatch": "Het apparaat op het nieuwe adres heeft een andere identiteit dan het momenteel geconfigureerde apparaat.",
             "already_in_progress": "De configuratiestroom is al actief.",
             "devices_configured": "Alle geselecteerde apparaten zijn al geconfigureerd.",
             "options_error": "Er is een fout opgetreden bij het laden van de opties.",
@@ -907,6 +909,7 @@
         "error": {
             "address": "Ongeldig extern adres. Het adres moet een IP-adres of een oplosbare hostnaam zijn.",
             "address_in_use": "De gekozen poort is al in gebruik op dit systeem.",
+            "cannot_connect": "Verbinding mislukt. Controleer de host en poort.",
             "unknown": "Onverwachte fout"
         },
         "step": {
@@ -949,6 +952,22 @@
                     "control_mode_home_assistant": "Wanneer de Home Assistant-thermostaat in de idle-status staat, wordt de uit-status aan Luxtronik gemeld en kan Luxtronik dit item niet starten.",
                     "ha_sensor_prefix": "Belangrijk bij gebruik van meerdere warmtepompen. Bij \u00e9\u00e9n enkele kan gewoon 'luxtronik' worden gebruikt."
                 }
+            },
+            "reconfigure": {
+                "title": "Luxtronik-verbinding opnieuw configureren",
+                "description": "Werk de verbindingsinstellingen bij voor de Luxtronik warmtepomp.",
+                "data": {
+                    "host": "Host",
+                    "port": "Netwerkpoort",
+                    "timeout": "Netwerk-socket-timeout (sec.)",
+                    "max_data_length": "Maximale datapakketlengte"
+                },
+                "data_description": {
+                    "host": "Hostname of IP-adres",
+                    "port": "Normaal 8889 of 8888",
+                    "timeout": "Als het netwerk of de warmtepomp langzaam reageert kan de timeout hierop aangepast worden.",
+                    "max_data_length": "Als het netwerk of de warmtepomp langzaam reageert kan de datapakketlengte aangepast worden."
+                }
             }
         }
     },
@@ -958,14 +977,10 @@
                 "title": "Opties configureren voor {name}",
                 "description": "Instellingen voor de Luxtronik warmtepomp {name}.",
                 "data": {
-                    "ha_sensor_indoor_temperature": "Sensor-ID voor de binnentemperatuur",
-                    "control_mode_home_assistant": "Experimenteel!: Thermostaatstatus regelen via Home Assistant.",
-                    "ha_sensor_prefix": "Voorvoegsel voor entiteit-ID's"
+                    "ha_sensor_indoor_temperature": "Sensor-ID voor de binnentemperatuur"
                 },
                 "data_description": {
-                    "ha_sensor_indoor_temperature": "Een thermostaat voor verwarmingsregeling wordt aangemaakt in Home Assistant. De werkelijke temperatuur wordt ingesteld door een Home Assistant-sensor.\nAls Luxtronik is verbonden met een hardware kamerthermostaat, laat dit veld dan leeg.",
-                    "control_mode_home_assistant": "Wanneer de Home Assistant-thermostaat in de idle-status staat, wordt de uit-status aan Luxtronik gemeld en kan Luxtronik dit item niet starten.",
-                    "ha_sensor_prefix": "Belangrijk bij gebruik van meerdere warmtepompen. Bij \u00e9\u00e9n enkele kan gewoon 'luxtronik' worden gebruikt."
+                    "ha_sensor_indoor_temperature": "Een thermostaat voor verwarmingsregeling wordt aangemaakt in Home Assistant. De werkelijke temperatuur wordt ingesteld door een Home Assistant-sensor.\nAls Luxtronik is verbonden met een hardware kamerthermostaat, laat dit veld dan leeg."
                 }
             }
         }

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -891,6 +891,8 @@
         "abort": {
             "cannot_connect": "Nie uda\u0142o si\u0119 po\u0142\u0105czy\u0107 z Luxtronik pod adresem {host}.\\nB\u0142\u0105d: {connect_error}",
             "already_configured": "To urz\u0105dzenie jest ju\u017c skonfigurowane.",
+            "reconfigure_successful": "Konfiguracja zosta\u0142a pomy\u015blnie zaktualizowana.",
+            "unique_id_mismatch": "Urz\u0105dzenie pod nowym adresem ma inn\u0105 to\u017csamo\u015b\u0107 ni\u017c aktualnie skonfigurowane urz\u0105dzenie.",
             "already_in_progress": "Proces konfiguracji jest ju\u017c w toku.",
             "devices_configured": "Wszystkie wybrane urz\u0105dzenia s\u0105 ju\u017c skonfigurowane.",
             "options_error": "Wyst\u0105pi\u0142 b\u0142\u0105d podczas \u0142adowania opcji.",
@@ -901,6 +903,7 @@
         "error": {
             "address": "Nieprawid\u0142owy adres zdalny. Adres musi by\u0107 adresem IP lub rozpoznawaln\u0105 nazw\u0105 hosta.",
             "address_in_use": "Wybrany port jest ju\u017c u\u017cywany w tym systemie.",
+            "cannot_connect": "Po\u0142\u0105czenie nie powiod\u0142o si\u0119. Sprawd\u017a host i port.",
             "unknown": "Nieoczekiwany b\u0142\u0105d"
         },
         "step": {
@@ -943,6 +946,22 @@
                     "control_mode_home_assistant": "Gdy termostat Home Assistant jest w stanie bezczynno\u015bci, stan wy\u0142\u0105czenia jest zg\u0142aszany do Luxtronik i Luxtronik nie mo\u017ce uruchomi\u0107 tego elementu.",
                     "ha_sensor_prefix": "Wa\u017cne przy u\u017cyciu wielu pomp ciep\u0142a. W przypadku jednej mo\u017cna po prostu u\u017cy\u0107 'luxtronik'."
                 }
+            },
+            "reconfigure": {
+                "title": "Rekonfiguracja po\u0142\u0105czenia Luxtronik",
+                "description": "Zaktualizuj ustawienia po\u0142\u0105czenia dla pompy ciep\u0142a Luxtronik.",
+                "data": {
+                    "host": "Host",
+                    "port": "Port sieciowy",
+                    "timeout": "Limit czasu gniazda sieciowego (s)",
+                    "max_data_length": "Maksymalna d\u0142ugo\u015b\u0107 pakietu danych"
+                },
+                "data_description": {
+                    "host": "Nazwa hosta lub adres IP",
+                    "port": "Zwykle 8889 lub 8888",
+                    "timeout": "Je\u015bli sie\u0107 lub pompa ciep\u0142a dzia\u0142a wolno, mo\u017cna dostosowa\u0107 limit czasu.",
+                    "max_data_length": "Je\u015bli sie\u0107 lub pompa ciep\u0142a dzia\u0142a wolno, mo\u017cna dostosowa\u0107 d\u0142ugo\u015b\u0107 pakietu danych."
+                }
             }
         }
     },
@@ -952,14 +971,10 @@
                 "title": "Skonfiguruj opcje dla {name}",
                 "description": "Ustawienia dla pompy ciep\u0142a Luxtronik {name}.",
                 "data": {
-                    "ha_sensor_indoor_temperature": "ID czujnika temperatury wewn\u0119trznej",
-                    "control_mode_home_assistant": "Eksperymentalne!: Sterowanie statusem termostatu przez Home Assistant.",
-                    "ha_sensor_prefix": "Prefiks dla identyfikator\u00f3w encji"
+                    "ha_sensor_indoor_temperature": "ID czujnika temperatury wewn\u0119trznej"
                 },
                 "data_description": {
-                    "ha_sensor_indoor_temperature": "Termostat do sterowania ogrzewaniem jest tworzony w Home Assistant. Rzeczywista temperatura jest ustawiana przez czujnik Home Assistant.\nJe\u015bli Luxtronik jest pod\u0142\u0105czony do sprz\u0119towego termostatu pokojowego, pozostaw to pole puste.",
-                    "control_mode_home_assistant": "Gdy termostat Home Assistant jest w stanie bezczynno\u015bci, stan wy\u0142\u0105czenia jest zg\u0142aszany do Luxtronik i Luxtronik nie mo\u017ce uruchomi\u0107 tego elementu.",
-                    "ha_sensor_prefix": "Wa\u017cne przy u\u017cyciu wielu pomp ciep\u0142a. W przypadku jednej mo\u017cna po prostu u\u017cy\u0107 'luxtronik'."
+                    "ha_sensor_indoor_temperature": "Termostat do sterowania ogrzewaniem jest tworzony w Home Assistant. Rzeczywista temperatura jest ustawiana przez czujnik Home Assistant.\nJe\u015bli Luxtronik jest pod\u0142\u0105czony do sprz\u0119towego termostatu pokojowego, pozostaw to pole puste."
                 }
             }
         }

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -42,6 +42,7 @@ from custom_components.luxtronik2.const import (
     DeviceKey,
     LuxMode,
     LuxOperationMode,
+    LuxRoomThermostatType,
 )
 
 
@@ -222,6 +223,25 @@ class TestClimateUnavailableKeys:
                 MagicMock(), entry, lambda entities, update: added.extend(entities)
             )
             mock_logger.debug.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_smart_thermostat_branch(self):
+        """When room_thermostat_type is smart, THERMOSTATS_SMART is used."""
+        from custom_components.luxtronik2.climate import async_setup_entry
+
+        coord = _mock_coordinator(make_coordinator_data())
+        coord.room_thermostat_type = LuxRoomThermostatType.smart
+        entry = MagicMock()
+        entry.runtime_data = coord
+
+        added = []
+        with patch(
+            "custom_components.luxtronik2.climate.key_exists", return_value=True
+        ):
+            await async_setup_entry(
+                MagicMock(), entry, lambda entities, update: added.extend(entities)
+            )
+        assert len(added) == len(THERMOSTATS_SMART)
 
 
 # ===========================================================================

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,7 +1,8 @@
-"""Tests for config_flow.py — ConfigFlow and OptionsFlow."""
+"""Tests for config_flow.py — ConfigFlow, OptionsFlow, and ReconfigureFlow."""
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
@@ -440,62 +441,56 @@ class TestOptionsFlow:
         flow.async_show_form.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_step_user_connection_error(self):
-        flow = _make_options_flow()
-        flow.hass = MagicMock()
-        flow.async_show_form = MagicMock(return_value={"type": "form"})
-        err = LuxtronikConnectionError("1.2.3.4", 8889, Exception("refused"))
-        with patch(
-            "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
-            new_callable=AsyncMock,
-            side_effect=err,
-        ):
-            await flow.async_step_user({CONF_HOST: "1.2.3.4", CONF_PORT: 8889})
-        flow.async_show_form.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_step_user_success(self):
+    async def test_step_user_saves_indoor_temp(self):
         entry = MagicMock()
         entry.data = {CONF_HOST: "1.2.3.4", CONF_PORT: 8889}
         entry.options = {}
-        entry.entry_id = "test"
+        entry.title = "Test HP"
         flow = _make_options_flow(entry)
         flow.hass = MagicMock()
-        flow.hass.config_entries.async_reload = AsyncMock()
         flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
-        coord = _mock_coordinator()
-        with patch(
-            "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
-            new_callable=AsyncMock,
-            return_value=coord,
-        ):
-            await flow.async_step_user({CONF_HOST: "1.2.3.4", CONF_PORT: 8889})
+        await flow.async_step_user(
+            {CONF_HA_SENSOR_INDOOR_TEMPERATURE: "sensor.indoor_temp"}
+        )
         flow.async_create_entry.assert_called_once()
+        call_kwargs = flow.async_create_entry.call_args[1]
+        assert (
+            call_kwargs["data"][CONF_HA_SENSOR_INDOOR_TEMPERATURE]
+            == "sensor.indoor_temp"
+        )
 
     @pytest.mark.asyncio
-    async def test_step_user_with_indoor_temp(self):
+    async def test_step_user_clears_indoor_temp(self):
         entry = MagicMock()
         entry.data = {CONF_HOST: "1.2.3.4", CONF_PORT: 8889}
-        entry.options = {}
-        entry.entry_id = "test"
+        entry.options = {CONF_HA_SENSOR_INDOOR_TEMPERATURE: "sensor.old"}
+        entry.title = "Test HP"
         flow = _make_options_flow(entry)
         flow.hass = MagicMock()
-        flow.hass.config_entries.async_reload = AsyncMock()
         flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
-        coord = _mock_coordinator()
-        with patch(
-            "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
-            new_callable=AsyncMock,
-            return_value=coord,
-        ):
-            await flow.async_step_user(
-                {
-                    CONF_HOST: "1.2.3.4",
-                    CONF_PORT: 8889,
-                    CONF_HA_SENSOR_INDOOR_TEMPERATURE: "sensor.indoor_temp",
-                }
-            )
+        await flow.async_step_user({})
         flow.async_create_entry.assert_called_once()
+        call_kwargs = flow.async_create_entry.call_args[1]
+        assert call_kwargs["data"].get(CONF_HA_SENSOR_INDOOR_TEMPERATURE) is None
+
+    @pytest.mark.asyncio
+    async def test_step_user_clears_legacy_indoor_temp_from_data(self):
+        """Clearing works even when the value only exists in config_entry.data."""
+        entry = MagicMock()
+        entry.data = {
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 8889,
+            CONF_HA_SENSOR_INDOOR_TEMPERATURE: "sensor.legacy",
+        }
+        entry.options = {}
+        entry.title = "Test HP"
+        flow = _make_options_flow(entry)
+        flow.hass = MagicMock()
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+        await flow.async_step_user({})
+        flow.async_create_entry.assert_called_once()
+        call_kwargs = flow.async_create_entry.call_args[1]
+        assert call_kwargs["data"][CONF_HA_SENSOR_INDOOR_TEMPERATURE] is None
 
     @pytest.mark.asyncio
     async def test_step_user_exception_aborts(self):
@@ -508,7 +503,7 @@ class TestOptionsFlow:
 
 
 # ===========================================================================
-# config_flow.py — indoor_temp None reset (line 432)
+# config_flow.py — indoor_temp None reset
 # ===========================================================================
 
 _ENTRY_DATA = {
@@ -523,25 +518,126 @@ _ENTRY_DATA = {
 class TestConfigFlowIndoorTempReset:
     @pytest.mark.asyncio
     async def test_indoor_temp_reset_to_none(self):
-        handler = MagicMock(spec=LuxtronikOptionsFlowHandler)
-        handler.options = {CONF_HA_SENSOR_INDOOR_TEMPERATURE: "sensor.old"}
-        handler.config_entry = MagicMock()
-        handler.config_entry.data = _ENTRY_DATA.copy()
-        handler.config_entry.entry_id = "test_id"
-        handler.hass = MagicMock()
-        handler.hass.config_entries.async_reload = AsyncMock()
+        entry = MagicMock()
+        entry.data = _ENTRY_DATA.copy()
+        entry.options = {CONF_HA_SENSOR_INDOOR_TEMPERATURE: "sensor.old"}
+        entry.title = "Test HP"
+        flow = _make_options_flow(entry)
+        flow.hass = MagicMock()
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
 
-        user_input = {CONF_HOST: "192.168.1.100", CONF_PORT: DEFAULT_PORT}
+        user_input: dict[str, Any] = {}
+        await flow.async_step_user(user_input)
 
+        flow.async_create_entry.assert_called_once()
+        call_kwargs = flow.async_create_entry.call_args[1]
+        assert call_kwargs["data"].get(CONF_HA_SENSOR_INDOOR_TEMPERATURE) is None
+
+
+# ===========================================================================
+# async_step_reconfigure
+# ===========================================================================
+
+
+class TestAsyncStepReconfigure:
+    @pytest.mark.asyncio
+    async def test_no_input_shows_form(self):
+        flow = LuxtronikFlowHandler()
+        entry = MagicMock()
+        entry.data = {
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 8889,
+            CONF_TIMEOUT: DEFAULT_TIMEOUT,
+            CONF_MAX_DATA_LENGTH: DEFAULT_MAX_DATA_LENGTH,
+        }
+        flow._get_reconfigure_entry = MagicMock(return_value=entry)
+        flow.async_show_form = MagicMock(return_value={"type": "form"})
+        await flow.async_step_reconfigure(None)
+        flow.async_show_form.assert_called_once()
+        assert flow.async_show_form.call_args[1]["step_id"] == "reconfigure"
+
+    @pytest.mark.asyncio
+    async def test_connection_error_shows_form_with_error(self):
+        flow = LuxtronikFlowHandler()
+        flow.hass = MagicMock()
+        entry = MagicMock()
+        entry.data = {
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 8889,
+            CONF_TIMEOUT: DEFAULT_TIMEOUT,
+            CONF_MAX_DATA_LENGTH: DEFAULT_MAX_DATA_LENGTH,
+        }
+        flow._get_reconfigure_entry = MagicMock(return_value=entry)
+        flow.async_show_form = MagicMock(return_value={"type": "form"})
+        err = LuxtronikConnectionError("5.6.7.8", 8889, Exception("refused"))
+        user_input = {CONF_HOST: "5.6.7.8", CONF_PORT: 8889}
         with patch(
             "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
             new_callable=AsyncMock,
+            side_effect=err,
         ):
-            await LuxtronikOptionsFlowHandler.async_step_user(handler, user_input)
+            await flow.async_step_reconfigure(user_input)
+        flow.async_show_form.assert_called_once()
+        call_kwargs = flow.async_show_form.call_args[1]
+        assert call_kwargs["errors"] == {"base": "cannot_connect"}
+        # Form must preserve user's attempted values, not revert to entry data
+        schema = call_kwargs["data_schema"]
+        defaults = {k.schema: k.default() for k in schema.schema}
+        assert defaults[CONF_HOST] == "5.6.7.8"
 
-        handler.hass.config_entries.async_update_entry.assert_called_once()
-        call_kwargs = handler.hass.config_entries.async_update_entry.call_args
-        updated_options = call_kwargs.kwargs.get(
-            "options", call_kwargs[1].get("options", {})
+    @pytest.mark.asyncio
+    async def test_successful_reconfigure(self):
+        flow = LuxtronikFlowHandler()
+        flow.hass = MagicMock()
+        entry = MagicMock()
+        entry.data = {
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 8889,
+            CONF_TIMEOUT: DEFAULT_TIMEOUT,
+            CONF_MAX_DATA_LENGTH: DEFAULT_MAX_DATA_LENGTH,
+        }
+        flow._get_reconfigure_entry = MagicMock(return_value=entry)
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_mismatch = MagicMock()
+        flow.async_update_reload_and_abort = MagicMock(
+            return_value={"type": "abort", "reason": "reconfigure_successful"}
         )
-        assert updated_options.get(CONF_HA_SENSOR_INDOOR_TEMPERATURE) is None
+        coord = _mock_coordinator()
+        with patch(
+            "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
+            new_callable=AsyncMock,
+            return_value=coord,
+        ):
+            result = await flow.async_step_reconfigure(
+                {CONF_HOST: "5.6.7.8", CONF_PORT: 8889}
+            )
+        assert result["type"] == "abort"
+        assert result["reason"] == "reconfigure_successful"
+        flow.async_update_reload_and_abort.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unique_id_mismatch_aborts(self):
+        flow = LuxtronikFlowHandler()
+        flow.hass = MagicMock()
+        entry = MagicMock()
+        entry.data = {
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 8889,
+            CONF_TIMEOUT: DEFAULT_TIMEOUT,
+            CONF_MAX_DATA_LENGTH: DEFAULT_MAX_DATA_LENGTH,
+        }
+        flow._get_reconfigure_entry = MagicMock(return_value=entry)
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_mismatch = MagicMock(
+            side_effect=AbortFlow("unique_id_mismatch")
+        )
+        coord = _mock_coordinator()
+        with (
+            patch(
+                "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
+                new_callable=AsyncMock,
+                return_value=coord,
+            ),
+            pytest.raises(AbortFlow, match="unique_id_mismatch"),
+        ):
+            await flow.async_step_reconfigure({CONF_HOST: "5.6.7.8", CONF_PORT: 8889})

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -182,6 +182,15 @@ class TestCoordinatorProperties:
         thermostat_type = coord.room_thermostat_type
         assert thermostat_type is None
 
+    def test_room_thermostat_type_missing_param(self):
+        coord = _make_coordinator()  # No P0033 parameter
+        assert coord.room_thermostat_type is None
+
+    def test_room_thermostat_type_get_value_raises(self):
+        coord = _make_coordinator()
+        with patch.object(coord, "get_value", side_effect=Exception("boom")):
+            assert coord.room_thermostat_type is None
+
 
 # ===========================================================================
 # device_key_active

--- a/tests/test_schema_helper.py
+++ b/tests/test_schema_helper.py
@@ -60,8 +60,6 @@ class TestBuildOptionsSchema:
 
     def test_with_current_value(self):
         schema = build_options_schema(
-            host="10.0.0.1",
-            port=8888,
             current_value="sensor.indoor_temp",
         )
         assert isinstance(schema, vol.Schema)


### PR DESCRIPTION
### ✨ Summary

Add a dedicated **reconfigure flow** for connection parameters and simplify the **options flow** to only manage non-connection settings, fulfilling the [Integration Quality Scale `reconfiguration-flow` rule](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/reconfiguration-flow/) (Silver tier). This aligns with Home Assistant best practices — connection parameters belong in `config_entry.data`, user preferences in `config_entry.options`.

### 🐛 Problem

The options flow was modifying `config_entry.data` (host, port) — an anti-pattern in HA. Additionally, it triggered a **double reload**: once via explicit `async_reload()` call in the options flow, and again via the `update_listener` registered in `__init__.py`.

### ✅ Changes

#### Reconfigure flow (`config_flow.py`)

- ➕ Add `async_step_reconfigure` to `LuxtronikFlowHandler`
- 🔌 Validates connection before applying changes
- 🔑 Checks `unique_id` mismatch (prevents accidentally pointing to a different heat pump)
- 🔄 Uses `async_update_reload_and_abort` with `data_updates` for atomic update + reload
- 🩹 Preserve user's attempted values in form on connection error (per-key fallback to entry data)
- 🩹 Use entry data as fallback for `timeout`/`max_data_length` in `_build_config` (prevents resetting non-default values)

#### Options flow (`config_flow.py`)

- ♻️ Simplify `LuxtronikOptionsFlowHandler.async_step_user` — only manages `ha_sensor_indoor_temperature`
- 🗑️ Remove host/port fields and connection validation
- 🐛 Fix double reload — removed explicit `async_reload()`, relies on existing `update_listener`
- 🩹 Fix clearing indoor temp when legacy value exists only in `config_entry.data`

#### Schema helper (`schema_helper.py`)

- ♻️ Simplify `build_options_schema` — remove `host`/`port` parameters, keep only `current_value` for indoor temp selector

#### Translations

- 🌍 Add `config.step.reconfigure` and `config.abort.reconfigure_successful` to all 5 languages (en, de, cs, nl, pl)
- 🌍 Add `config.error.cannot_connect` for reconfigure form error to all 5 languages
- 🌍 Add `config.abort.unique_id_mismatch` to all 5 languages
- 🗑️ Remove obsolete `options.error.cannot_connect` from en and de
- ♻️ Simplify `options.step.user.data` — remove host/port, keep only `ha_sensor_indoor_temperature`

### ✅ Tests

#### In scope

- ➕ `TestAsyncStepReconfigure` (4 tests): no input shows form, connection error (verifies user input preserved), successful reconfigure, unique_id mismatch abort
- ♻️ `TestOptionsFlow`: updated to match simplified flow — `test_step_user_saves_indoor_temp`, `test_step_user_clears_indoor_temp`, `test_step_user_clears_legacy_indoor_temp_from_data`
- ♻️ `TestConfigFlowIndoorTempReset`: updated to use `_make_options_flow` directly

#### Out of scope (bonus coverage)

- ➕ `test_room_thermostat_type_missing_param` — covers `coordinator.py` line 364 (missing P0033 parameter)
- ➕ `test_room_thermostat_type_get_value_raises` — covers `coordinator.py` lines 373–374 (exception in `get_value`)
- ➕ `test_smart_thermostat_branch` — covers `climate.py` line 209 (`THERMOSTATS_SMART` branch)

These bring both `coordinator.py` and `climate.py` from 99% to **100% coverage**.

### 📦 Files changed

| File                                                | Change                                      |
| --------------------------------------------------- | ------------------------------------------- |
| `custom_components/luxtronik2/config_flow.py`       | add reconfigure step, simplify options flow |
| `custom_components/luxtronik2/schema_helper.py`     | simplify `build_options_schema`             |
| `custom_components/luxtronik2/translations/en.json` | reconfigure strings, remove options.error   |
| `custom_components/luxtronik2/translations/de.json` | reconfigure strings, remove options.error   |
| `custom_components/luxtronik2/translations/cs.json` | reconfigure strings                         |
| `custom_components/luxtronik2/translations/nl.json` | reconfigure strings                         |
| `custom_components/luxtronik2/translations/pl.json` | reconfigure strings                         |
| `tests/test_config_flow.py`                         | reconfigure + options flow tests            |
| `tests/test_schema_helper.py`                       | update options schema test                  |
| `tests/test_coordinator.py`                         | 2 coverage tests (bonus)                    |
| `tests/test_climate.py`                             | 1 coverage test (bonus)                     |

### 🧪 Verification

- ✅ 657 tests passing
- ✅ basedpyright: 0 errors
- ✅ ruff check + format: clean
- ✅ coordinator.py: 100% coverage
- ✅ climate.py: 100% coverage
- ✅ config_flow.py: 100% coverage
- ✅ schema_helper.py: 100% coverage
