### PR TITLE
fix(coordinator): 🐛 validate serial number instead of masking missing data

### DIFF
--- a/custom_components/luxtronik2/config_flow.py
+++ b/custom_components/luxtronik2/config_flow.py
@@ -32,6 +32,7 @@ from .const import (
 from .coordinator import (
     LuxtronikConnectionError,
     LuxtronikCoordinator,
+    LuxtronikSerialNumberError,
     connect_and_get_coordinator,
 )
 from .lux_helper import discover
@@ -75,16 +76,27 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _set_unique_id_or_abort(
         self, coordinator: LuxtronikCoordinator, config: dict[str, Any]
-    ) -> bool:
-        """Set unique ID and abort if already configured."""
+    ) -> ConfigFlowResult | None:
+        """Set unique ID, returning an abort result if the flow should stop.
+
+        Returns None if the flow should proceed to create/update the entry.
+        """
         try:
             await self.async_set_unique_id(coordinator.unique_id)
             self._abort_if_unique_id_configured()
-
-            return True
+            return None
         except AbortFlow:
             LOGGER.debug("Device already configured: %s", config[CONF_HOST])
-            return False
+            return self.async_abort(reason="already_configured")
+        except LuxtronikSerialNumberError as err:
+            LOGGER.error("Could not identify device at %s: %s", config[CONF_HOST], err)
+            return self.async_abort(
+                reason="cannot_identify",
+                description_placeholders={
+                    "host": config[CONF_HOST],
+                    "error": str(err),
+                },
+            )
 
     def _create_entry(
         self, config: dict[str, Any], coordinator: LuxtronikCoordinator
@@ -206,8 +218,8 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             )
 
-        if not await self._set_unique_id_or_abort(coordinator, config):
-            return self.async_abort(reason="already_configured")
+        if abort_result := await self._set_unique_id_or_abort(coordinator, config):
+            return abort_result
 
         return self._create_entry(config, coordinator)
 
@@ -239,10 +251,10 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 },
             )
 
-        if not await self._set_unique_id_or_abort(
+        if abort_result := await self._set_unique_id_or_abort(  # pragma: no cover
             coordinator, config
-        ):  # pragma: no cover
-            return self.async_abort(reason="already_configured")
+        ):
+            return abort_result
 
         return self._create_entry(config, coordinator)
 
@@ -360,7 +372,16 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                 )
 
