### PR TITLE
FEAT: Allow users to configure coordinator update interval

### DIFF
--- a/custom_components/luxtronik2/config_flow.py
+++ b/custom_components/luxtronik2/config_flow.py
@@ -19,11 +19,13 @@ from .const import (
     CONF_HA_SENSOR_INDOOR_TEMPERATURE,
     CONF_HA_SENSOR_PREFIX,
     CONF_MAX_DATA_LENGTH,
+    CONF_UPDATE_INTERVAL,
     CONFIG_ENTRY_VERSION,
     DEFAULT_HOST,
     DEFAULT_MAX_DATA_LENGTH,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
+    DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     LOGGER,
 )
@@ -468,14 +470,23 @@ class LuxtronikOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                 ):
                     new_options[CONF_HA_SENSOR_INDOOR_TEMPERATURE] = None
 
+                update_interval = user_input.get(
+                    CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                )
+                new_options[CONF_UPDATE_INTERVAL] = update_interval
+
                 return self.async_create_entry(title="", data=new_options)
 
             current_indoor_temp = self._get_value(CONF_HA_SENSOR_INDOOR_TEMPERATURE)
+            current_interval = self._get_value(
+                CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
+            )
 
             return self.async_show_form(
                 step_id="user",
                 data_schema=build_options_schema(
-                    current_value=current_indoor_temp,
+                    current_indoor_temp=current_indoor_temp,
+                    current_interval=current_interval,
                 ),
                 description_placeholders={"name": self.config_entry.title},
             )

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -35,7 +35,7 @@ PLATFORMS: list[str] = [
 ]
 CONF_UPDATE_INTERVAL: Final = "update_interval"
 
