### PR TITLE
fix(coordinator): 🐛 stop hiding heating/cooling devices before first use

### DIFF
--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -515,21 +515,13 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
 
     def device_key_active(self, device_key: DeviceKey) -> bool:
         """Is device key activated."""
-        if device_key == DeviceKey.heatpump:
+        if device_key in (DeviceKey.heatpump, DeviceKey.heating):
             return True
-        if device_key == DeviceKey.heating:
-            return self.has_heating
         if device_key == DeviceKey.domestic_water:
             return self.has_domestic_water
         if device_key == DeviceKey.cooling:
             return self.has_cooling
         raise NotImplementedError
-
-    @property
-    def has_heating(self) -> bool:
-        """Is heating activated."""
-        val = self.get_value(LC.C0064_OPERATION_HOURS_HEATING)
-        return val is not None and val > 0
 
     @property
     def has_domestic_water(self) -> bool:
@@ -541,7 +533,9 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
     def has_cooling(self) -> bool:
         """Is cooling activated."""
         val = self.get_value(LC.C0066_OPERATION_HOURS_COOLING)
-        return val is not None and val > 0
+        if val is not None and val > 0:
+            return True
+        return self.detect_cooling_present()
 
     def get_value(self, group_sensor_id: str | LP | LC | LV):
         """Get a sensor value from Luxtronik."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -271,9 +271,10 @@ class TestDeviceKeyActive:
         coord = _make_coordinator(calculations={"ID_WEB_Zaehler_BetrZeitHz": 100})
         assert coord.device_key_active(DeviceKey.heating) is True
 
-    def test_heating_inactive(self):
+    def test_heating_always_active_without_usage_hours(self):
+        """Heating device should show up even if heating has never run yet (#655)."""
         coord = _make_coordinator(calculations={"ID_WEB_Zaehler_BetrZeitHz": 0})
-        assert coord.device_key_active(DeviceKey.heating) is False
+        assert coord.device_key_active(DeviceKey.heating) is True
 
     def test_domestic_water_active(self):
         coord = _make_coordinator(calculations={"ID_WEB_Zaehler_BetrZeitBW": 100})
@@ -290,6 +291,14 @@ class TestDeviceKeyActive:
     def test_cooling_inactive(self):
         coord = _make_coordinator(calculations={"ID_WEB_Zaehler_BetrZeitKue": 0})
         assert coord.device_key_active(DeviceKey.cooling) is False
+
+    def test_cooling_active_without_usage_hours_when_configured(self):
+        """Cooling device should show up even if cooling has never run yet (#655)."""
+        coord = _make_coordinator(
+            calculations={"ID_WEB_Zaehler_BetrZeitKue": 0},
+            parameters={"ID_Einst_MK1Typ_akt": 3},  # LuxMkTypes.cooling.value
+        )
+        assert coord.device_key_active(DeviceKey.cooling) is True
 
     def test_unknown_device_key_raises(self):
         coord = _make_coordinator()


### PR DESCRIPTION
## 🐛 Problem

Reported in #655: on a freshly commissioned system, the **heating** and **cooling** devices (and every entity under them) were missing entirely, even though DHW showed up fine.

Cause: `has_heating`/`has_cooling` gated the *entire device* on cumulative operating hours reported by the heat pump (`> 0`). If a mode simply hadn't run yet — e.g. heating/cooling never activated on a newly poured floor, or cooling checked outside the season — its device was hidden instead of just showing zeroed-out sensors. DHW only worked for the reporter by coincidence, since it had already accumulated hours.

## ✅ Fix

- **Heating**: now always creates the device, the same way the `heatpump` device is always created. Every supported Luxtronik heat pump can heat, so there isn't a meaningful "not present" case here — removed the now-dead `has_heating` property.
- **Cooling**: creates the device if usage hours are `> 0` **or** `detect_cooling_present()` says a mixing circuit is configured for `cooling`/`heating_cooling`. This reuses the existing, already-trusted MK-based detection (previously only used for per-entity visibility of `V0005_COOLING`), so cooling shows up as soon as it's configured rather than after it's actually run once.
- **Domestic water** is intentionally left unchanged — DHW is used year-round (not seasonal like heating/cooling), so a system with 0 DHW hours self-corrects within days. We'll only revisit it if it turns out to be a real problem in practice.

## 🧪 Test plan

- [x] Added `test_heating_always_active_without_usage_hours` (heating device active even with 0 hours)
- [x] Added `test_cooling_active_without_usage_hours_when_configured` (cooling device active with 0 hours but MK1 configured as cooling)
- [x] `pytest` — 747 passed, 100% coverage maintained
- [x] `ruff check` / `ruff format --check` — clean
- [x] `basedpyright` — 0 errors

Resolves #655