-            await self.async_set_unique_id(coordinator.unique_id)
+            try:
+                await self.async_set_unique_id(coordinator.unique_id)
+            except LuxtronikSerialNumberError as err:
+                LOGGER.error(
+                    "Could not identify DHCP-discovered device at %s: %s", host, err
+                )
+                return self.async_abort(
+                    reason="cannot_identify",
+                    description_placeholders={"host": host, "error": str(err)},
+                )
             self._abort_if_unique_id_configured(
                 updates={CONF_HOST: host, CONF_PORT: int(port or DEFAULT_PORT)},
                 # Our own update listener (see __init__.py) already reloads the
@@ -425,12 +446,12 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 LOGGER.exception("Unexpected exception during reconfigure connect")
                 errors["base"] = "unknown"
             else:
-                LOGGER.debug(
-                    "Reconfigure connected and refreshed successfully; entry unique_id=%s, coordinator unique_id=%s",
-                    reconfigure_entry.unique_id,
-                    coordinator.unique_id,
-                )
                 try:
+                    LOGGER.debug(
+                        "Reconfigure connected and refreshed successfully; entry unique_id=%s, coordinator unique_id=%s",
+                        reconfigure_entry.unique_id,
+                        coordinator.unique_id,
+                    )
                     await self.async_set_unique_id(coordinator.unique_id)
                     if reconfigure_entry.unique_id is None:
                         LOGGER.debug(
@@ -454,6 +475,13 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         err,
                     )
                     raise
+                except LuxtronikSerialNumberError as err:
+                    LOGGER.error(
+                        "Reconfigure could not identify device at %s: %s",
+                        config[CONF_HOST],
+                        err,
+                    )
+                    errors["base"] = "cannot_identify"
                 except Exception:  # pylint: disable=broad-except
                     LOGGER.exception("Unexpected exception during reconfigure update")
                     errors["base"] = "unknown"

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -4,13 +4,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Coroutine, Mapping
+from collections.abc import Callable, Mapping
 from datetime import timedelta
-from functools import wraps
 import operator
 import re
 from types import MappingProxyType
-from typing import Any, Concatenate, Final, ParamSpec, TypeVar
+from typing import Any, Final
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
@@ -52,30 +51,6 @@ from .lux_overrides import (
 from .model import LuxtronikCoordinatorData, LuxtronikEntityDescription
 
 # endregion Imports
-
-_LuxtronikCoordinatorT = TypeVar("_LuxtronikCoordinatorT", bound="LuxtronikCoordinator")
-_P = ParamSpec("_P")
-
-
-def catch_luxtronik_errors(
-    func: Callable[Concatenate[_LuxtronikCoordinatorT, _P], Awaitable[None]],
-) -> Callable[Concatenate[_LuxtronikCoordinatorT, _P], Coroutine[Any, Any, None]]:
-    """Catch Luxtronik errors."""
-
-    @wraps(func)
-    async def wrapper(
-        self: _LuxtronikCoordinatorT,
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> None:
-        """Catch Luxtronik errors and log message."""
-        try:
-            await func(self, *args, **kwargs)
-        except Exception as err:  # pylint: disable=broad-except
-            LOGGER.error("Command error: %s", err)
-        await self.async_request_refresh()
-
-    return wrapper
 
 
 class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
@@ -160,7 +135,7 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
 
             return self.data
         except Exception as err:
-            raise UpdateFailed(f"Write error: {err}") from err
+            raise LuxtronikWriteError(f"Write error: {err}") from err
 
     @staticmethod
     async def connect(  # pragma: no cover
@@ -318,8 +293,21 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
 
     @property
     def serial_number(self) -> str:
-        """Return the serial number."""
+        """Return the serial number.
+
+        Raises:
+            LuxtronikSerialNumberError: if the serial number date (P0874) is
+                unavailable. This feeds `unique_id`, so it must be treated as
+                a hard error rather than silently identifying the device
+                with an empty/placeholder value.
+
+        """
         serial_number_date = self.get_value(LP.P0874_SERIAL_NUMBER)
+        if serial_number_date is None:
+            raise LuxtronikSerialNumberError(
+                "Serial number (P0874) is not available - coordinator data "
+                "may not be populated yet"
+            )
         serial_number_model = self.get_value(LP.P0875_SERIAL_NUMBER_MODEL)
         serial_number_hex = (
             hex(int(serial_number_model)) if serial_number_model is not None else "0"
@@ -558,6 +546,8 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
 
     def get_sensor(self, group: str, sensor_id: str):
         """Get sensor by configured sensor ID from coordinator data."""
+        if self.data is None:
+            return None
         if group == CONF_PARAMETERS:
             return self.data.parameters.get(sensor_id)
         if group == CONF_CALCULATIONS:
@@ -618,6 +608,7 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         """Make sure a coordinator is shut down as well as its connection."""
         await super().async_shutdown()
         if hasattr(self, "client") and self.client is not None:
+            await self.hass.async_add_executor_job(self.client.disconnect)
             del self.client
 
 
@@ -631,6 +622,19 @@ class LuxtronikConnectionError(HomeAssistantError):
         self.host = host
         self.port = port
         self.original = original
+
+
+class LuxtronikWriteError(HomeAssistantError):
+    """Raised when writing a parameter to the Luxtronik device fails."""
+
+
+class LuxtronikSerialNumberError(HomeAssistantError):
+    """Raised when the heatpump's serial number cannot be determined.
+
+    The serial number feeds `unique_id`, so treating it as "not available
+    yet" and falling back to an empty value would risk two different
+    devices ending up with colliding (empty) device/entry identifiers.
+    """
 
 
 _OVERRIDES_APPLIED = False
@@ -674,6 +678,15 @@ async def connect_and_get_coordinator(
             )
         else:
             await coordinator.async_refresh()
+            if not coordinator.last_update_success:
+                # async_refresh() (unlike async_config_entry_first_refresh())
+                # swallows update failures instead of raising. Without this
+                # check we'd hand back a coordinator with no data, and the
+                # failure would only surface later as a confusing error when
+                # something (e.g. unique_id) tries to read a sensor value.
+                raise RuntimeError(
+                    f"Initial data refresh did not succeed for {host}:{port}"
+                )
             LOGGER.debug(
                 "Initial coordinator refresh completed for %s:%s via direct config",
                 host,

--- a/custom_components/luxtronik2/lux_helper.py
+++ b/custom_components/luxtronik2/lux_helper.py
@@ -228,6 +228,10 @@ class Luxtronik:
         """Luxtronik helper descructor."""
         self._disconnect()
 
+    def disconnect(self) -> None:
+        """Explicitly close the connection to the heatpump."""
+        self._disconnect()
+
     def _disconnect(self):
         if self._socket is not None:
             if not _is_socket_closed(self._socket):

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -1012,6 +1012,7 @@
     "config": {
         "abort": {
             "cannot_connect": "Nepoda\u0159ilo se p\u0159ipojit k Luxtronik na adrese {host}.\\nChyba: {connect_error}",
+            "cannot_identify": "P\u0159ipojeno k za\u0159\u00edzen\u00ed na adrese {host}, ale nepoda\u0159ilo se p\u0159e\u010d\u00edst jeho s\u00e9riov\u00e9 \u010d\u00edslo pro identifikaci.\\nChyba: {error}",
             "already_configured": "Toto za\u0159\u00edzen\u00ed je ji\u017e nakonfigurov\u00e1no.",
             "reconfigure_successful": "Konfigurace \u00fasp\u011b\u0161n\u011b aktualizov\u00e1na.",
             "unique_id_mismatch": "Za\u0159\u00edzen\u00ed na nov\u00e9 adrese m\u00e1 jinou identitu ne\u017e aktu\u00e1ln\u011b nakonfigurovan\u00e9 za\u0159\u00edzen\u00ed.",
@@ -1026,6 +1027,7 @@
             "address": "Neplatn\u00e1 vzd\u00e1len\u00e1 adresa. Adresa mus\u00ed b\u00fdt IP adresa nebo rozpoznateln\u00fd n\u00e1zev hostitele.",
             "address_in_use": "Zvolen\u00fd port je ji\u017e v tomto syst\u00e9mu pou\u017e\u00edv\u00e1n.",
             "cannot_connect": "P\u0159ipojen\u00ed se nezda\u0159ilo. Zkontrolujte pros\u00edm host a port.",
+            "cannot_identify": "P\u0159ipojeno k za\u0159\u00edzen\u00ed, ale nepoda\u0159ilo se p\u0159e\u010d\u00edst jeho s\u00e9riov\u00e9 \u010d\u00edslo pro identifikaci.",
             "unknown": "Neo\u010dek\u00e1van\u00e1 chyba"
         },
         "step": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -1007,6 +1007,7 @@
     "config": {
         "abort": {
             "cannot_connect": "Verbindung zu Luxtronik unter {host} fehlgeschlagen.\\nFehler: {connect_error}",
+            "cannot_identify": "Verbindung zum Ger\u00e4t unter {host} hergestellt, aber die Seriennummer zur Identifizierung konnte nicht gelesen werden.\\nFehler: {error}",
             "already_configured": "Dieses Ger\u00e4t ist bereits konfiguriert.",
             "reconfigure_successful": "Konfiguration erfolgreich aktualisiert.",
             "unique_id_mismatch": "Das Ger\u00e4t an der neuen Adresse hat eine andere Identit\u00e4t als das aktuell konfigurierte Ger\u00e4t.",
@@ -1021,6 +1022,7 @@
             "address": "Ung\u00fcltige Remote-Adresse. Die Adresse muss eine IP-Adresse oder ein aufl\u00f6sbarer Hostname sein.",
             "address_in_use": "Der gew\u00e4hlte Port wird bereits auf diesem System verwendet.",
             "cannot_connect": "Verbindung fehlgeschlagen. Bitte Host und Port \u00fcberpr\u00fcfen.",
+            "cannot_identify": "Verbindung zum Ger\u00e4t hergestellt, aber die Seriennummer zur Identifizierung konnte nicht gelesen werden.",
             "unknown": "Unerwarteter Fehler"
         },
         "step": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -742,6 +742,7 @@
     "config": {
         "abort": {
             "cannot_connect": "Failed to connect to Luxtronik at {host}.\\nError: {connect_error}",
+            "cannot_identify": "Connected to the device at {host}, but could not read its serial number to identify it.\\nError: {error}",
             "already_configured": "This device is already configured.",
             "reconfigure_successful": "Configuration updated successfully.",
             "unique_id_mismatch": "The device at the new address has a different identity than the currently configured device.",
@@ -756,6 +757,7 @@
             "address": "Invalid remote-address insert. The address has to be an IP address or a resolvable hostname.",
             "address_in_use": "The chosen listen port is already in use on this system.",
             "cannot_connect": "Failed to connect. Please check the host and port.",
+            "cannot_identify": "Connected to the device, but could not read its serial number to identify it.",
             "unknown": "Unexpected error"
         },
         "step": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -997,6 +997,7 @@
     "config": {
         "abort": {
             "cannot_connect": "De verbinding met Luxtronik op {host} is mislukt.\nFout: {connect_error}",
+            "cannot_identify": "Verbonden met het apparaat op {host}, maar het serienummer kon niet worden gelezen om het te identificeren.\nFout: {error}",
             "already_configured": "Dit apparaat is al geconfigureerd.",
             "reconfigure_successful": "Configuratie succesvol bijgewerkt.",
             "unique_id_mismatch": "Het apparaat op het nieuwe adres heeft een andere identiteit dan het momenteel geconfigureerde apparaat.",
@@ -1011,6 +1012,7 @@
             "address": "Ongeldig extern adres. Het adres moet een IP-adres of een oplosbare hostnaam zijn.",
             "address_in_use": "De gekozen poort is al in gebruik op dit systeem.",
             "cannot_connect": "Verbinding mislukt. Controleer de host en poort.",
+            "cannot_identify": "Verbonden met het apparaat, maar het serienummer kon niet worden gelezen om het te identificeren.",
             "unknown": "Onverwachte fout"
         },
         "step": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -1025,6 +1025,7 @@
     "config": {
         "abort": {
             "cannot_connect": "Nie uda\u0142o si\u0119 po\u0142\u0105czy\u0107 z Luxtronik pod adresem {host}.\\nB\u0142\u0105d: {connect_error}",
+            "cannot_identify": "Po\u0142\u0105czono z urz\u0105dzeniem pod adresem {host}, ale nie uda\u0142o si\u0119 odczyta\u0107 jego numeru seryjnego w celu identyfikacji.\\nB\u0142\u0105d: {error}",
             "already_configured": "To urz\u0105dzenie jest ju\u017c skonfigurowane.",
             "reconfigure_successful": "Konfiguracja zosta\u0142a pomy\u015blnie zaktualizowana.",
             "unique_id_mismatch": "Urz\u0105dzenie pod nowym adresem ma inn\u0105 to\u017csamo\u015b\u0107 ni\u017c aktualnie skonfigurowane urz\u0105dzenie.",
@@ -1039,6 +1040,7 @@
             "address": "Nieprawid\u0142owy adres zdalny. Adres musi by\u0107 adresem IP lub rozpoznawaln\u0105 nazw\u0105 hosta.",
             "address_in_use": "Wybrany port jest ju\u017c u\u017cywany w tym systemie.",
             "cannot_connect": "Po\u0142\u0105czenie nie powiod\u0142o si\u0119. Sprawd\u017a host i port.",
+            "cannot_identify": "Po\u0142\u0105czono z urz\u0105dzeniem, ale nie uda\u0142o si\u0119 odczyta\u0107 jego numeru seryjnego w celu identyfikacji.",
             "unknown": "Nieoczekiwany b\u0142\u0105d"
         },
         "step": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 from homeassistant.data_entry_flow import AbortFlow
@@ -23,7 +23,10 @@ from custom_components.luxtronik2.const import (
     DEFAULT_TIMEOUT,
     DOMAIN,
 )
-from custom_components.luxtronik2.coordinator import LuxtronikConnectionError
+from custom_components.luxtronik2.coordinator import (
+    LuxtronikConnectionError,
+    LuxtronikSerialNumberError,
+)
 
 
 def _mock_coordinator():
@@ -114,11 +117,11 @@ class TestSetUniqueIdOrAbort:
         flow._abort_if_unique_id_configured = MagicMock()
         coord = _mock_coordinator()
         result = await flow._set_unique_id_or_abort(coord, {CONF_HOST: "1.2.3.4"})
-        assert result is True
+        assert result is None
         flow.async_set_unique_id.assert_awaited_once_with(coord.unique_id)
 
     @pytest.mark.asyncio
-    async def test_returns_false_on_abort(self):
+    async def test_returns_abort_result_on_already_configured(self):
         flow = LuxtronikFlowHandler()
         flow.async_set_unique_id = AsyncMock()
         flow._abort_if_unique_id_configured = MagicMock(
@@ -126,7 +129,20 @@ class TestSetUniqueIdOrAbort:
         )
         coord = _mock_coordinator()
         result = await flow._set_unique_id_or_abort(coord, {CONF_HOST: "1.2.3.4"})
-        assert result is False
+        assert result is not None
+        assert result["reason"] == "already_configured"
+
+    @pytest.mark.asyncio
+    async def test_returns_abort_result_on_serial_number_error(self):
+        flow = LuxtronikFlowHandler()
+        flow.async_set_unique_id = AsyncMock()
+        coord = MagicMock()
+        type(coord).unique_id = PropertyMock(
+            side_effect=LuxtronikSerialNumberError("no serial number")
+        )
+        result = await flow._set_unique_id_or_abort(coord, {CONF_HOST: "1.2.3.4"})
+        assert result is not None
+        assert result["reason"] == "cannot_identify"
 
 
 # ===========================================================================
@@ -349,6 +365,41 @@ class TestAsyncStepDhcp:
         ):
             await flow.async_step_dhcp(self._make_dhcp_info())
         flow.async_create_entry.assert_called_once()
+        # Regression guard: our own update listener (__init__.py) already
+        # reloads the entry on data changes. If this ever goes back to the
+        # default (reload_on_update=True), core schedules a second reload and
+        # logs HA's "has an update listener and should use it for scheduling
+        # a reload" deprecation warning (removed in 2026.12.0).
+        assert (
+            flow._abort_if_unique_id_configured.call_args.kwargs["reload_on_update"]
+            is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_dhcp_already_configured_after_connect_reraises_abort(self):
+        """AbortFlow raised by _abort_if_unique_id_configured after a successful
+        connect must propagate (via the `except AbortFlow: raise` guard added in
+        c8f0795) instead of being swallowed by the catch-all handler and
+        reported as an "unknown" error.
+        """
+        flow = LuxtronikFlowHandler()
+        flow.hass = MagicMock()
+        flow.hass.async_add_executor_job = AsyncMock(return_value=[("1.2.3.4", 8889)])
+        flow._async_current_entries = MagicMock(return_value=[])
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_configured = MagicMock(
+            side_effect=AbortFlow("already_configured")
+        )
+        coord = _mock_coordinator()
+        with (
+            patch(
+                "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
+                new_callable=AsyncMock,
+                return_value=coord,
+            ),
+            pytest.raises(AbortFlow, match="already_configured"),
+        ):
+            await flow.async_step_dhcp(self._make_dhcp_info())
 
     @pytest.mark.asyncio
     async def test_dhcp_no_match_uses_default_port(self):
@@ -384,6 +435,31 @@ class TestAsyncStepDhcp:
         ):
             await flow.async_step_dhcp(self._make_dhcp_info())
         flow.async_abort.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dhcp_cannot_identify_aborts(self):
+        flow = LuxtronikFlowHandler()
+        flow.hass = MagicMock()
+        flow.hass.async_add_executor_job = AsyncMock(return_value=[("1.2.3.4", 8889)])
+        flow._async_current_entries = MagicMock(return_value=[])
+        flow.async_set_unique_id = AsyncMock(
+            side_effect=LuxtronikSerialNumberError("no serial number")
+        )
+        flow.async_abort = MagicMock(return_value={"type": "abort"})
+        coord = _mock_coordinator()
+        with patch(
+            "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
+            new_callable=AsyncMock,
+            return_value=coord,
+        ):
+            await flow.async_step_dhcp(self._make_dhcp_info())
+        flow.async_abort.assert_called_with(
+            reason="cannot_identify",
+            description_placeholders={
+                "host": "1.2.3.4",
+                "error": "no serial number",
+            },
+        )
 
     @pytest.mark.asyncio
     async def test_dhcp_unknown_error_aborts(self):
@@ -662,6 +738,34 @@ class TestAsyncStepReconfigure:
             await flow.async_step_reconfigure({CONF_HOST: "5.6.7.8", CONF_PORT: 8889})
         flow.async_show_form.assert_called_once()
         assert flow.async_show_form.call_args[1]["errors"] == {"base": "unknown"}
+
+    @pytest.mark.asyncio
+    async def test_serial_number_error_shows_cannot_identify_error(self):
+        flow = LuxtronikFlowHandler()
+        flow.hass = MagicMock()
+        entry = MagicMock()
+        entry.data = {
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 8889,
+            CONF_TIMEOUT: DEFAULT_TIMEOUT,
+            CONF_MAX_DATA_LENGTH: DEFAULT_MAX_DATA_LENGTH,
+        }
+        flow._get_reconfigure_entry = MagicMock(return_value=entry)
+        flow.async_show_form = MagicMock(return_value={"type": "form"})
+        flow.async_set_unique_id = AsyncMock(
+            side_effect=LuxtronikSerialNumberError("no serial number")
+        )
+        coord = _mock_coordinator()
+        with patch(
+            "custom_components.luxtronik2.config_flow.connect_and_get_coordinator",
+            new_callable=AsyncMock,
+            return_value=coord,
+        ):
+            await flow.async_step_reconfigure({CONF_HOST: "5.6.7.8", CONF_PORT: 8889})
+        flow.async_show_form.assert_called_once()
+        assert flow.async_show_form.call_args[1]["errors"] == {
+            "base": "cannot_identify"
+        }
 
     @pytest.mark.asyncio
     async def test_successful_reconfigure(self):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -27,7 +27,8 @@ from custom_components.luxtronik2.const import (
 from custom_components.luxtronik2.coordinator import (
     LuxtronikConnectionError,
     LuxtronikCoordinator,
-    catch_luxtronik_errors,
+    LuxtronikSerialNumberError,
+    LuxtronikWriteError,
 )
 from custom_components.luxtronik2.model import (
     LuxtronikCoordinatorData,
@@ -223,6 +224,11 @@ class TestCoordinatorProperties:
         sn = coord.serial_number
         assert "20230101" in sn
         assert "ff" in sn.lower()  # hex(255) = 0xff
+
+    def test_serial_number_missing_date_raises(self):
+        coord = _make_coordinator()
+        with pytest.raises(LuxtronikSerialNumberError):
+            _ = coord.serial_number
 
     def test_room_thermostat_type(self):
         coord = _make_coordinator(parameters={"ID_Einst_RFVEinb_akt": 4})
@@ -665,6 +671,11 @@ class TestCoordinatorGetValue:
         coord = _make_coordinator()
         assert coord.get_sensor("unknown_group", "some_key") is None
 
+    def test_get_sensor_no_data_yet(self):
+        coord = _make_coordinator()
+        coord.data = None
+        assert coord.get_sensor("parameters", "some_key") is None
+
 
 # ===========================================================================
 # async operations
@@ -727,33 +738,6 @@ class TestCoordinatorAsync:
 
 
 # ===========================================================================
-# catch_luxtronik_errors decorator
-# ===========================================================================
-
-
-class TestCatchLuxtronikErrors:
-    @pytest.mark.asyncio
-    async def test_catches_exception_and_refreshes(self):
-        @catch_luxtronik_errors
-        async def failing_method(self):
-            raise ValueError("test error")
-
-        coord = _make_coordinator_direct()
-        await failing_method(coord)
-        coord.async_request_refresh.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_calls_refresh_on_success(self):
-        @catch_luxtronik_errors
-        async def success_method(self):
-            pass
-
-        coord = _make_coordinator_direct()
-        await success_method(coord)
-        coord.async_request_refresh.assert_awaited_once()
-
-
-# ===========================================================================
 # _async_update_data (direct coordinator)
 # ===========================================================================
 
@@ -808,7 +792,7 @@ class TestAsyncWrite:
         coord.hass.async_add_executor_job = AsyncMock(
             side_effect=Exception("write fail")
         )
-        with pytest.raises(UpdateFailed):
+        with pytest.raises(LuxtronikWriteError):
             await coord.async_write("param", 1)
 
 
@@ -821,12 +805,17 @@ class TestAsyncShutdownDirect:
     @pytest.mark.asyncio
     async def test_shutdown_with_client(self):
         coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock(
+            side_effect=lambda fn, *a, **kw: fn(*a, **kw)
+        )
+        client = coord.client
         with patch(
             "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.async_shutdown",
             new_callable=AsyncMock,
         ):
             await coord.async_shutdown()
         assert not hasattr(coord, "client")
+        client.disconnect.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_shutdown_without_client(self):
@@ -1145,6 +1134,26 @@ class TestConnectAndGetCoordinator:
         assert result is coordinator
         coordinator.async_refresh.assert_awaited_once()
         coordinator.async_config_entry_first_refresh.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_initial_refresh_failure_raises_connection_error(self):
+        """async_refresh() swallows failures; connect_and_get_coordinator must not."""
+        from custom_components.luxtronik2.coordinator import connect_and_get_coordinator
+
+        config = {CONF_HOST: "192.168.1.100", CONF_PORT: DEFAULT_PORT}
+        coordinator = MagicMock()
+        coordinator.async_refresh = AsyncMock()
+        coordinator.last_update_success = False
+
+        with (
+            patch(
+                "custom_components.luxtronik2.coordinator.LuxtronikCoordinator.connect",
+                new_callable=AsyncMock,
+                return_value=coordinator,
+            ),
+            pytest.raises(LuxtronikConnectionError),
+        ):
+            await connect_and_get_coordinator(MagicMock(), config)
 
     @pytest.mark.asyncio
     async def test_initial_refresh_uses_config_entry_first_refresh_for_config_entry(

--- a/tests/test_lux_helper.py
+++ b/tests/test_lux_helper.py
@@ -169,6 +169,20 @@ class TestLuxtronikClient:
     @patch(
         "custom_components.luxtronik2.lux_helper._is_socket_closed", return_value=False
     )
+    def test_public_disconnect_closes_socket(self, mock_is_closed):
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        client._socket = mock_sock
+
+        client.disconnect()
+
+        mock_sock.close.assert_called_once()
+        assert client._socket is None
+
+    @patch(
+        "custom_components.luxtronik2.lux_helper._is_socket_closed", return_value=False
+    )
     def test_disconnect_closes_socket(self, mock_is_closed):
         client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
         mock_sock = MagicMock()


### PR DESCRIPTION
## 🐛 Summary

Follow-up hardening from a review of `coordinator.py`, focused on failing loudly instead of masking problems:

- 🧹 Removed the unused `catch_luxtronik_errors` decorator — it was defined and had tests, but was never applied anywhere, so it protected nothing.
- 🔌 `async_shutdown` now explicitly closes the connection via a new public `Luxtronik.disconnect()` (run in an executor job), instead of `del`-ing the client and hoping GC/`__del__` closes the socket before shutdown completes.
- 🚧 Split write/identification failures out of `UpdateFailed` into dedicated `LuxtronikWriteError` / `LuxtronikSerialNumberError` exceptions — `UpdateFailed` is meant for a failed `update_method`, not an arbitrary write or a missing serial number.
- 🛡️ `get_sensor()` now tolerates `coordinator.data` being unpopulated (returns `None`) instead of raising `AttributeError`.
- 🔑 `serial_number` now raises `LuxtronikSerialNumberError` instead of silently falling back to `""` when the date parameter is missing — since it feeds `unique_id`, an empty fallback risks colliding device/entry identifiers between two different heat pumps.
- 🔄 `connect_and_get_coordinator()` now checks `last_update_success` after the config-flow path's `async_refresh()` (which swallows failures, unlike `async_config_entry_first_refresh()`), converting a silently-failed initial refresh into the existing, well-handled `LuxtronikConnectionError` — so problems surface at the connection step rather than later as a confusing serial-number error.
- 🌐 `config_flow` now catches `LuxtronikSerialNumberError` everywhere `coordinator.unique_id` is read (`select_devices`, `manual_entry`, `dhcp`, `reconfigure`) and shows a dedicated `cannot_identify` abort/error message (added to all 5 locales) instead of a generic "unknown" error.

## ✅ Test plan

- [x] `pytest` — 753 passed
- [x] `pytest --cov=custom_components.luxtronik2` — 100% coverage (including the previously-untested `except AbortFlow: raise` guard in `async_step_dhcp`)
- [x] `ruff check` / `ruff format --check` — clean
- [x] `basedpyright` — 0 errors
- [x] Verified the DHCP `reload_on_update=False` safeguard (which prevents HA's "has an update listener and should use it for scheduling a reload" deprecation warning) is untouched, and added a regression assertion for it

🤖 Generated with [Claude Code](https://claude.com/claude-code)