### PR TITLE
fix(config_flow): stop DHCP discovery masking already_configured as unknown error

### DIFF
--- a/custom_components/luxtronik2/config_flow.py
+++ b/custom_components/luxtronik2/config_flow.py
@@ -46,11 +46,6 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Luxtronik heatpump controller config flow."""
 
     VERSION = CONFIG_ENTRY_VERSION
-    _discovery_host = None
-    _discovery_port = None
-
-    _sensor_prefix = DOMAIN
-    _title = "Luxtronik"
     _all_devices: list[dict[str, Any]] = []
     _available_devices: list[dict[str, Any]] = []
 
@@ -378,6 +373,8 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             return self._create_entry(config, coordinator)
 
+        except AbortFlow:
+            raise
         except Exception as err:
             LOGGER.error("Unhandled DHCP discovery error", exc_info=err)
             return self.async_abort(reason="unknown")
@@ -481,15 +478,11 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> config_entries.OptionsFlow:
         """Get default options flow."""
-        from .config_flow import LuxtronikOptionsFlowHandler
-
         return LuxtronikOptionsFlowHandler(config_entry)
 
 
 class LuxtronikOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
     """Handle a Luxtronik options flow."""
-
-    _sensor_prefix = DOMAIN
 
     def _get_value(self, key: str, default=None):
         """Return a value from Luxtronik."""

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -1056,19 +1056,6 @@
                     "select_device_to_configure": "Vyberte za\u0159\u00edzen\u00ed, kter\u00e9 chcete nakonfigurovat"
                 }
             },
-            "options": {
-                "description": "Nastaven\u00ed pro tepeln\u00e9 \u010derpadlo Luxtronik {name}.\nTato nastaven\u00ed lze pozd\u011bji zm\u011bnit v sekci Integrace.",
-                "data": {
-                    "ha_sensor_indoor_temperature": "ID senzoru vnit\u0159n\u00ed teploty",
-                    "control_mode_home_assistant": "Experiment\u00e1ln\u00ed!: \u0158\u00edzen\u00ed stavu termostatu pomoc\u00ed Home Assistant.",
-                    "ha_sensor_prefix": "P\u0159edpona pro ID entit"
-                },
-                "data_description": {
-                    "ha_sensor_indoor_temperature": "Termostat pro \u0159\u00edzen\u00ed vyt\u00e1p\u011bn\u00ed je vytvo\u0159en v Home Assistant. Skute\u010dn\u00e1 teplota je nastavena senzorem Home Assistant.\nPokud je Luxtronik p\u0159ipojen k hardwarov\u00e9mu pokojov\u00e9mu termostatu, ponechte toto pole pr\u00e1zdn\u00e9.",
-                    "control_mode_home_assistant": "Kdy\u017e je termostat Home Assistant v ne\u010dinn\u00e9m stavu, stav vypnut\u00ed je hl\u00e1\u0161en Luxtroniku a Luxtronik nem\u016f\u017ee tento prvek spustit.",
-                    "ha_sensor_prefix": "D\u016fle\u017eit\u00e9 p\u0159i pou\u017eit\u00ed v\u00edce tepeln\u00fdch \u010derpadel. V p\u0159\u00edpad\u011b jednoho lze jednodu\u0161e pou\u017e\u00edt 'luxtronik'."
-                }
-            },
             "reconfigure": {
                 "title": "P\u0159ekonfigurovat p\u0159ipojen\u00ed Luxtronik",
                 "description": "Aktualizujte nastaven\u00ed p\u0159ipojen\u00ed pro tepeln\u00e9 \u010derpadlo Luxtronik.",
@@ -1093,10 +1080,12 @@
                 "title": "Nakonfigurujte mo\u017enosti pro {name}",
                 "description": "Nastaven\u00ed pro tepeln\u00e9 \u010derpadlo Luxtronik {name}.",
                 "data": {
-                    "ha_sensor_indoor_temperature": "ID senzoru vnit\u0159n\u00ed teploty"
+                    "ha_sensor_indoor_temperature": "ID senzoru vnit\u0159n\u00ed teploty",
+                    "update_interval": "Interval aktualizace"
                 },
                 "data_description": {
-                    "ha_sensor_indoor_temperature": "Termostat pro \u0159\u00edzen\u00ed vyt\u00e1p\u011bn\u00ed je vytvo\u0159en v Home Assistant. Skute\u010dn\u00e1 teplota je nastavena senzorem Home Assistant.\nPokud je Luxtronik p\u0159ipojen k hardwarov\u00e9mu pokojov\u00e9mu termostatu, ponechte toto pole pr\u00e1zdn\u00e9."
+                    "ha_sensor_indoor_temperature": "Termostat pro \u0159\u00edzen\u00ed vyt\u00e1p\u011bn\u00ed je vytvo\u0159en v Home Assistant. Skute\u010dn\u00e1 teplota je nastavena senzorem Home Assistant.\nPokud je Luxtronik p\u0159ipojen k hardwarov\u00e9mu pokojov\u00e9mu termostatu, ponechte toto pole pr\u00e1zdn\u00e9.",
+                    "update_interval": "Jak \u010dasto se m\u00e1 tepeln\u00e9 \u010derpadlo dotazovat na nov\u00e1 data."
                 }
             }
         }

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -1051,19 +1051,6 @@
                     "select_device_to_configure": "W\u00e4hlen Sie das Ger\u00e4t aus, das Sie konfigurieren m\u00f6chten"
                 }
             },
-            "options": {
-                "description": "Einstellungen f\u00fcr die Luxtronik-W\u00e4rmepumpe {name}.\nDiese Einstellungen k\u00f6nnen sp\u00e4ter unter Integrationen ge\u00e4ndert werden.",
-                "data": {
-                    "ha_sensor_indoor_temperature": "Sensor-ID f\u00fcr die Raumtemperatur",
-                    "control_mode_home_assistant": "Experimentell!: Thermostatstatus \u00fcber Home Assistant steuern.",
-                    "ha_sensor_prefix": "Pr\u00e4fix f\u00fcr Entity-IDs"
-                },
-                "data_description": {
-                    "ha_sensor_indoor_temperature": "Ein Thermostat zur Heizungssteuerung wird in Home Assistant erstellt. Die tats\u00e4chliche Temperatur wird von einem Home Assistant-Sensor gesetzt.\nWenn Luxtronik mit einem Hardware-Raumthermostat verbunden ist, sollte dieses Feld leer bleiben.",
-                    "control_mode_home_assistant": "Wenn sich das Home Assistant-Thermostat im Leerlauf befindet, wird der Aus-Zustand an Luxtronik gemeldet und Luxtronik kann dieses Element nicht starten.",
-                    "ha_sensor_prefix": "Wichtig bei Verwendung mehrerer W\u00e4rmepumpen. Bei einer einzelnen kann einfach 'luxtronik' verwendet werden."
-                }
-            },
             "reconfigure": {
                 "title": "Luxtronik-Verbindung neu konfigurieren",
                 "description": "Aktualisieren Sie die Verbindungseinstellungen f\u00fcr die Luxtronik-W\u00e4rmepumpe.",
@@ -1088,10 +1075,12 @@
                 "title": "Optionen f\u00fcr {name} konfigurieren",
                 "description": "Einstellungen f\u00fcr die Luxtronik-W\u00e4rmepumpe {name}.",
                 "data": {
-                    "ha_sensor_indoor_temperature": "Sensor-ID f\u00fcr die Raumtemperatur"
+                    "ha_sensor_indoor_temperature": "Sensor-ID f\u00fcr die Raumtemperatur",
+                    "update_interval": "Aktualisierungsintervall"
                 },
                 "data_description": {
-                    "ha_sensor_indoor_temperature": "Ein Thermostat zur Heizungssteuerung wird in Home Assistant erstellt. Die tats\u00e4chliche Temperatur wird von einem Home Assistant-Sensor gesetzt.\nWenn Luxtronik mit einem Hardware-Raumthermostat verbunden ist, sollte dieses Feld leer bleiben."
+                    "ha_sensor_indoor_temperature": "Ein Thermostat zur Heizungssteuerung wird in Home Assistant erstellt. Die tats\u00e4chliche Temperatur wird von einem Home Assistant-Sensor gesetzt.\nWenn Luxtronik mit einem Hardware-Raumthermostat verbunden ist, sollte dieses Feld leer bleiben.",
+                    "update_interval": "Wie oft die W\u00e4rmepumpe nach neuen Daten abgefragt wird."
                 }
             }
         }

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -786,19 +786,6 @@
                     "select_device_to_configure": "Select the device you want to configure"
                 }
             },
-            "options": {
-                "description": "Settings for the Luxtronik heatpump {name}.\nThese settings can also be changed later under Integrations.",
-                "data": {
-                    "ha_sensor_indoor_temperature": "Sensor ID for the indoor temperature",
-                    "control_mode_home_assistant": "Experimental!: Control thermostat on/off status by Home Assistant.",
-                    "ha_sensor_prefix": "Prefix entity IDs"
-                },
-                "data_description": {
-                    "ha_sensor_indoor_temperature": "A thermostat for heating control is created in Home Assistant. The actual temperature for this is set by a Home Assistant sensor.\nIf Luxtronik is connected to a hardware room thermostat, then this field should be left empty.",
-                    "control_mode_home_assistant": "When the Home Assistant Thermostat is in the Idle state, the Off state is reported to Luxtronik and Luxtronik cannot start this item.",
-                    "ha_sensor_prefix": "Important if several heat pumps are used.\nIn the case of a single one, 'luxtronik' can simply be used."
-                }
-            },
             "reconfigure": {
                 "title": "Reconfigure Luxtronik connection",
                 "description": "Update the connection settings for the Luxtronik heat pump.",
@@ -823,10 +810,12 @@
                 "title": "Configure options for {name}",
                 "description": "Settings for the Luxtronik heat pump {name}.",
                 "data": {
-                    "ha_sensor_indoor_temperature": "Sensor ID for the indoor temperature"
+                    "ha_sensor_indoor_temperature": "Sensor ID for the indoor temperature",
+                    "update_interval": "Update interval"
                 },
                 "data_description": {
-                    "ha_sensor_indoor_temperature": "A thermostat for heating control is created in Home Assistant. The actual temperature for this is set by a Home Assistant sensor.\nIf Luxtronik is connected to a hardware room thermostat, then this field should be left empty."
+                    "ha_sensor_indoor_temperature": "A thermostat for heating control is created in Home Assistant. The actual temperature for this is set by a Home Assistant sensor.\nIf Luxtronik is connected to a hardware room thermostat, then this field should be left empty.",
+                    "update_interval": "How often to poll the heat pump for new data."
                 }
             }
         }

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -1041,19 +1041,6 @@
                     "select_device_to_configure": "Selecteer de heatpomp die je wilt configureren"
                 }
             },
-            "options": {
-                "description": "Instellingen voor de Luxtronik warmtepomp {name}.\nDeze instellingen kunnen later worden gewijzigd onder Integraties.",
-                "data": {
-                    "ha_sensor_indoor_temperature": "Sensor-ID voor de binnentemperatuur",
-                    "control_mode_home_assistant": "Experimenteel!: Thermostaatstatus regelen via Home Assistant.",
-                    "ha_sensor_prefix": "Voorvoegsel voor entiteit-ID's"
-                },
-                "data_description": {
-                    "ha_sensor_indoor_temperature": "Een thermostaat voor verwarmingsregeling wordt aangemaakt in Home Assistant. De werkelijke temperatuur wordt ingesteld door een Home Assistant-sensor.\nAls Luxtronik is verbonden met een hardware kamerthermostaat, laat dit veld dan leeg.",
-                    "control_mode_home_assistant": "Wanneer de Home Assistant-thermostaat in de idle-status staat, wordt de uit-status aan Luxtronik gemeld en kan Luxtronik dit item niet starten.",
-                    "ha_sensor_prefix": "Belangrijk bij gebruik van meerdere warmtepompen. Bij \u00e9\u00e9n enkele kan gewoon 'luxtronik' worden gebruikt."
-                }
-            },
             "reconfigure": {
                 "title": "Luxtronik-verbinding opnieuw configureren",
                 "description": "Werk de verbindingsinstellingen bij voor de Luxtronik warmtepomp.",
@@ -1078,10 +1065,12 @@
                 "title": "Opties configureren voor {name}",
                 "description": "Instellingen voor de Luxtronik warmtepomp {name}.",
                 "data": {
-                    "ha_sensor_indoor_temperature": "Sensor-ID voor de binnentemperatuur"
+                    "ha_sensor_indoor_temperature": "Sensor-ID voor de binnentemperatuur",
+                    "update_interval": "Update-interval"
                 },
                 "data_description": {
-                    "ha_sensor_indoor_temperature": "Een thermostaat voor verwarmingsregeling wordt aangemaakt in Home Assistant. De werkelijke temperatuur wordt ingesteld door een Home Assistant-sensor.\nAls Luxtronik is verbonden met een hardware kamerthermostaat, laat dit veld dan leeg."
+                    "ha_sensor_indoor_temperature": "Een thermostaat voor verwarmingsregeling wordt aangemaakt in Home Assistant. De werkelijke temperatuur wordt ingesteld door een Home Assistant-sensor.\nAls Luxtronik is verbonden met een hardware kamerthermostaat, laat dit veld dan leeg.",
+                    "update_interval": "Hoe vaak de warmtepomp wordt bevraagd voor nieuwe gegevens."
                 }
             }
         }

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -1069,19 +1069,6 @@
                     "select_device_to_configure": "Wybierz urz\u0105dzenie, kt\u00f3re chcesz skonfigurowa\u0107"
                 }
             },
-            "options": {
-                "description": "Ustawienia dla pompy ciep\u0142a Luxtronik {name}.\nTe ustawienia mo\u017cna p\u00f3\u017aniej zmieni\u0107 w sekcji Integracje.",
-                "data": {
-                    "ha_sensor_indoor_temperature": "ID czujnika temperatury wewn\u0119trznej",
-                    "control_mode_home_assistant": "Eksperymentalne!: Sterowanie statusem termostatu przez Home Assistant.",
-                    "ha_sensor_prefix": "Prefiks dla identyfikator\u00f3w encji"
-                },
-                "data_description": {
-                    "ha_sensor_indoor_temperature": "Termostat do sterowania ogrzewaniem jest tworzony w Home Assistant. Rzeczywista temperatura jest ustawiana przez czujnik Home Assistant.\nJe\u015bli Luxtronik jest pod\u0142\u0105czony do sprz\u0119towego termostatu pokojowego, pozostaw to pole puste.",
-                    "control_mode_home_assistant": "Gdy termostat Home Assistant jest w stanie bezczynno\u015bci, stan wy\u0142\u0105czenia jest zg\u0142aszany do Luxtronik i Luxtronik nie mo\u017ce uruchomi\u0107 tego elementu.",
-                    "ha_sensor_prefix": "Wa\u017cne przy u\u017cyciu wielu pomp ciep\u0142a. W przypadku jednej mo\u017cna po prostu u\u017cy\u0107 'luxtronik'."
-                }
-            },
             "reconfigure": {
                 "title": "Rekonfiguracja po\u0142\u0105czenia Luxtronik",
                 "description": "Zaktualizuj ustawienia po\u0142\u0105czenia dla pompy ciep\u0142a Luxtronik.",
@@ -1106,10 +1093,12 @@
                 "title": "Skonfiguruj opcje dla {name}",
                 "description": "Ustawienia dla pompy ciep\u0142a Luxtronik {name}.",
                 "data": {
-                    "ha_sensor_indoor_temperature": "ID czujnika temperatury wewn\u0119trznej"
+                    "ha_sensor_indoor_temperature": "ID czujnika temperatury wewn\u0119trznej",
+                    "update_interval": "Interwa\u0142 aktualizacji"
                 },
                 "data_description": {
-                    "ha_sensor_indoor_temperature": "Termostat do sterowania ogrzewaniem jest tworzony w Home Assistant. Rzeczywista temperatura jest ustawiana przez czujnik Home Assistant.\nJe\u015bli Luxtronik jest pod\u0142\u0105czony do sprz\u0119towego termostatu pokojowego, pozostaw to pole puste."
+                    "ha_sensor_indoor_temperature": "Termostat do sterowania ogrzewaniem jest tworzony w Home Assistant. Rzeczywista temperatura jest ustawiana przez czujnik Home Assistant.\nJe\u015bli Luxtronik jest pod\u0142\u0105czony do sprz\u0119towego termostatu pokojowego, pozostaw to pole puste.",
+                    "update_interval": "Jak cz\u0119sto odpytywa\u0107 pomp\u0119 ciep\u0142a o nowe dane."
                 }
             }
         }


### PR DESCRIPTION
## 🐛 What

- **DHCP AbortFlow masking:** `async_step_dhcp`'s broad `except Exception` was catching the `AbortFlow` legitimately raised by `_abort_if_unique_id_configured` when a previously-configured heat pump gets a new DHCP lease/IP. Instead of the intended graceful "already_configured" abort (which had already updated the entry's host/port), the flow logged a scary "Unhandled DHCP discovery error" traceback and reported `reason="unknown"`. Fixed by re-raising `AbortFlow` before the catch-all, matching the pattern already used in `async_step_reconfigure`.
- **Missing options translation:** the options flow's `update_interval` selector (added for configurable poll interval) had no translation label in any of the 5 locale files, so it rendered as the raw key `update_interval`. Added labels/descriptions to en/de/nl/pl/cs.

## 🧹 Cleanup

- Removed dead class attributes `_discovery_host`, `_discovery_port`, `_title`, `_sensor_prefix` (never read anywhere).
- Removed an unnecessary self-import in `async_get_options_flow`.
- Removed leftover dead `config.step.options` translation blocks (`control_mode_home_assistant`, `ha_sensor_prefix`) in all 5 locales — cruft from before the options flow moved to the top-level `options` translation key; never read by any code path.

## Test plan

- [x] `pytest` — 747 passed
- [x] `ruff check` — clean
- [x] `basedpyright` — 0 errors
- [x] Reproduced the DHCP bug with a scripted repro (mocking `_abort_if_unique_id_configured` to raise `AbortFlow` as real HA does) — confirmed `AbortFlow` now propagates instead of being swallowed.
- [x] Verified all 5 translation JSON files still parse.