### PR TITLE
Add selector for parameter 119 (ID_Ba_Sw_akt)

### DIFF
--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -152,6 +152,16 @@ class LuxMode(StrEnum):
     holidays = "Holidays"
 
 
+class LuxPoolPVMode(StrEnum):
+    """Luxmodes off etc."""
+
+    automatic = "Automatic"
+    pv_off = "PV_Off"
+    pool_off = "Pool_Off"
+    pool_party = "Pool_Party"
+    pool_holidays = "Pool_Holidays"
+
+
 class LuxSmartGridStatus(StrEnum):
     """SmartGrid status based on EVU and EVU2 inputs."""
 
@@ -223,7 +233,6 @@ class LuxRoomThermostatType(Enum):
     """LuxMkTypes etc."""
 
     none = 0
-    # TODO: Validate types:
     rfv = 1
     rfv_k = 2
     rfv_dk = 3
@@ -386,7 +395,7 @@ class LuxParameter(StrEnum):
     P0108_MODE_COOLING = "parameters.ID_Einst_BA_Kuehl_akt"
     P0110_COOLING_OUTDOOR_TEMP_THRESHOLD = "parameters.ID_Einst_KuehlFreig_akt"
     P0111_HEATING_NIGHT_LOWERING_TO_TEMPERATURE = "parameters.ID_Einst_TAbsMin_akt"
-    P0119_MODE_POOL = "parameters.ID_Ba_Sw_akt"
+    P0119_MODE_PV = "parameters.ID_Ba_Sw_akt"
     P0122_SOLAR_PUMP_ON_DIFFERENCE_TEMPERATURE = "parameters.ID_Einst_TDC_Ein_akt"
     P0123_SOLAR_PUMP_OFF_DIFFERENCE_TEMPERATURE = "parameters.ID_Einst_TDC_Aus_akt"
     P0130_MIXING_CIRCUIT2_TYPE = "parameters.ID_Einst_MK2Typ_akt"
@@ -844,6 +853,7 @@ class SensorKey(StrEnum):
     PUMP_VENT_TIMER_H = "pump_vent_timer_h"
     PUMP_VENT_ACTIVE = "pump_vent_active"
     THERMAL_DESINFECTION_DAY = "thermal_desinfection_day"
+    PV_MODE_SELECTOR = "pv_mode_selector"
 
     AWAY_HEATING_STARTDATE = "away_heating_startdate"
     AWAY_HEATING_ENDDATE = "away_heating_enddate"

--- a/custom_components/luxtronik2/lux_overrides.py
+++ b/custom_components/luxtronik2/lux_overrides.py
@@ -8,6 +8,7 @@ from luxtronik.datatypes import (
     MixedCircuitMode,
     Percent,
     Percent2,
+    SelectionBase,
     Timestamp,
 )
 from luxtronik.parameters import Parameters
@@ -25,10 +26,25 @@ class MajorMinorVersion(Base):
         return f"{major}.{minor:02d}"
 
 
