### PR TITLE
fix(config_flow): 🐛 stop options flow crashing with a 500 on default update interval

### DIFF
--- a/custom_components/luxtronik2/config_flow.py
+++ b/custom_components/luxtronik2/config_flow.py
@@ -25,7 +25,7 @@ from .const import (
     DEFAULT_MAX_DATA_LENGTH,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
-    DEFAULT_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL_OPTION,
     DOMAIN,
     LOGGER,
 )
@@ -512,7 +512,7 @@ class LuxtronikOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
                     new_options[CONF_HA_SENSOR_INDOOR_TEMPERATURE] = None
 
                 update_interval = user_input.get(
-                    CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                    CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL_OPTION
                 )
                 new_options[CONF_UPDATE_INTERVAL] = update_interval
 
@@ -520,7 +520,7 @@ class LuxtronikOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
 
             current_indoor_temp = self._get_value(CONF_HA_SENSOR_INDOOR_TEMPERATURE)
             current_interval = self._get_value(
-                CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL_OPTION
             )
 
             return self.async_show_form(

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -42,6 +42,15 @@ UPDATE_INTERVAL_OPTIONS: Final = {
     "1 minute (default)": timedelta(seconds=60),
     "5 minutes": timedelta(minutes=5),
 }
+# The UPDATE_INTERVAL_OPTIONS key matching DEFAULT_UPDATE_INTERVAL. The options
+# flow's CONF_UPDATE_INTERVAL field is a SelectSelector whose default/suggested
+# value must be one of these string keys - DEFAULT_UPDATE_INTERVAL itself is a
+# timedelta and isn't JSON-serializable when used there.
+DEFAULT_UPDATE_INTERVAL_OPTION: Final = next(
+    key
+    for key, value in UPDATE_INTERVAL_OPTIONS.items()
+    if value == DEFAULT_UPDATE_INTERVAL
+)
 
 UPDATE_INTERVAL_FAST: Final = timedelta(seconds=10)
 UPDATE_INTERVAL_NORMAL: Final = timedelta(minutes=1)

--- a/custom_components/luxtronik2/schema_helper.py
+++ b/custom_components/luxtronik2/schema_helper.py
@@ -10,7 +10,7 @@ from .const import (
     DEFAULT_MAX_DATA_LENGTH,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
-    DEFAULT_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL_OPTION,
     UPDATE_INTERVAL_OPTIONS,
 )
 
@@ -53,9 +53,10 @@ def build_options_schema(
             ),
             vol.Optional(
                 CONF_UPDATE_INTERVAL,
-                default=current_interval or DEFAULT_UPDATE_INTERVAL,
+                default=current_interval or DEFAULT_UPDATE_INTERVAL_OPTION,
                 description={
-                    "suggested_value": current_interval or DEFAULT_UPDATE_INTERVAL
+                    "suggested_value": current_interval
+                    or DEFAULT_UPDATE_INTERVAL_OPTION
                 },
             ): selector.SelectSelector(
                 selector.SelectSelectorConfig(

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -14,6 +14,7 @@ from custom_components.luxtronik2.const import (
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
     DEFAULT_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL_OPTION,
     DOMAIN,
     PLATFORMS,
     UPDATE_INTERVAL_OPTIONS,
@@ -197,6 +198,19 @@ class TestUpdateIntervalConstants:
         assert UPDATE_INTERVAL_OPTIONS["30 seconds"].total_seconds() == 30
         assert UPDATE_INTERVAL_OPTIONS["1 minute (default)"].total_seconds() == 60
         assert UPDATE_INTERVAL_OPTIONS["5 minutes"].total_seconds() == 300
+
+    def test_default_update_interval_option_is_a_valid_key(self):
+        """DEFAULT_UPDATE_INTERVAL_OPTION must be a string key of
+        UPDATE_INTERVAL_OPTIONS, not the DEFAULT_UPDATE_INTERVAL timedelta
+        itself - the options flow's SelectSelector default must match one of
+        its own option values or the schema fails to serialize (see #656).
+        """
+        assert isinstance(DEFAULT_UPDATE_INTERVAL_OPTION, str)
+        assert DEFAULT_UPDATE_INTERVAL_OPTION in UPDATE_INTERVAL_OPTIONS
+        assert (
+            UPDATE_INTERVAL_OPTIONS[DEFAULT_UPDATE_INTERVAL_OPTION]
+            == DEFAULT_UPDATE_INTERVAL
+        )
 
     def test_conf_update_interval_constant(self):
         assert CONF_UPDATE_INTERVAL == "update_interval"

--- a/tests/test_schema_helper.py
+++ b/tests/test_schema_helper.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, cast
 
 from homeassistant.const import CONF_HOST, CONF_PORT
+import homeassistant.helpers.config_validation as cv
 import pytest
 import voluptuous as vol
+import voluptuous_serialize
 
 from custom_components.luxtronik2.const import (
     DEFAULT_PORT,
@@ -92,3 +95,18 @@ class TestBuildOptionsSchema:
             current_interval="1 minute",
         )
         assert isinstance(schema, vol.Schema)
+
+    def test_default_schema_is_json_serializable(self):
+        """Regression test for issue #656.
+
+        A config entry that has never saved options before (current_interval=None,
+        the common case) must not fall back to the raw DEFAULT_UPDATE_INTERVAL
+        timedelta - the frontend serializes this schema to JSON to render the
+        "Configure" form, and a timedelta default/suggested_value crashes that
+        with a 500 (TypeError: Object of type timedelta is not JSON serializable).
+        """
+        schema = build_options_schema()
+        converted = voluptuous_serialize.convert(
+            schema, custom_serializer=cv.custom_serializer
+        )
+        json.dumps(converted)  # must not raise


### PR DESCRIPTION
## 🐞 Problem

Opening "Configure" (gear icon) on the integration entry gives a `500 Internal Server Error`, reported across #656.

## 🔍 Root cause

Confirmed against a user's `home-assistant.log` in [#656](https://github.com/BenPru/luxtronik/issues/656):

```
ERROR (MainThread) [homeassistant.helpers.http] Unable to serialize to JSON. Bad data found at
$.data_schema[1].default=0:01:00(<class 'datetime.timedelta'>, $.data_schema[1].description.suggested_value=0:01:00(<class 'datetime.timedelta'>
```

`DEFAULT_UPDATE_INTERVAL` (`timedelta(seconds=60)`) was reused as the fallback default for the options flow's `CONF_UPDATE_INTERVAL` field. That field is a `SelectSelector` whose valid values are the *string* keys of `UPDATE_INTERVAL_OPTIONS` (`"10 seconds"`, `"1 minute (default)"`, ...) — not the timedelta itself. Any config entry that had never explicitly saved options before (the common case: fresh installs, reconfigured entries, anyone who hasn't touched the update-interval dropdown) fell through to this fallback, putting a raw `timedelta` into the schema's `default`/`suggested_value`. The frontend serializes the schema to JSON to render the form, and `timedelta` isn't JSON-serializable — hence the 500.

This was introduced when the update-interval option was added (`66c9fbe`, 2026-06-14) and is untouched by the earlier coordinator-refresh-ordering fixes in this issue, which is why those didn't resolve it.

## 🔧 Fix

- Add `DEFAULT_UPDATE_INTERVAL_OPTION` to `const.py`: the `UPDATE_INTERVAL_OPTIONS` string key matching `DEFAULT_UPDATE_INTERVAL`, derived from the dict itself so the two can never drift apart.
- Use it instead of `DEFAULT_UPDATE_INTERVAL` in `config_flow.py` and `schema_helper.py` wherever the options-flow schema needs a default. `DEFAULT_UPDATE_INTERVAL` itself is untouched and still correctly used as the coordinator's own polling-interval fallback.

## 🧪 Testing

- New regression test: `build_options_schema()` with no stored interval is run through `voluptuous_serialize.convert()` + `json.dumps()` — the exact path Home Assistant's frontend uses — and must not raise. Verified this test fails with the exact reported `TypeError: Object of type timedelta is not JSON serializable` against the old code.
- New const-level test pinning `DEFAULT_UPDATE_INTERVAL_OPTION` to a valid `UPDATE_INTERVAL_OPTIONS` key.
- `pytest -q` — 746 passed
- `ruff check` / `ruff format --check` — clean
- `basedpyright` — 0 errors

## ✅ Test plan

- [ ] Confirm "Configure" (gear icon) opens without error on an entry that has never saved options before
- [ ] Confirm the update-interval dropdown still shows/saves correctly

Resolves #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)