### PR TITLE
fix(config_flow): 🐛 stop DHCP discovery double-reloading config entries

### DIFF
--- a/custom_components/luxtronik2/config_flow.py
+++ b/custom_components/luxtronik2/config_flow.py
@@ -367,7 +367,13 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             await self.async_set_unique_id(coordinator.unique_id)
             self._abort_if_unique_id_configured(
-                updates={CONF_HOST: host, CONF_PORT: int(port or DEFAULT_PORT)}
+                updates={CONF_HOST: host, CONF_PORT: int(port or DEFAULT_PORT)},
+                # Our own update listener (see __init__.py) already reloads the
+                # entry on any data/options change, so core scheduling its own
+                # reload here as well is redundant and triggers a deprecation
+                # warning ("has an update listener and should use it for
+                # scheduling a reload"), which will start failing in 2026.12.
+                reload_on_update=False,
             )
 
             return self._create_entry(config, coordinator)


### PR DESCRIPTION
## 🐞 Problem

```
WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'luxtronik2' has an update listener and should use it for scheduling a reload. This will stop working in Home Assistant 2026.12.0, please create a bug report at https://github.com/BenPru/luxtronik/issues
```

## 🔍 Root cause

`__init__.py` registers a generic update listener (`entry.add_update_listener(update_listener)`) whose body unconditionally calls `hass.config_entries.async_reload(...)`. Home Assistant fires `update_listeners` on **any** entry change, not just options-flow changes — including data changes.

`async_step_dhcp` in `config_flow.py` calls `_abort_if_unique_id_configured(updates={...})` to silently keep a rediscovered device's host/port in sync. That data update:
- immediately fires our own `update_listener`, which schedules a reload, **and**
- separately, since `reload_on_update` defaults to `True`, core also schedules its own reload for the same entry, logging this deprecation warning in the process.

So a single DHCP rediscovery currently triggers two redundant reload schedules for the same entry. HA is deprecating this combination and it will stop working in 2026.12.0.

## 🔧 Fix

Pass `reload_on_update=False` to `_abort_if_unique_id_configured` in `async_step_dhcp`, since our own update listener already reloads the entry whenever its data changes. Core no longer needs to (and shouldn't) schedule a second reload.

## 🧪 Testing

- `pytest -k dhcp -q` — 5 passed
- `ruff check` — clean
- `basedpyright` — 0 errors

## ✅ Test plan

- [ ] Confirm DHCP rediscovery of an already-configured heat pump at a new IP still updates the entry's host/port
- [ ] Confirm the deprecation warning no longer appears in the log after a DHCP rediscovery event

🤖 Generated with [Claude Code](https://claude.com/claude-code)