+class PoolPVMode(SelectionBase):
+    """PoolPVMode datatype, converts from and to a PoolPVMode"""
+
+    measurement_type = "selection"
+
+    codes = {
+        0: "Automatic",
+        1: "PV_Off",
+        2: "Pool_Party",
+        3: "Pool_Holidays",
+        4: "Pool_Off",
+    }
+
+
 # Define your new/updated custom parameters in a dictionary
 parameters_to_add_update = {
     6: Timestamp("ID_SU_FrkdHz", True),
     7: Timestamp("ID_SU_FrkdBw", True),
+    119: PoolPVMode("ID_Ba_Sw_akt", True),
     695: MixedCircuitMode("ID_Ba_Hz_MK1_akt", True),
     696: MixedCircuitMode("ID_Ba_Hz_MK2_akt", True),
     731: Timestamp("ID_SU_FstdHz", True),

--- a/custom_components/luxtronik2/select.py
+++ b/custom_components/luxtronik2/select.py
@@ -22,6 +22,7 @@ from .const import (
     DAY_SELECTOR_OPTIONS,
     LOGGER,
     DeviceKey,
+    LuxParameter as LP,
     LuxPoolPVMode,
     SensorKey as SK,
 )
@@ -226,6 +227,8 @@ class LuxtronikModeSelector(
         coordinator: LuxtronikCoordinator,
         description: LuxtronikSelectEntityDescription,
         device_info_ident: DeviceKey,
+        lux_parameter: str | LP | None = None,
+        options: list[str] | None = None,
     ) -> None:
         super().__init__(
             coordinator=coordinator,
@@ -233,8 +236,10 @@ class LuxtronikModeSelector(
             device_info_ident=device_info_ident,
         )
 
-        self._lux_parameter = description.luxtronik_key
-        self._attr_options = list(description.options or [])
+        self._lux_parameter = (
+            description.luxtronik_key if lux_parameter is None else lux_parameter
+        )
+        self._attr_options = list(options or description.options or [])
         self._attr_current_option = None
 
         prefix = entry.data[CONF_HA_SENSOR_PREFIX]

--- a/custom_components/luxtronik2/select.py
+++ b/custom_components/luxtronik2/select.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from homeassistant.components.select import (
     ENTITY_ID_FORMAT,  # pyright: ignore[reportAttributeAccessIssue]
     SelectEntity,
@@ -13,21 +15,19 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
-from .common import get_sensor_data
+from .common import get_sensor_data, key_exists
 from .const import (
     CONF_HA_SENSOR_PREFIX,
     DAY_NAME_TO_PARAM,
     DAY_SELECTOR_OPTIONS,
     LOGGER,
     DeviceKey,
-    LuxDaySelectorParameter,
-    LuxHeatingControlModeTypes,
-    LuxMode,
-    LuxParameter,
+    LuxPoolPVMode,
     SensorKey as SK,
 )
 from .coordinator import LuxtronikCoordinator, LuxtronikCoordinatorData
 from .model import LuxtronikSelectEntityDescription
+from .select_entities_predefined import SELECT_ENTITIES
 
 PARALLEL_UPDATES = 1
 
@@ -44,140 +44,92 @@ async def async_setup_entry(
     if not coordinator.last_update_success:
         return
 
-    # ---- Descriptions -------------------------------------------------
-
-    thermal_desinfection_description = LuxtronikSelectEntityDescription(
-        key=SK.THERMAL_DESINFECTION_DAY,
-        device_key=DeviceKey.domestic_water,
-        luxtronik_key=LuxDaySelectorParameter.MONDAY,  # pyright: ignore[reportArgumentType]
-        name="Thermal disinfection day",
-        entity_category=EntityCategory.CONFIG,
-    )
-
-    dhw_description = LuxtronikSelectEntityDescription(
-        key=SK.DOMESTIC_WATER_MODE_SELECTOR,
-        device_key=DeviceKey.domestic_water,
-        luxtronik_key=LuxParameter.P0004_MODE_DHW,
-        name="DHW mode",
-    )
-
-    heating_mode_description = LuxtronikSelectEntityDescription(
-        key=SK.HEATING_MODE_SELECTOR,
-        device_key=DeviceKey.heating,
-        luxtronik_key=LuxParameter.P0003_MODE_HEATING,
-        name="Heating mode",
-    )
-
-    heating_mk1_mode_description = LuxtronikSelectEntityDescription(
-        key=SK.HEATING_MODE_MK1,
-        device_key=DeviceKey.heating,
-        luxtronik_key=LuxParameter.P0695_MODE_HZ_MK1,
-        name="Heating mode MK1",
-        entity_registry_enabled_default=False,
-    )
-
-    heating_mk2_mode_description = LuxtronikSelectEntityDescription(
-        key=SK.HEATING_MODE_MK2,
-        device_key=DeviceKey.heating,
-        luxtronik_key=LuxParameter.P0696_MODE_HZ_MK2,
-        name="Heating mode MK2",
-        entity_registry_enabled_default=False,
-    )
-
-    heating_mk3_mode_description = LuxtronikSelectEntityDescription(
-        key=SK.HEATING_MODE_MK3,
-        device_key=DeviceKey.heating,
-        luxtronik_key=LuxParameter.P0779_MODE_HZ_MK3,
-        name="Heating mode MK3",
-        entity_registry_enabled_default=False,
-    )
-
-    heating_control_mode_description = LuxtronikSelectEntityDescription(
-        key=SK.HEATING_CONTROL_CIRCUIT_MODE,
-        device_key=DeviceKey.heating,
-        translation_key="heating_control_circuit_mode",
-        luxtronik_key=LuxParameter.P0103_HEATING_CONTROL_CIRCUIT_MODE,
-        entity_category=EntityCategory.CONFIG,
-        entity_registry_enabled_default=False,
-    )
-
-    # ---- Options (always strings!) ------------------------------------
-
-    mode_options: list[str] = [
-        m.value
-        for m in (
-            LuxMode.off,
-            LuxMode.automatic,
-            LuxMode.second_heatsource,
-            LuxMode.party,
-            LuxMode.holidays,
-        )
+    unavailable_keys = [
+        i.luxtronik_key
+        for i in SELECT_ENTITIES
+        if not key_exists(coordinator.data, i.luxtronik_key)
     ]
+    if unavailable_keys:
+        # Not all models/firmware versions support every parameter;
+        # missing keys are expected and not an error.
+        LOGGER.debug("Not present in Luxtronik data, skipping: %s", unavailable_keys)
 
-    mode_mk_options: list[str] = [
-        m.value
-        for m in (
-            LuxMode.off,
-            LuxMode.automatic,
-            LuxMode.party,
-            LuxMode.holidays,
-        )
-    ]
-
-    heating_control_mode_options: list[str] = [
-        m.value for m in LuxHeatingControlModeTypes
-    ]
+    # Descriptions are defined in select_entities_predefined.py
 
     # ---- Build entities in a compact, data-driven way -----------------
 
-    entities: list[SelectEntity] = [
-        LuxtronikThermalDesinfectionDaySelector(
-            entry=entry,
-            coordinator=coordinator,
-            description=thermal_desinfection_description,
-            device_info_ident=thermal_desinfection_description.device_key,
-        ),
-        *[
-            LuxtronikModeSelector(
+    select_descriptions = build_select_descriptions(coordinator)
+
+    async_add_entities(
+        [
+            LuxtronikThermalDesinfectionDaySelector(
                 entry=entry,
                 coordinator=coordinator,
                 description=desc,
                 device_info_ident=desc.device_key,
-                lux_parameter=lux_param,
-                options=opts,
             )
-            for (desc, lux_param, opts) in (
-                (dhw_description, LuxParameter.P0004_MODE_DHW, mode_mk_options),
-                (
-                    heating_mode_description,
-                    LuxParameter.P0003_MODE_HEATING,
-                    mode_options,
-                ),
-                (
-                    heating_mk1_mode_description,
-                    LuxParameter.P0695_MODE_HZ_MK1,
-                    mode_mk_options,
-                ),
-                (
-                    heating_mk2_mode_description,
-                    LuxParameter.P0696_MODE_HZ_MK2,
-                    mode_mk_options,
-                ),
-                (
-                    heating_mk3_mode_description,
-                    LuxParameter.P0779_MODE_HZ_MK3,
-                    mode_mk_options,
-                ),
-                (
-                    heating_control_mode_description,
-                    LuxParameter.P0103_HEATING_CONTROL_CIRCUIT_MODE,
-                    heating_control_mode_options,
-                ),
+            if desc.key == SK.THERMAL_DESINFECTION_DAY
+            else LuxtronikModeSelector(
+                entry=entry,
+                coordinator=coordinator,
+                description=desc,
+                device_info_ident=desc.device_key,
+            )
+            for desc in select_descriptions
+            if (
+                coordinator.entity_active(desc)
+                and key_exists(coordinator.data, desc.luxtronik_key)
             )
         ],
-    ]
+        True,
+    )
 
-    async_add_entities(entities, True)
+
+def build_select_descriptions(
+    coordinator: LuxtronikCoordinator,
+) -> list[LuxtronikSelectEntityDescription]:
+    """Return select descriptions with PV mode options adjusted at runtime."""
+    descriptions: list[LuxtronikSelectEntityDescription] = []
+    for desc in SELECT_ENTITIES:
+        if desc.key == SK.PV_MODE_SELECTOR:
+            descriptions.append(_build_pv_mode_selector_description(coordinator, desc))
+        else:
+            descriptions.append(desc)
+    return descriptions
+
+
+def _build_pv_mode_selector_description(
+    coordinator: LuxtronikCoordinator,
+    description: LuxtronikSelectEntityDescription,
+) -> LuxtronikSelectEntityDescription:
+    value = coordinator.get_value(description.luxtronik_key)
+
+    if value == LuxPoolPVMode.pv_off:
+        options = [
+            m.value
+            for m in (
+                LuxPoolPVMode.automatic,
+                LuxPoolPVMode.pv_off,
+            )
+        ]
+    elif value in (
+        LuxPoolPVMode.pool_party,
+        LuxPoolPVMode.pool_holidays,
+        LuxPoolPVMode.pool_off,
+    ):
+        options = [
+            m.value
+            for m in (
+                LuxPoolPVMode.automatic,
+                LuxPoolPVMode.pool_off,
+                LuxPoolPVMode.pool_party,
+                LuxPoolPVMode.pool_holidays,
+            )
+        ]
+    else:
+        return description
+
+    return replace(description, options=options)
 
 
 class LuxtronikThermalDesinfectionDaySelector(  # type: ignore  # pyright: ignore[reportIncompatibleVariableOverride]
@@ -274,8 +226,6 @@ class LuxtronikModeSelector(
         coordinator: LuxtronikCoordinator,
         description: LuxtronikSelectEntityDescription,
         device_info_ident: DeviceKey,
-        lux_parameter: LuxParameter,
-        options: list[str],
     ) -> None:
         super().__init__(
             coordinator=coordinator,
@@ -283,8 +233,8 @@ class LuxtronikModeSelector(
             device_info_ident=device_info_ident,
         )
 
-        self._lux_parameter = lux_parameter
-        self._attr_options = options
+        self._lux_parameter = description.luxtronik_key
+        self._attr_options = list(description.options or [])
         self._attr_current_option = None
 
         prefix = entry.data[CONF_HA_SENSOR_PREFIX]
@@ -332,7 +282,7 @@ class LuxtronikModeSelector(
         self._attr_current_option = option
 
         updated_data = await self.coordinator.async_write(
-            self._lux_parameter.split(".")[1],
+            str(self._lux_parameter).split(".")[1],
             option,
         )
         self._handle_coordinator_update(updated_data)

--- a/custom_components/luxtronik2/select_entities_predefined.py
+++ b/custom_components/luxtronik2/select_entities_predefined.py
@@ -1,0 +1,121 @@
+"""Predefined Select entity descriptions for Luxtronik."""
+
+from __future__ import annotations
+
+from homeassistant.const import EntityCategory
+
+from .const import (
+    DAY_SELECTOR_OPTIONS,
+    DeviceKey,
+    LuxDaySelectorParameter,
+    LuxHeatingControlModeTypes,
+    LuxMode,
+    LuxParameter,
+    LuxPoolPVMode,
+    SensorKey as SK,
+)
+from .model import LuxtronikSelectEntityDescription
+
+# ---- Options (always strings!) ------------------------------------
+mode_options: list[str] = [
+    m.value
+    for m in (
+        LuxMode.off,
+        LuxMode.automatic,
+        LuxMode.second_heatsource,
+        LuxMode.party,
+        LuxMode.holidays,
+    )
+]
+
+mode_mk_options: list[str] = [
+    m.value
+    for m in (
+        LuxMode.off,
+        LuxMode.automatic,
+        LuxMode.party,
+        LuxMode.holidays,
+    )
+]
+
+mode_pv_pool_options: list[str] = [
+    m.value
+    for m in (
+        LuxPoolPVMode.automatic,
+        LuxPoolPVMode.pv_off,
+        LuxPoolPVMode.pool_party,
+        LuxPoolPVMode.pool_holidays,
+        LuxPoolPVMode.pool_off,
+    )
+]
+
+heating_control_mode_options: list[str] = [m.value for m in LuxHeatingControlModeTypes]
+
+
+# ---- Descriptions directly in SELECT_ENTITIES ---------------------
+SELECT_ENTITIES: list[LuxtronikSelectEntityDescription] = [
+    LuxtronikSelectEntityDescription(
+        key=SK.THERMAL_DESINFECTION_DAY,
+        device_key=DeviceKey.domestic_water,
+        luxtronik_key=LuxDaySelectorParameter.MONDAY,  # pyright: ignore[reportArgumentType]
+        name="Thermal disinfection day",
+        entity_category=EntityCategory.CONFIG,
+        options=DAY_SELECTOR_OPTIONS,
+    ),
+    LuxtronikSelectEntityDescription(
+        key=SK.DOMESTIC_WATER_MODE_SELECTOR,
+        device_key=DeviceKey.domestic_water,
+        luxtronik_key=LuxParameter.P0004_MODE_DHW,
+        name="DHW mode",
+        options=mode_mk_options,
+    ),
+    LuxtronikSelectEntityDescription(
+        key=SK.HEATING_MODE_SELECTOR,
+        device_key=DeviceKey.heating,
+        luxtronik_key=LuxParameter.P0003_MODE_HEATING,
+        name="Heating mode",
+        options=mode_options,
+    ),
+    LuxtronikSelectEntityDescription(
+        key=SK.HEATING_MODE_MK1,
+        device_key=DeviceKey.heating,
+        luxtronik_key=LuxParameter.P0695_MODE_HZ_MK1,
+        name="Heating mode MK1",
+        entity_registry_enabled_default=False,
+        options=mode_mk_options,
+    ),
+    LuxtronikSelectEntityDescription(
+        key=SK.HEATING_MODE_MK2,
+        device_key=DeviceKey.heating,
+        luxtronik_key=LuxParameter.P0696_MODE_HZ_MK2,
+        name="Heating mode MK2",
+        entity_registry_enabled_default=False,
+        options=mode_mk_options,
+    ),
+    LuxtronikSelectEntityDescription(
+        key=SK.HEATING_MODE_MK3,
+        device_key=DeviceKey.heating,
+        luxtronik_key=LuxParameter.P0779_MODE_HZ_MK3,
+        name="Heating mode MK3",
+        entity_registry_enabled_default=False,
+        options=mode_mk_options,
+    ),
+    LuxtronikSelectEntityDescription(
+        key=SK.HEATING_CONTROL_CIRCUIT_MODE,
+        device_key=DeviceKey.heating,
+        translation_key="heating_control_circuit_mode",
+        luxtronik_key=LuxParameter.P0103_HEATING_CONTROL_CIRCUIT_MODE,
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+        options=heating_control_mode_options,
+    ),
+    LuxtronikSelectEntityDescription(
+        key=SK.PV_MODE_SELECTOR,
+        device_key=DeviceKey.heatpump,
+        translation_key="pv_mode_selector",
+        luxtronik_key=LuxParameter.P0119_MODE_PV,
+        entity_category=EntityCategory.CONFIG,
+        entity_registry_enabled_default=False,
+        options=mode_pv_pool_options,
+    ),
+]

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -916,11 +916,11 @@
             "pv_mode_selector": {
                 "name": "PV re\u017eim",
                 "state": {
-                    "Automatic": "Automaticky",
-                    "PV_Off": "PV vypnuto",
-                    "Pool_Off": "Pool vypnuto",
-                    "Pool_Party": "Pool p\u00e1rty",
-                    "Pool_Holidays": "Pool pr\u00e1zdniny"
+                    "automatic": "Automaticky",
+                    "pv_off": "PV vypnuto",
+                    "pool_off": "Pool vypnuto",
+                    "pool_party": "Pool p\u00e1rty",
+                    "pool_holidays": "Pool pr\u00e1zdniny"
                 }
             }
         },

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -912,6 +912,16 @@
                     "1": "Manu\u00e1ln\u011b nastaven\u00e1 teplota",
                     "2": "Analogov\u00fd vstup"
                 }
+            },
+            "pv_mode_selector": {
+                "name": "PV re\u017eim",
+                "state": {
+                    "Automatic": "Automaticky",
+                    "PV_Off": "PV vypnuto",
+                    "Pool_Off": "Pool vypnuto",
+                    "Pool_Party": "Pool p\u00e1rty",
+                    "Pool_Holidays": "Pool pr\u00e1zdniny"
+                }
             }
         },
         "climate": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -902,11 +902,11 @@
             "pv_mode_selector": {
                 "name": "PV Modus",
                 "state": {
-                    "Automatic": "Automatisch",
-                    "PV_Off": "PV aus",
-                    "Pool_Off": "Pool aus",
-                    "Pool_Party": "Pool-Party",
-                    "Pool_Holidays": "Pool-Ferien"
+                    "automatic": "Automatisch",
+                    "pv_off": "PV aus",
+                    "pool_off": "Pool aus",
+                    "pool_party": "Pool-Party",
+                    "pool_holidays": "Pool-Ferien"
                 }
             }
         },

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -898,6 +898,16 @@
                     "1": "Manuell gesetzte Temperatur",
                     "2": "AIn"
                 }
+            },
+            "pv_mode_selector": {
+                "name": "PV Modus",
+                "state": {
+                    "Automatic": "Automatisch",
+                    "PV_Off": "PV aus",
+                    "Pool_Off": "Pool aus",
+                    "Pool_Party": "Pool-Party",
+                    "Pool_Holidays": "Pool-Ferien"
+                }
             }
         },
         "climate": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -650,11 +650,11 @@
             "pv_mode_selector": {
                 "name": "PV Mode",
                 "state": {
-                    "Automatic": "Automatic",
-                    "PV_Off": "PV Off",
-                    "Pool_Off": "Pool Off",
-                    "Pool_Party": "Pool Party",
-                    "Pool_Holidays": "Pool Holidays"
+                    "automatic": "Automatic",
+                    "pv_off": "PV Off",
+                    "pool_off": "Pool Off",
+                    "pool_party": "Pool Party",
+                    "pool_holidays": "Pool Holidays"
                 }
             }
         },

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -646,6 +646,16 @@
                     "1": "Manual set temperature",
                     "2": "Analog in"
                 }
+            },
+            "pv_mode_selector": {
+                "name": "PV Mode",
+                "state": {
+                    "Automatic": "Automatic",
+                    "PV_Off": "PV Off",
+                    "Pool_Off": "Pool Off",
+                    "Pool_Party": "Pool Party",
+                    "Pool_Holidays": "Pool Holidays"
+                }
             }
         },
         "climate": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -884,11 +884,11 @@
             "pv_mode_selector": {
                 "name": "PV Mode",
                 "state": {
-                    "Automatic": "Automatisch",
-                    "PV_Off": "PV uit",
-                    "Pool_Off": "Pool uit",
-                    "Pool_Party": "Pool party",
-                    "Pool_Holidays": "Pool vakantie"
+                    "automatic": "Automatisch",
+                    "pv_off": "PV uit",
+                    "pool_off": "Pool uit",
+                    "pool_party": "Pool party",
+                    "pool_holidays": "Pool vakantie"
                 }
             }
         },

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -880,6 +880,16 @@
                     "1": "Handmatig ingestelde temperatuur",
                     "2": "Analoge ingang"
                 }
