### PR TITLE
feat(config_flow): broadcast discovery on every enabled IPv4 interface

### DIFF
--- a/custom_components/luxtronik2/config_flow.py
+++ b/custom_components/luxtronik2/config_flow.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant import config_entries
+from homeassistant.components import network
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 from homeassistant.core import callback
@@ -66,8 +67,19 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         }
 
     async def _discover_devices(self) -> list[tuple[str, int | None]]:
-        """Run device discovery in executor."""
-        return await self.hass.async_add_executor_job(discover)
+        """Run device discovery in executor.
+
+        Enumerates every enabled IPv4 adapter via HA's network helper and
+        broadcasts on each. Without this, a single broadcast to
+        ``255.255.255.255`` only goes out the kernel's default route,
+        which misses heatpumps reachable from HA but not via that route
+        (multi-homed hosts: extra NICs, VLANs, Docker bridges).
+        """
+        broadcasts = await network.async_get_ipv4_broadcast_addresses(self.hass)
+        broadcast_addresses = [str(addr) for addr in broadcasts]
+        return await self.hass.async_add_executor_job(
+            discover, broadcast_addresses
+        )
 
     async def _set_unique_id_or_abort(
         self, coordinator: LuxtronikCoordinator, config: dict[str, Any]

--- a/custom_components/luxtronik2/config_flow.py
+++ b/custom_components/luxtronik2/config_flow.py
@@ -69,11 +69,8 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def _discover_devices(self) -> list[tuple[str, int | None]]:
         """Run device discovery in executor.
 
-        Enumerates every enabled IPv4 adapter via HA's network helper and
-        broadcasts on each. Without this, a single broadcast to
-        ``255.255.255.255`` only goes out the kernel's default route,
-        which misses heatpumps reachable from HA but not via that route
-        (multi-homed hosts: extra NICs, VLANs, Docker bridges).
+        Enumerates every enabled IPv4 adapter via HA's network helper, vs
+        just the default adapter we'd get if we passed ``255.255.255.255``.
         """
         broadcasts = await network.async_get_ipv4_broadcast_addresses(self.hass)
         broadcast_addresses = [str(addr) for addr in broadcasts]

--- a/custom_components/luxtronik2/config_flow.py
+++ b/custom_components/luxtronik2/config_flow.py
@@ -74,9 +74,7 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """
         broadcasts = await network.async_get_ipv4_broadcast_addresses(self.hass)
         broadcast_addresses = [str(addr) for addr in broadcasts]
-        return await self.hass.async_add_executor_job(
-            discover, broadcast_addresses
-        )
+        return await self.hass.async_add_executor_job(discover, broadcast_addresses)
 
     async def _set_unique_id_or_abort(
         self, coordinator: LuxtronikCoordinator, config: dict[str, Any]

--- a/custom_components/luxtronik2/lux_helper.py
+++ b/custom_components/luxtronik2/lux_helper.py
@@ -49,15 +49,8 @@ def discover(
 ) -> list[tuple[str, int | None]]:
     """Broadcast discovery for Luxtronik heat pumps.
 
-    When ``broadcast_addresses`` is provided, the magic packet is sent
-    to each address (one per network interface, in the caller's case).
-    Multi-homed Home Assistant hosts need this: a single broadcast to
-    ``255.255.255.255`` only goes out the kernel's default route,
-    missing devices that live on other subnets.
-
-    Default ``None`` preserves the legacy single-broadcast behavior so
-    external callers (the python-luxtronik library, the command-line
-    helper, etc.) keep working unchanged.
+    If you omit ``broadcast_addresses``, fallback to the OS-selected
+    default route.
     """
 
     targets: list[str] = (

--- a/custom_components/luxtronik2/lux_helper.py
+++ b/custom_components/luxtronik2/lux_helper.py
@@ -44,23 +44,40 @@ LUXTRONIK_CALCULATIONS_READ = 3004
 LUXTRONIK_VISIBILITIES_READ = 3005
 
 
-def discover() -> list[tuple[str, int | None]]:
-    """Broadcast discovery for Luxtronik heat pumps."""
+def discover(
+    broadcast_addresses: list[str] | None = None,
+) -> list[tuple[str, int | None]]:
+    """Broadcast discovery for Luxtronik heat pumps.
 
+    When ``broadcast_addresses`` is provided, the magic packet is sent
+    to each address (one per network interface, in the caller's case).
+    Multi-homed Home Assistant hosts need this: a single broadcast to
+    ``255.255.255.255`` only goes out the kernel's default route,
+    missing devices that live on other subnets.
+
+    Default ``None`` preserves the legacy single-broadcast behavior so
+    external callers (the python-luxtronik library, the command-line
+    helper, etc.) keep working unchanged.
+    """
+
+    targets: list[str] = (
+        list(broadcast_addresses) if broadcast_addresses else ["255.255.255.255"]
+    )
     results: list[tuple[str, int | None]] = []
 
     # pylint: disable=too-many-nested-blocks
     for port in LUXTRONIK_DISCOVERY_PORTS:
-        LOGGER.info("Send discovery packets to port %s", port)
+        LOGGER.info("Send discovery packets to port %s on %s", port, targets)
         server = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         server.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         server.bind(("", port))
         server.settimeout(LUXTRONIK_DISCOVERY_TIMEOUT)
 
-        # send AIT magic broadcast packet
+        # send AIT magic broadcast packet to every target broadcast address
         magic_bytes = LUXTRONIK_DISCOVERY_MAGIC_PACKET.encode()
-        server.sendto(magic_bytes, ("255.255.255.255", port))
-        LOGGER.debug("Sending broadcast request %s", magic_bytes)
+        for target in targets:
+            server.sendto(magic_bytes, (target, port))
+            LOGGER.debug("Sent broadcast request to %s:%s", target, port)
 
         while True:
             try:

--- a/custom_components/luxtronik2/manifest.json
+++ b/custom_components/luxtronik2/manifest.json
@@ -9,7 +9,8 @@
   ],
   "config_flow": true,
   "dependencies": [
-    "http"
+    "http",
+    "network"
   ],
   "dhcp": [
     {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -33,6 +33,19 @@ def _mock_coordinator():
     return coord
 
 
+@pytest.fixture(autouse=True)
+def _stub_network_broadcasts():
+    # _discover_devices calls network.async_get_ipv4_broadcast_addresses(hass);
+    # tests use a MagicMock hass, so the real helper crashes on storage load.
+    with patch(
+        "custom_components.luxtronik2.config_flow.network."
+        "async_get_ipv4_broadcast_addresses",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        yield
+
+
 # ===========================================================================
 # LuxtronikFlowHandler helpers
 # ===========================================================================

--- a/tests/test_lux_helper.py
+++ b/tests/test_lux_helper.py
@@ -306,6 +306,64 @@ class TestDiscover:
         results = discover()
         assert ("192.168.1.200", None) not in results
 
+    @patch("custom_components.luxtronik2.lux_helper.socket")
+    def test_discover_default_uses_global_broadcast(self, mock_socket_module):
+        """Without an explicit address list, sendto targets 255.255.255.255."""
+        sock_instance = MagicMock()
+        mock_socket_module.socket.return_value = sock_instance
+        mock_socket_module.AF_INET = 2
+        mock_socket_module.SOCK_DGRAM = 2
+        mock_socket_module.IPPROTO_UDP = 17
+        mock_socket_module.SOL_SOCKET = 1
+        mock_socket_module.SO_BROADCAST = 6
+        sock_instance.recvfrom.side_effect = TimeoutError
+
+        discover()
+
+        target_addrs = {call.args[1][0] for call in sock_instance.sendto.call_args_list}
+        assert target_addrs == {"255.255.255.255"}
+
+    @patch("custom_components.luxtronik2.lux_helper.socket")
+    def test_discover_broadcasts_on_every_supplied_address(self, mock_socket_module):
+        """Per-interface broadcasts: each address gets the magic packet on each port."""
+        sock_instance = MagicMock()
+        mock_socket_module.socket.return_value = sock_instance
+        mock_socket_module.AF_INET = 2
+        mock_socket_module.SOCK_DGRAM = 2
+        mock_socket_module.IPPROTO_UDP = 17
+        mock_socket_module.SOL_SOCKET = 1
+        mock_socket_module.SO_BROADCAST = 6
+        sock_instance.recvfrom.side_effect = TimeoutError
+
+        broadcasts = ["192.168.1.255", "192.168.120.255", "10.0.0.255"]
+        discover(broadcast_addresses=broadcasts)
+
+        # Each address should appear at least once per broadcast port.
+        target_addrs = [call.args[1][0] for call in sock_instance.sendto.call_args_list]
+        for addr in broadcasts:
+            assert target_addrs.count(addr) >= 1, (
+                f"{addr} was not broadcast to; calls: {target_addrs}"
+            )
+        # No fallback to 255.255.255.255 when explicit list is supplied.
+        assert "255.255.255.255" not in target_addrs
+
+    @patch("custom_components.luxtronik2.lux_helper.socket")
+    def test_discover_empty_address_list_falls_back_to_global(self, mock_socket_module):
+        """An empty list is treated like None: fall back to 255.255.255.255."""
+        sock_instance = MagicMock()
+        mock_socket_module.socket.return_value = sock_instance
+        mock_socket_module.AF_INET = 2
+        mock_socket_module.SOCK_DGRAM = 2
+        mock_socket_module.IPPROTO_UDP = 17
+        mock_socket_module.SOL_SOCKET = 1
+        mock_socket_module.SO_BROADCAST = 6
+        sock_instance.recvfrom.side_effect = TimeoutError
+
+        discover(broadcast_addresses=[])
+
+        target_addrs = {call.args[1][0] for call in sock_instance.sendto.call_args_list}
+        assert target_addrs == {"255.255.255.255"}
+
 
 # ===========================================================================
 # _is_socket_closed


### PR DESCRIPTION
Fixes #646.

Discovery currently broadcasts to `255.255.255.255`, which the kernel routes out the default interface only. On multi-homed Home Assistant hosts (extra NICs, VLANs, Docker bridges) heatpumps on other subnets aren't found.

This enumerates every enabled IPv4 adapter via HA's `network.async_get_ipv4_broadcast_addresses` and sends the magic packet to each. Same pattern as `flux_led`, `wiz`, `elkm1`.

`discover()`'s new `broadcast_addresses` param defaults to `None`, preserving the legacy single-broadcast for external callers.