-DEFAULT_UPDATE_INTERVAL: Final = "1 minute (default)"
+DEFAULT_UPDATE_INTERVAL: Final = timedelta(seconds=60)
 UPDATE_INTERVAL_OPTIONS: Final = {
     "10 seconds": timedelta(seconds=10),
     "30 seconds": timedelta(seconds=30),

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -33,6 +33,16 @@ PLATFORMS: list[str] = [
     Platform.SELECT,
     Platform.DATE,
 ]
+CONF_UPDATE_INTERVAL: Final = "update_interval"
+
+DEFAULT_UPDATE_INTERVAL: Final = "1 minute (default)"
+UPDATE_INTERVAL_OPTIONS: Final = {
+    "10 seconds": timedelta(seconds=10),
+    "30 seconds": timedelta(seconds=30),
+    "1 minute (default)": timedelta(seconds=60),
+    "5 minutes": timedelta(minutes=5),
+}
+
 UPDATE_INTERVAL_FAST: Final = timedelta(seconds=10)
 UPDATE_INTERVAL_NORMAL: Final = timedelta(minutes=1)
 UPDATE_INTERVAL_SLOW: Final = timedelta(minutes=3)

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -24,14 +24,17 @@ from .const import (
     CONF_CALCULATIONS,
     CONF_MAX_DATA_LENGTH,
     CONF_PARAMETERS,
+    CONF_UPDATE_INTERVAL,
     CONF_VISIBILITIES,
     DEFAULT_MAX_DATA_LENGTH,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
+    DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     LOGGER,
     LUX_PARAMETER_MK_SENSORS,
     UPDATE_INTERVAL_NORMAL,
+    UPDATE_INTERVAL_OPTIONS,
     DeviceKey,
     LuxCalculation as LC,
     LuxMkTypes,
@@ -90,19 +93,36 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         self._config = config
         self.device_infos = dict[str, DeviceInfo]()
         self.update_reason_write = False
+
+        update_interval = UPDATE_INTERVAL_NORMAL
+        raw = config.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+        update_interval = UPDATE_INTERVAL_OPTIONS.get(str(raw), update_interval)
+
         super().__init__(
             hass,
             LOGGER,
             name=DOMAIN,
             update_method=self._async_update_data,
-            update_interval=UPDATE_INTERVAL_NORMAL,
+            update_interval=update_interval,
+        )
+
+        LOGGER.info(
+            "Coordinator update interval=%s s",
+            self.update_interval.total_seconds()
+            if self.update_interval is not None
+            else None,
         )
 
     async def _async_update_data(self) -> LuxtronikCoordinatorData:
         async with self._lock:
             try:
                 await self.hass.async_add_executor_job(self.client.read)
-                LOGGER.debug("_async_update_data")
+                LOGGER.debug(
+                    "Update coordinator data  (Async, interval=%s s)",
+                    self.update_interval.total_seconds()
+                    if self.update_interval is not None
+                    else None,
+                )
                 self.data = LuxtronikCoordinatorData(
                     parameters=self.client.parameters,
                     calculations=self.client.calculations,
@@ -545,10 +565,6 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         await super().async_shutdown()
         if hasattr(self, "client") and self.client is not None:
             del self.client
-        else:
-            LOGGER.warning(
-                "LuxtronikCoordinator has no 'client' attribute during shutdown."
-            )
 
 
 class LuxtronikConnectionError(HomeAssistantError):
@@ -585,6 +601,8 @@ async def connect_and_get_coordinator(
     config_data: dict[str, Any] = dict(
         config.data if isinstance(config, ConfigEntry) else config
     )
+    if isinstance(config, ConfigEntry):
+        config_data.update(dict(config.options))
 
     host: str = config_data.get(CONF_HOST, "")
     port = config_data.get(CONF_PORT, DEFAULT_PORT)
@@ -593,9 +611,8 @@ async def connect_and_get_coordinator(
         coordinator = await LuxtronikCoordinator.connect(hass, config_data)
         LOGGER.info("Luxtronik connect to device %s:%s successful!", host, port)
 
-        # ✅ Perform initial data fetch manually
-        await coordinator._async_update_data()
-        LOGGER.info("Initial data fetched for coordinator")
+        # no need to fetch first data manually here,
+        # already done by async_config_entry_first_refresh() in __init.py:47__
 
         return coordinator
     except Exception as err:

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable, Coroutine, Mapping
+from datetime import timedelta
 from functools import wraps
 import re
 from types import MappingProxyType
@@ -33,7 +34,6 @@ from .const import (
     DOMAIN,
     LOGGER,
     LUX_PARAMETER_MK_SENSORS,
-    UPDATE_INTERVAL_NORMAL,
     UPDATE_INTERVAL_OPTIONS,
     DeviceKey,
     LuxCalculation as LC,
@@ -94,9 +94,10 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         self.device_infos = dict[str, DeviceInfo]()
         self.update_reason_write = False
 
-        update_interval = UPDATE_INTERVAL_NORMAL
-        raw = config.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
-        update_interval = UPDATE_INTERVAL_OPTIONS.get(str(raw), update_interval)
+        update_interval: timedelta = DEFAULT_UPDATE_INTERVAL
+        raw = config.get(CONF_UPDATE_INTERVAL)
+        if isinstance(raw, str) and raw in UPDATE_INTERVAL_OPTIONS:
+            update_interval = UPDATE_INTERVAL_OPTIONS[raw]
 
         super().__init__(
             hass,

--- a/custom_components/luxtronik2/schema_helper.py
+++ b/custom_components/luxtronik2/schema_helper.py
@@ -5,10 +5,13 @@ import voluptuous as vol
 from .const import (
     CONF_HA_SENSOR_INDOOR_TEMPERATURE,
     CONF_MAX_DATA_LENGTH,
+    CONF_UPDATE_INTERVAL,
     DEFAULT_HOST,
     DEFAULT_MAX_DATA_LENGTH,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
+    DEFAULT_UPDATE_INTERVAL,
+    UPDATE_INTERVAL_OPTIONS,
 )
 
 
@@ -29,17 +32,31 @@ def build_user_data_schema(
 
 
 def build_options_schema(
-    current_value: str | None = None,
+    current_indoor_temp: str | None = None,
+    current_interval: str | None = None,
 ) -> vol.Schema:
+    interval_options = [
+        selector.SelectOptionDict(value=k, label=k) for k in UPDATE_INTERVAL_OPTIONS
+    ]
     return vol.Schema(
         {
             vol.Optional(
                 CONF_HA_SENSOR_INDOOR_TEMPERATURE,
-                default=current_value,
-                description={"suggested_value": current_value},
+                default=current_indoor_temp,
+                description={"suggested_value": current_indoor_temp},
             ): selector.EntitySelector(
                 selector.EntitySelectorConfig(
                     domain="sensor", device_class="temperature"
+                )
+            ),
+            vol.Optional(
+                CONF_UPDATE_INTERVAL,
+                default=current_interval or DEFAULT_UPDATE_INTERVAL,
+                description={"suggested_value": current_interval or DEFAULT_UPDATE_INTERVAL},
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=interval_options,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
         }

--- a/custom_components/luxtronik2/schema_helper.py
+++ b/custom_components/luxtronik2/schema_helper.py
@@ -52,7 +52,9 @@ def build_options_schema(
             vol.Optional(
                 CONF_UPDATE_INTERVAL,
                 default=current_interval or DEFAULT_UPDATE_INTERVAL,
-                description={"suggested_value": current_interval or DEFAULT_UPDATE_INTERVAL},
+                description={
+                    "suggested_value": current_interval or DEFAULT_UPDATE_INTERVAL
+                },
             ): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=interval_options,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -17,6 +17,7 @@ from custom_components.luxtronik2.const import (
     CONF_HA_SENSOR_INDOOR_TEMPERATURE,
     CONF_HA_SENSOR_PREFIX,
     CONF_MAX_DATA_LENGTH,
+    CONF_UPDATE_INTERVAL,
     DEFAULT_MAX_DATA_LENGTH,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
@@ -487,6 +488,20 @@ class TestOptionsFlow:
         assert call_kwargs["data"].get(CONF_HA_SENSOR_INDOOR_TEMPERATURE) is None
 
     @pytest.mark.asyncio
+    async def test_step_user_saves_update_interval(self):
+        entry = MagicMock()
+        entry.data = {CONF_HOST: "1.2.3.4", CONF_PORT: 8889}
+        entry.options = {}
+        entry.title = "Test HP"
+        flow = _make_options_flow(entry)
+        flow.hass = MagicMock()
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+        await flow.async_step_user({CONF_UPDATE_INTERVAL: "1 minute (default)"})
+        flow.async_create_entry.assert_called_once()
+        call_kwargs = flow.async_create_entry.call_args[1]
+        assert call_kwargs["data"][CONF_UPDATE_INTERVAL] == "1 minute (default)"
+
+    @pytest.mark.asyncio
     async def test_step_user_clears_legacy_indoor_temp_from_data(self):
         """Clearing works even when the value only exists in config_entry.data."""
         entry = MagicMock()
@@ -624,8 +639,8 @@ class TestAsyncStepReconfigure:
             result = await flow.async_step_reconfigure(
                 {CONF_HOST: "5.6.7.8", CONF_PORT: 8889}
             )
-        assert result["type"] == "abort"
-        assert result["reason"] == "reconfigure_successful"
+        assert result.get("type") == "abort"
+        assert result.get("reason") == "reconfigure_successful"
         flow.async_update_reload_and_abort.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 from custom_components.luxtronik2.const import (
     CONF_UPDATE_INTERVAL,
     CONFIG_ENTRY_VERSION,
@@ -178,7 +180,7 @@ class TestSensorKey:
 
 class TestUpdateIntervalConstants:
     def test_default_update_interval(self):
-        assert DEFAULT_UPDATE_INTERVAL == "30 seconds"
+        assert timedelta(seconds=60) == DEFAULT_UPDATE_INTERVAL
 
     def test_update_interval_options_keys_and_timedeltas(self):
         assert set(UPDATE_INTERVAL_OPTIONS.keys()) == {

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from custom_components.luxtronik2.const import (
+    CONF_UPDATE_INTERVAL,
     CONFIG_ENTRY_VERSION,
     DEFAULT_MAX_DATA_LENGTH,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
+    DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     PLATFORMS,
+    UPDATE_INTERVAL_OPTIONS,
     DeviceKey,
     LuxCalculation,
     LuxMkTypes,
@@ -171,3 +174,23 @@ class TestLuxVisibility:
 class TestSensorKey:
     def test_firmware(self):
         assert SensorKey.FIRMWARE is not None
+
+
+class TestUpdateIntervalConstants:
+    def test_default_update_interval(self):
+        assert DEFAULT_UPDATE_INTERVAL == "30 seconds"
+
+    def test_update_interval_options_keys_and_timedeltas(self):
+        assert set(UPDATE_INTERVAL_OPTIONS.keys()) == {
+            "10 seconds",
+            "30 seconds",
+            "1 minute (default)",
+            "5 minutes",
+        }
+        assert UPDATE_INTERVAL_OPTIONS["10 seconds"].total_seconds() == 10
+        assert UPDATE_INTERVAL_OPTIONS["30 seconds"].total_seconds() == 30
+        assert UPDATE_INTERVAL_OPTIONS["1 minute (default)"].total_seconds() == 60
+        assert UPDATE_INTERVAL_OPTIONS["5 minutes"].total_seconds() == 300
+
+    def test_conf_update_interval_constant(self):
+        assert CONF_UPDATE_INTERVAL == "update_interval"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -13,6 +13,7 @@ from packaging.version import Version
 import pytest
 
 from custom_components.luxtronik2.const import (
+    CONF_UPDATE_INTERVAL,
     DEFAULT_PORT,
     DeviceKey,
     LuxCalculation as LC,
@@ -89,6 +90,61 @@ def _make_coordinator_direct(data=None):
         )
     coord.data = data
     return coord
+
+
+class TestUpdateIntervalConfig:
+    def test_default_update_interval_when_missing(self):
+        coord = _make_coordinator()
+        with patch.object(coord, "_async_update_data", new_callable=AsyncMock):
+            pass
+        assert coord.update_interval is not None
+        assert coord.update_interval.total_seconds() == 30
+
+    def test_custom_update_interval_from_config(self):
+        config = {
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: DEFAULT_PORT,
+            CONF_UPDATE_INTERVAL: "1 minute (default)",
+        }
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coord = LuxtronikCoordinator(
+                hass=MagicMock(), client=MagicMock(), config=config
+            )
+        assert coord.update_interval is not None
+        assert coord.update_interval.total_seconds() == 60
+
+    def test_unknown_update_interval_falls_back_to_default(self):
+        config = {
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: DEFAULT_PORT,
+            CONF_UPDATE_INTERVAL: "not_a_real_option",
+        }
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coord = LuxtronikCoordinator(
+                hass=MagicMock(), client=MagicMock(), config=config
+            )
+        assert coord.update_interval is not None
+        assert coord.update_interval.total_seconds() == 60
+
+    def test_all_known_intervals_map_correctly(self):
+        expected = {
+            "10 seconds": 10,
+            "30 seconds": 30,
+            "1 minute": 60,
+            "5 minutes": 300,
+        }
+        for label, seconds in expected.items():
+            config = {
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: DEFAULT_PORT,
+                CONF_UPDATE_INTERVAL: label,
+            }
+            with patch("homeassistant.helpers.frame.report_usage"):
+                coord = LuxtronikCoordinator(
+                    hass=MagicMock(), client=MagicMock(), config=config
+                )
+            assert coord.update_interval is not None
+            assert coord.update_interval.total_seconds() == seconds
 
 
 # ===========================================================================
@@ -490,7 +546,8 @@ class TestCoordinatorGetValue:
         coord = _make_coordinator(parameters={"ID_Ba_Hz_akt": "Automatic"})
         sensor = coord.get_sensor("parameters", "ID_Ba_Hz_akt")
         assert sensor is not None
-        assert sensor.value == "Automatic"
+        value = sensor[1] if isinstance(sensor, tuple) else sensor.value
+        assert value == "Automatic"
 
     def test_get_sensor_unknown_group(self):
         coord = _make_coordinator()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -15,6 +15,7 @@ import pytest
 from custom_components.luxtronik2.const import (
     CONF_UPDATE_INTERVAL,
     DEFAULT_PORT,
+    DEFAULT_UPDATE_INTERVAL,
     DeviceKey,
     LuxCalculation as LC,
     LuxMkTypes,
@@ -82,6 +83,7 @@ def _make_coordinator_direct(data=None):
     coord.update_reason_write = False
     coord.async_request_refresh = AsyncMock()
     coord.async_refresh = AsyncMock()
+    coord.update_interval = DEFAULT_UPDATE_INTERVAL
     if data is None:
         data = LuxtronikCoordinatorData(
             parameters={"ID_WEB_WP_BZ_akt": (0, 0)},
@@ -98,7 +100,7 @@ class TestUpdateIntervalConfig:
         with patch.object(coord, "_async_update_data", new_callable=AsyncMock):
             pass
         assert coord.update_interval is not None
-        assert coord.update_interval.total_seconds() == 30
+        assert coord.update_interval == DEFAULT_UPDATE_INTERVAL
 
     def test_custom_update_interval_from_config(self):
         config = {
@@ -130,7 +132,7 @@ class TestUpdateIntervalConfig:
         expected = {
             "10 seconds": 10,
             "30 seconds": 30,
-            "1 minute": 60,
+            "1 minute (default)": 60,
             "5 minutes": 300,
         }
         for label, seconds in expected.items():

--- a/tests/test_schema_helper.py
+++ b/tests/test_schema_helper.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
 from homeassistant.const import CONF_HOST, CONF_PORT
 import pytest
 import voluptuous as vol
@@ -31,18 +33,21 @@ class TestBuildUserDataSchema:
 
     def test_schema_validates_valid_data(self):
         schema = build_user_data_schema()
-        result = schema(
-            {
-                CONF_HOST: "192.168.1.100",
-                CONF_PORT: DEFAULT_PORT,
-            }
+        result = cast(
+            dict[str, Any],
+            schema(
+                {
+                    CONF_HOST: "192.168.1.100",
+                    CONF_PORT: DEFAULT_PORT,
+                }
+            ),
         )
         assert result[CONF_HOST] == "192.168.1.100"
         assert result[CONF_PORT] == DEFAULT_PORT
 
     def test_schema_uses_defaults(self):
         schema = build_user_data_schema()
-        result = schema({})
+        result = cast(dict[str, Any], schema({}))
         # Both host and port have defaults, so empty dict is valid
         assert CONF_HOST in result
         assert CONF_PORT in result
@@ -58,8 +63,14 @@ class TestBuildOptionsSchema:
         schema = build_options_schema()
         assert isinstance(schema, vol.Schema)
 
-    def test_with_current_value(self):
+    def test_with_indoor_temperature_sensor(self):
         schema = build_options_schema(
-            current_value="sensor.indoor_temp",
+            current_indoor_temp="sensor.indoor_temp",
+        )
+        assert isinstance(schema, vol.Schema)
+
+    def test_with_update_interval(self):
+        schema = build_options_schema(
+            current_interval="1 minute",
         )
         assert isinstance(schema, vol.Schema)


### PR DESCRIPTION
Update interval can be set using config flow.
Choice from:
UPDATE_INTERVAL_OPTIONS: Final = {
    "10 seconds": timedelta(seconds=10),
    "30 seconds": timedelta(seconds=30),
    "1 minute (default)": timedelta(seconds=60),
    "5 minutes": timedelta(minutes=5),
}