### PR TITLE
fix(config_flow): 🐛 refresh coordinator before unique id lookup

### DIFF
--- a/custom_components/luxtronik2/__init__.py
+++ b/custom_components/luxtronik2/__init__.py
@@ -44,7 +44,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: LuxtronikConfigEntry) ->
 
     try:
         coordinator = await connect_and_get_coordinator(hass, entry)
-        await coordinator.async_config_entry_first_refresh()
     except Exception as err:
         LOGGER.error("Luxtronik connection failed: %s", err)
         ir.async_create_issue(

--- a/custom_components/luxtronik2/config_flow.py
+++ b/custom_components/luxtronik2/config_flow.py
@@ -202,6 +202,7 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             coordinator = await connect_and_get_coordinator(self.hass, config)
+            await coordinator.async_config_entry_first_refresh()
         except LuxtronikConnectionError as err:
             return self.async_abort(
                 reason="cannot_connect",
@@ -235,6 +236,7 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             coordinator = await connect_and_get_coordinator(self.hass, config)
+            await coordinator.async_config_entry_first_refresh()
         except LuxtronikConnectionError as err:
             return self.async_abort(
                 reason="cannot_connect",
@@ -385,6 +387,11 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             entry_data = reconfigure_entry.data
+            LOGGER.debug(
+                "Reconfigure submitted with user_input=%s and existing entry_data=%s",
+                user_input,
+                entry_data,
+            )
             config = self._build_config(
                 user_input[CONF_HOST],
                 int(user_input[CONF_PORT]),
@@ -401,18 +408,55 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     )
                 ),
             )
+            LOGGER.debug("Reconfigure built config=%s", config)
 
             try:
                 coordinator = await connect_and_get_coordinator(self.hass, config)
-            except LuxtronikConnectionError:
-                errors["base"] = "cannot_connect"
-            else:
-                await self.async_set_unique_id(coordinator.unique_id)
-                self._abort_if_unique_id_mismatch()
-                return self.async_update_reload_and_abort(
-                    reconfigure_entry,
-                    data_updates=config,
+                await coordinator.async_config_entry_first_refresh()
+            except LuxtronikConnectionError as err:
+                LOGGER.warning(
+                    "Reconfigure connection failed for host=%s port=%s: %s",
+                    config[CONF_HOST],
+                    config[CONF_PORT],
+                    err,
                 )
+                errors["base"] = "cannot_connect"
+            except Exception as err:  # pylint: disable=broad-except
+                LOGGER.exception("Unexpected exception during reconfigure connect")
+                errors["base"] = "unknown"
+            else:
+                LOGGER.debug(
+                    "Reconfigure connected and refreshed successfully; entry unique_id=%s, coordinator unique_id=%s",
+                    reconfigure_entry.unique_id,
+                    coordinator.unique_id,
+                )
+                try:
+                    await self.async_set_unique_id(coordinator.unique_id)
+                    if reconfigure_entry.unique_id is None:
+                        LOGGER.debug(
+                            "Reconfigure updating entry without existing unique_id"
+                        )
+                        return self.async_update_reload_and_abort(
+                            reconfigure_entry,
+                            unique_id=coordinator.unique_id,
+                            data_updates=config,
+                        )
+                    self._abort_if_unique_id_mismatch()
+                    LOGGER.debug("Reconfigure unique_id matches; updating entry")
+                    return self.async_update_reload_and_abort(
+                        reconfigure_entry,
+                        unique_id=coordinator.unique_id,
+                        data_updates=config,
+                    )
+                except AbortFlow as err:
+                    LOGGER.warning(
+                        "Reconfigure aborted during unique_id check: %s",
+                        err,
+                    )
+                    raise
+                except Exception as err:  # pylint: disable=broad-except
+                    LOGGER.exception("Unexpected exception during reconfigure update")
+                    errors["base"] = "unknown"
 
         form_defaults = {**reconfigure_entry.data, **(user_input or {})}
         return self.async_show_form(

--- a/custom_components/luxtronik2/config_flow.py
+++ b/custom_components/luxtronik2/config_flow.py
@@ -202,7 +202,6 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             coordinator = await connect_and_get_coordinator(self.hass, config)
-            await coordinator.async_config_entry_first_refresh()
         except LuxtronikConnectionError as err:
             return self.async_abort(
                 reason="cannot_connect",
@@ -236,7 +235,6 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             coordinator = await connect_and_get_coordinator(self.hass, config)
-            await coordinator.async_config_entry_first_refresh()
         except LuxtronikConnectionError as err:
             return self.async_abort(
                 reason="cannot_connect",
@@ -412,7 +410,6 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 coordinator = await connect_and_get_coordinator(self.hass, config)
-                await coordinator.async_config_entry_first_refresh()
             except LuxtronikConnectionError as err:
                 LOGGER.warning(
                     "Reconfigure connection failed for host=%s port=%s: %s",
@@ -421,7 +418,7 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     err,
                 )
                 errors["base"] = "cannot_connect"
-            except Exception as err:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 LOGGER.exception("Unexpected exception during reconfigure connect")
                 errors["base"] = "unknown"
             else:
@@ -454,7 +451,7 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         err,
                     )
                     raise
-                except Exception as err:  # pylint: disable=broad-except
+                except Exception:  # pylint: disable=broad-except
                     LOGGER.exception("Unexpected exception during reconfigure update")
                     errors["base"] = "unknown"
 

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -671,8 +671,8 @@ async def connect_and_get_coordinator(
         coordinator = await LuxtronikCoordinator.connect(hass, config_data)
         LOGGER.info("Luxtronik connect to device %s:%s successful!", host, port)
 
-        # no need to fetch first data manually here,
-        # already done by async_config_entry_first_refresh() in __init.py:47__
+        await coordinator.async_config_entry_first_refresh()
+        LOGGER.debug("Initial coordinator refresh completed for %s:%s", host, port)
 
         return coordinator
     except Exception as err:

--- a/custom_components/luxtronik2/schema_helper.py
+++ b/custom_components/luxtronik2/schema_helper.py
@@ -24,9 +24,11 @@ def build_user_data_schema(
     return vol.Schema(
         {
             vol.Required(CONF_HOST, default=host): str,
-            vol.Required(CONF_PORT, default=port): int,
+            vol.Required(CONF_PORT, default=port): vol.Coerce(int),
             vol.Optional(CONF_TIMEOUT, default=timeout): vol.Coerce(float),
-            vol.Optional(CONF_MAX_DATA_LENGTH, default=max_data_length): int,
+            vol.Optional(CONF_MAX_DATA_LENGTH, default=max_data_length): vol.Coerce(
+                int
+            ),
         }
     )
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -231,6 +231,7 @@ class TestAsyncStepSelectDevices:
         flow.async_set_unique_id = AsyncMock()
         flow._abort_if_unique_id_configured = MagicMock()
         coord = _mock_coordinator()
+        coord.async_config_entry_first_refresh = AsyncMock()
         with patch(
             "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
             new_callable=AsyncMock,
@@ -251,6 +252,7 @@ class TestAsyncStepSelectDevices:
         )
         flow.async_abort = MagicMock(return_value={"type": "abort"})
         coord = _mock_coordinator()
+        coord.async_config_entry_first_refresh = AsyncMock()
         with patch(
             "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
             new_callable=AsyncMock,
@@ -297,6 +299,7 @@ class TestAsyncStepManualEntry:
         flow.async_set_unique_id = AsyncMock()
         flow._abort_if_unique_id_configured = MagicMock()
         coord = _mock_coordinator()
+        coord.async_config_entry_first_refresh = AsyncMock()
         with patch(
             "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
             new_callable=AsyncMock,
@@ -631,6 +634,7 @@ class TestAsyncStepReconfigure:
             return_value={"type": "abort", "reason": "reconfigure_successful"}
         )
         coord = _mock_coordinator()
+        coord.async_config_entry_first_refresh = AsyncMock()
         with patch(
             "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
             new_callable=AsyncMock,
@@ -642,6 +646,50 @@ class TestAsyncStepReconfigure:
         assert result.get("type") == "abort"
         assert result.get("reason") == "reconfigure_successful"
         flow.async_update_reload_and_abort.assert_called_once()
+        coord.async_config_entry_first_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reconfigure_without_existing_unique_id_updates_entry(self):
+        flow = LuxtronikFlowHandler()
+        flow.hass = MagicMock()
+        entry = MagicMock()
+        entry.data = {
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 8889,
+            CONF_TIMEOUT: DEFAULT_TIMEOUT,
+            CONF_MAX_DATA_LENGTH: DEFAULT_MAX_DATA_LENGTH,
+        }
+        entry.unique_id = None
+        flow._get_reconfigure_entry = MagicMock(return_value=entry)
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_mismatch = MagicMock(
+            side_effect=AbortFlow("unique_id_mismatch")
+        )
+        flow.async_update_reload_and_abort = MagicMock(
+            return_value={"type": "abort", "reason": "reconfigure_successful"}
+        )
+        coord = _mock_coordinator()
+        coord.async_config_entry_first_refresh = AsyncMock()
+        with patch(
+            "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
+            new_callable=AsyncMock,
+            return_value=coord,
+        ):
+            result = await flow.async_step_reconfigure(
+                {CONF_HOST: "5.6.7.8", CONF_PORT: 8889}
+            )
+        assert result.get("type") == "abort"
+        assert result.get("reason") == "reconfigure_successful"
+        flow.async_update_reload_and_abort.assert_called_once_with(
+            entry,
+            unique_id=coord.unique_id,
+            data_updates={
+                CONF_HOST: "5.6.7.8",
+                CONF_PORT: 8889,
+                CONF_TIMEOUT: DEFAULT_TIMEOUT,
+                CONF_MAX_DATA_LENGTH: DEFAULT_MAX_DATA_LENGTH,
+            },
+        )
 
     @pytest.mark.asyncio
     async def test_unique_id_mismatch_aborts(self):
@@ -654,12 +702,14 @@ class TestAsyncStepReconfigure:
             CONF_TIMEOUT: DEFAULT_TIMEOUT,
             CONF_MAX_DATA_LENGTH: DEFAULT_MAX_DATA_LENGTH,
         }
+        entry.unique_id = "old_id"
         flow._get_reconfigure_entry = MagicMock(return_value=entry)
         flow.async_set_unique_id = AsyncMock()
         flow._abort_if_unique_id_mismatch = MagicMock(
             side_effect=AbortFlow("unique_id_mismatch")
         )
         coord = _mock_coordinator()
+        coord.async_config_entry_first_refresh = AsyncMock()
         with (
             patch(
                 "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -617,6 +617,53 @@ class TestAsyncStepReconfigure:
         assert defaults[CONF_HOST] == "5.6.7.8"
 
     @pytest.mark.asyncio
+    async def test_connect_exception_shows_unknown_error(self):
+        flow = LuxtronikFlowHandler()
+        flow.hass = MagicMock()
+        entry = MagicMock()
+        entry.data = {
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 8889,
+            CONF_TIMEOUT: DEFAULT_TIMEOUT,
+            CONF_MAX_DATA_LENGTH: DEFAULT_MAX_DATA_LENGTH,
+        }
+        flow._get_reconfigure_entry = MagicMock(return_value=entry)
+        flow.async_show_form = MagicMock(return_value={"type": "form"})
+        user_input = {CONF_HOST: "5.6.7.8", CONF_PORT: 8889}
+        with patch(
+            "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
+            new_callable=AsyncMock,
+            side_effect=Exception("boom"),
+        ):
+            await flow.async_step_reconfigure(user_input)
+        flow.async_show_form.assert_called_once()
+        assert flow.async_show_form.call_args[1]["errors"] == {"base": "unknown"}
+
+    @pytest.mark.asyncio
+    async def test_update_exception_shows_unknown_error(self):
+        flow = LuxtronikFlowHandler()
+        flow.hass = MagicMock()
+        entry = MagicMock()
+        entry.data = {
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 8889,
+            CONF_TIMEOUT: DEFAULT_TIMEOUT,
+            CONF_MAX_DATA_LENGTH: DEFAULT_MAX_DATA_LENGTH,
+        }
+        flow._get_reconfigure_entry = MagicMock(return_value=entry)
+        flow.async_show_form = MagicMock(return_value={"type": "form"})
+        flow.async_set_unique_id = AsyncMock(side_effect=Exception("boom"))
+        coord = _mock_coordinator()
+        with patch(
+            "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
+            new_callable=AsyncMock,
+            return_value=coord,
+        ):
+            await flow.async_step_reconfigure({CONF_HOST: "5.6.7.8", CONF_PORT: 8889})
+        flow.async_show_form.assert_called_once()
+        assert flow.async_show_form.call_args[1]["errors"] == {"base": "unknown"}
+
+    @pytest.mark.asyncio
     async def test_successful_reconfigure(self):
         flow = LuxtronikFlowHandler()
         flow.hass = MagicMock()
@@ -646,7 +693,6 @@ class TestAsyncStepReconfigure:
         assert result.get("type") == "abort"
         assert result.get("reason") == "reconfigure_successful"
         flow.async_update_reload_and_abort.assert_called_once()
-        coord.async_config_entry_first_refresh.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_reconfigure_without_existing_unique_id_updates_entry(self):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1118,6 +1118,24 @@ class TestConnectAndGetCoordinator:
             assert mock_iso.call_count == 1
 
     @pytest.mark.asyncio
+    async def test_initial_refresh_is_performed(self):
+        from custom_components.luxtronik2.coordinator import connect_and_get_coordinator
+
+        config = {CONF_HOST: "192.168.1.100", CONF_PORT: DEFAULT_PORT}
+        coordinator = MagicMock()
+        coordinator.async_config_entry_first_refresh = AsyncMock()
+
+        with patch(
+            "custom_components.luxtronik2.coordinator.LuxtronikCoordinator.connect",
+            new_callable=AsyncMock,
+            return_value=coordinator,
+        ):
+            result = await connect_and_get_coordinator(MagicMock(), config)
+
+        assert result is coordinator
+        coordinator.async_config_entry_first_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_config_entry_options_merged(self):
         from custom_components.luxtronik2.coordinator import connect_and_get_coordinator
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -451,7 +451,6 @@ class TestAsyncSetupEntry:
             result = await async_setup_entry(hass, entry)
 
         assert result is True
-        coord.async_config_entry_first_refresh.assert_awaited_once()
         hass.config_entries.async_forward_entry_setups.assert_awaited_once_with(
             entry, PLATFORMS
         )

--- a/tests/test_schema_helper.py
+++ b/tests/test_schema_helper.py
@@ -45,6 +45,24 @@ class TestBuildUserDataSchema:
         assert result[CONF_HOST] == "192.168.1.100"
         assert result[CONF_PORT] == DEFAULT_PORT
 
+    def test_schema_coerces_string_inputs_from_ui(self):
+        schema = build_user_data_schema()
+        result = cast(
+            dict[str, Any],
+            schema(
+                {
+                    CONF_HOST: "192.168.1.100",
+                    CONF_PORT: "8889",
+                    "timeout": "30.5",
+                    "max_data_length": "5000",
+                }
+            ),
+        )
+        assert result[CONF_HOST] == "192.168.1.100"
+        assert result[CONF_PORT] == 8889
+        assert result["timeout"] == 30.5
+        assert result["max_data_length"] == 5000
+
     def test_schema_uses_defaults(self):
         schema = build_user_data_schema()
         result = cast(dict[str, Any], schema({}))


### PR DESCRIPTION
## ✅ Summary

This PR fixes #656 and addresses a regression that was likely introduced with one line of code changed in #652 

The reconfigure flow could fail with a generic “unknown error” because the integration tried to read device identity information before the coordinator had completed its initial refresh. In addition, Home Assistant can submit numeric form values as strings, so the config schema needed to coerce those values correctly.

## 🔧 What changed

- Refresh the coordinator before using coordinator-derived unique ID data during initial setup and reconfigure
- Keep serial-number handling strict, without falling back to a compatibility path
- Coerce numeric form values in the config schema so manual entry and reconfigure submissions are accepted correctly
- Add regression tests covering the reconfigure and schema-validation behavior

## 💡 Why

This prevents the reconfigure flow from failing when the device is reachable but the first data refresh has not yet populated the required metadata.

## 🧪 Validation

Verified locally with:

- `pytest -q test_config_flow.py test_schema_helper.py tests/test_coordinator.py`

Result:
- 156 passed
- 1 warning
