### PR TITLE
Revert "chore(deps-dev): update pytest-asyncio requirement from >=1.3.0 to >=1.4.0"

### DIFF
--- a/tests/requirements-dev.txt
+++ b/tests/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest
-pytest-asyncio>=1.4.0
+pytest-asyncio>=1.3.0
 pytest-homeassistant-custom-component
 pytest-cov
 ruff


### PR DESCRIPTION
Reverts BenPru/luxtronik#637
Seems to break the tests