+            },
+            "pv_mode_selector": {
+                "name": "PV Mode",
+                "state": {
+                    "Automatic": "Automatisch",
+                    "PV_Off": "PV uit",
+                    "Pool_Off": "Pool uit",
+                    "Pool_Party": "Pool party",
+                    "Pool_Holidays": "Pool vakantie"
+                }
             }
         },
         "climate": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -878,11 +878,11 @@
             "pv_mode_selector": {
                 "name": "Tryb PV",
                 "state": {
-                    "Automatic": "Automatyczny",
-                    "PV_Off": "PV wy\u0142\u0105czony",
-                    "Pool_Off": "Basen wy\u0142\u0105czony",
-                    "Pool_Party": "Impreza basenowa",
-                    "Pool_Holidays": "Wakacje basenowe"
+                    "automatic": "Automatyczny",
+                    "pv_off": "PV wy\u0142\u0105czony",
+                    "pool_off": "Basen wy\u0142\u0105czony",
+                    "pool_party": "Impreza basenowa",
+                    "pool_holidays": "Wakacje basenowe"
                 }
             }
         },

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -874,6 +874,16 @@
                     "1": "R\u0119cznie ustawiona temperatura",
                     "2": "Wej\u015bcie analogowe"
                 }
+            },
+            "pv_mode_selector": {
+                "name": "Tryb PV",
+                "state": {
+                    "Automatic": "Automatyczny",
+                    "PV_Off": "PV wy\u0142\u0105czony",
+                    "Pool_Off": "Basen wy\u0142\u0105czony",
+                    "Pool_Party": "Impreza basenowa",
+                    "Pool_Holidays": "Wakacje basenowe"
+                }
             }
         },
         "climate": {


### PR DESCRIPTION
Code tries to discrimnate between Pool mode and PVmode. 
In case Parameter 119 = Automatic during HA startup, it cannot discriminate, and it will allow ALL options (both PV mode and Pool mode).

Additionally, refactored code: 
moved select entity descriptions to separate file select_entities_predefined.py, similar to the other platforms.