### PR TITLE
feat(text): add editable DHW timer-program schedule entities

### DIFF
--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -32,6 +32,7 @@ PLATFORMS: list[str] = [
     Platform.CLIMATE,
     Platform.SELECT,
     Platform.DATE,
+    Platform.TEXT,
 ]
 CONF_UPDATE_INTERVAL: Final = "update_interval"
 
@@ -913,6 +914,17 @@ class SensorKey(StrEnum):
 
     EXTRA_DHW_TARGET_TEMPERATURE = "extra_dhw_target_temperature"
     EXTRA_DHW_DURATION = "extra_dhw_duration"
+
+    TIMER_DHW_SCHEDULE_WEEK = "timer_dhw_schedule_week"
+    TIMER_DHW_SCHEDULE_WEEKDAY = "timer_dhw_schedule_weekday"
+    TIMER_DHW_SCHEDULE_WEEKEND = "timer_dhw_schedule_weekend"
+    TIMER_DHW_SCHEDULE_MONDAY = "timer_dhw_schedule_monday"
+    TIMER_DHW_SCHEDULE_TUESDAY = "timer_dhw_schedule_tuesday"
+    TIMER_DHW_SCHEDULE_WEDNESDAY = "timer_dhw_schedule_wednesday"
+    TIMER_DHW_SCHEDULE_THURSDAY = "timer_dhw_schedule_thursday"
+    TIMER_DHW_SCHEDULE_FRIDAY = "timer_dhw_schedule_friday"
+    TIMER_DHW_SCHEDULE_SATURDAY = "timer_dhw_schedule_saturday"
+    TIMER_DHW_SCHEDULE_SUNDAY = "timer_dhw_schedule_sunday"
 
 
 # endregion Keys

--- a/custom_components/luxtronik2/lux_overrides.py
+++ b/custom_components/luxtronik2/lux_overrides.py
@@ -62,6 +62,46 @@ class FrequencyAutomatic(Base):
         return int(value - 20)  # 21 → 1, 22 → 2, ..., 121 → 101
 
 
+class TimeOfDay(Base):
+    """TimeOfDay datatype, converts from and to TimeOfDay."""
+
+    datatype_class = "timeofday"
+
+    @classmethod
+    def from_heatpump(cls, value):
+        if not isinstance(value, int):
+            return None
+        hours = value // 3600
+        minutes = (value // 60) % 60
+        seconds = value % 60
+
+        return f"{hours:02d}:{minutes:02d}" + (f":{seconds:02d}" if seconds > 0 else "")
+
+    @classmethod
+    def to_heatpump(cls, value):
+        if isinstance(value, int):
+            return value
+        if not isinstance(value, str):
+            return None
+        d = [int(v) for v in value.split(":")]
+
+        val = d[0] * 3600 + d[1] * 60
+        if len(d) == 3:
+            val += d[2]
+
+        return val
+
+
+class TimerProgram(SelectionBase):
+    """TimerProgram datatype, converts from and to list of TimerProgram codes"""
+
+    codes = {
+        0: "week",
+        1: "5+2",
+        2: "days",
+    }
+
+
 class PoolPVMode(SelectionBase):
     """PoolPVMode datatype, converts from and to a PoolPVMode"""
 
@@ -140,6 +180,13 @@ def update_Luxtronik_Parameters():
     # Kelvin temperature-difference parameters stored as tenths.
     delta_temperature_numbers = [88, 89]
     update_Luxtronik_Parameter_Classes(delta_temperature_numbers, Kelvin)
+
+    # Timer program schedule parameters: mostly TimeOfDay entries, with a
+    # handful of TimerProgram mode selectors interspersed in the range.
+    timer_program_numbers = {222, 283, 344, 405, 506, 607}
+    time_of_day_numbers = [n for n in range(162, 668) if n not in timer_program_numbers]
+    update_Luxtronik_Parameter_Classes(time_of_day_numbers, TimeOfDay)
+    update_Luxtronik_Parameter_Classes(list(timer_program_numbers), TimerProgram)
 
 
 def update_Luxtronik_Parameter_Classes(numbers, datatype_class):

--- a/custom_components/luxtronik2/model.py
+++ b/custom_components/luxtronik2/model.py
@@ -18,6 +18,7 @@ from homeassistant.components.number import NumberEntityDescription, NumberMode
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.components.switch import SwitchEntityDescription
+from homeassistant.components.text import TextEntityDescription
 from homeassistant.components.update import UpdateDeviceClass, UpdateEntityDescription
 from homeassistant.components.water_heater import (
     WaterHeaterEntityDescription,
@@ -241,3 +242,21 @@ class LuxtronikSelectEntityDescription(
     """Class describing Luxtronik date entities."""
 
     platform = Platform.SELECT
+
+
+class LuxtronikTimerScheduleTextDescription(
+    LuxtronikEntityDescription,
+    TextEntityDescription,
+    frozen_or_thawed=True,
+):
+    """Class describing a single timer-program schedule block as an editable text entity.
+
+    Reads/writes multiple raw Luxtronik parameters (one pair per row) as a
+    delimited "start-end/start-end/..." string, so ``luxtronik_key`` is left
+    unused (stays at its ``LuxParameter.UNSET`` default).
+    """
+
+    platform = Platform.TEXT
+    mode_selector_name: str = ""
+    active_mode: str = ""
+    row_names: tuple[tuple[str, str], ...] = ()

--- a/custom_components/luxtronik2/text.py
+++ b/custom_components/luxtronik2/text.py
@@ -1,0 +1,164 @@
+"""Support for Luxtronik timer-program schedule text entities."""
+
+from __future__ import annotations
+
+import re
+
+from homeassistant.components.text import (
+    ENTITY_ID_FORMAT,  # pyright: ignore[reportAttributeAccessIssue]
+    TextEntity,
+    TextMode,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import LuxtronikConfigEntry
+from .base import LuxtronikEntity
+from .common import get_sensor_data, key_exists
+from .const import CONF_HA_SENSOR_PREFIX, DOMAIN, DeviceKey
+from .coordinator import LuxtronikCoordinator, LuxtronikCoordinatorData
+from .model import LuxtronikTimerScheduleTextDescription
+from .timer_schedule_entities_predefined import TIMER_SCHEDULE_ENTITIES
+
+PARALLEL_UPDATES = 1
+
+_UNSET_TIME = "00:00"
+_PAIR_PATTERN = re.compile(r"^([01]\d|2[0-3]):[0-5]\d-([01]\d|2[0-3]):[0-5]\d$")
+
+
+async def async_setup_entry(  # pragma: no cover
+    hass: HomeAssistant,
+    entry: LuxtronikConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator = entry.runtime_data
+
+    if not coordinator.last_update_success:
+        return
+
+    async_add_entities(
+        [
+            LuxtronikTimerScheduleText(
+                entry, coordinator, description, description.device_key
+            )
+            for description in TIMER_SCHEDULE_ENTITIES
+            if (
+                coordinator.entity_active(description)
+                and key_exists(
+                    coordinator.data, f"parameters.{description.mode_selector_name}"
+                )
+            )
+        ],
+        True,
+    )
+
+
+def _parse_schedule(value: str, max_rows: int) -> list[tuple[str, str]]:
+    """Parse a "HH:MM-HH:MM/HH:MM-HH:MM/..." schedule string into pairs.
+
+    Raises ServiceValidationError if the string doesn't match the expected
+    shape or supplies more entries than the block has rows.
+    """
+    if value == "":
+        return []
+
+    entries = value.split("/")
+    if len(entries) > max_rows or not all(
+        _PAIR_PATTERN.match(entry) for entry in entries
+    ):
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_timer_schedule",
+            translation_placeholders={"value": value, "max_rows": str(max_rows)},
+        )
+    return [(entry[:5], entry[6:]) for entry in entries]
+
+
+class LuxtronikTimerScheduleText(
+    LuxtronikEntity[LuxtronikTimerScheduleTextDescription],  # type: ignore  # pyright: ignore[reportIncompatibleVariableOverride]
+    TextEntity,
+):
+    """A single timer-program schedule block, edited as a delimited string.
+
+    Reads/writes multiple raw parameters (one start/end pair per row) at
+    once, so it deliberately does not go through `LuxtronikEntity`'s
+    `luxtronik_key`-based state handling -- reading and writing are fully
+    custom, similar to how `LuxtronikDateEntity` bypasses `_get_value`.
+    """
+
+    def __init__(
+        self,
+        entry: LuxtronikConfigEntry,
+        coordinator: LuxtronikCoordinator,
+        description: LuxtronikTimerScheduleTextDescription,
+        device_info_ident: DeviceKey,
+    ) -> None:
+        super().__init__(
+            coordinator=coordinator,
+            description=description,
+            device_info_ident=device_info_ident,
+        )
+        prefix = entry.data[CONF_HA_SENSOR_PREFIX]
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{prefix}_{description.key}")
+        self._attr_unique_id = self.entity_id
+        self._attr_mode = TextMode.TEXT
+        self._attr_native_min = 0
+        # Each "HH:MM-HH:MM" pair is 11 chars, joined by a single "/".
+        self._attr_native_max = len(description.row_names) * 12 - 1
+        self._attr_native_value = None
+
+    @property
+    def available(self) -> bool:
+        """Only the schedule block matching the circuit's active mode is available."""
+        if not super().available:
+            return False
+        data = self.coordinator.data
+        if data is None:
+            return False
+        current_mode = get_sensor_data(
+            data, f"parameters.{self.entity_description.mode_selector_name}"
+        )
+        return current_mode == self.entity_description.active_mode
+
+    @callback
+    def _handle_coordinator_update(
+        self, data: LuxtronikCoordinatorData | None = None
+    ) -> None:
+        data = self.coordinator.data if data is None else data
+        if data is None:
+            return
+
+        pairs = []
+        for start_name, end_name in self.entity_description.row_names:
+            start = get_sensor_data(data, f"parameters.{start_name}")
+            end = get_sensor_data(data, f"parameters.{end_name}")
+            if start in (None, _UNSET_TIME) and end in (None, _UNSET_TIME):
+                continue
+            pairs.append(f"{start}-{end}")
+        self._attr_native_value = "/".join(pairs)
+
+        self.async_write_ha_state()
+        super()._handle_coordinator_update()
+
+    async def async_set_value(self, value: str) -> None:
+        """Handle a user-edited schedule string.
+
+        Rows beyond the supplied entries are cleared to 00:00-00:00 so a
+        shortened string actually removes the trailing rows on the device,
+        rather than leaving stale values in effect.
+        """
+        row_names = self.entity_description.row_names
+        pairs = _parse_schedule(value, len(row_names))
+
+        data = self.coordinator.data
+        for index, (start_name, end_name) in enumerate(row_names):
+            start, end = (
+                pairs[index] if index < len(pairs) else (_UNSET_TIME, _UNSET_TIME)
+            )
+            if get_sensor_data(data, f"parameters.{start_name}") != start:
+                data = await self.coordinator.async_write(start_name, start)
+            if get_sensor_data(data, f"parameters.{end_name}") != end:
+                data = await self.coordinator.async_write(end_name, end)
+
+        self._handle_coordinator_update(data)

--- a/custom_components/luxtronik2/timer_schedule_entities_predefined.py
+++ b/custom_components/luxtronik2/timer_schedule_entities_predefined.py
@@ -1,0 +1,145 @@
+"""Predefined timer-program schedule text entities.
+
+Only the DHW (Bw) circuit is wired up so far, to validate the approach
+before rolling out to the other 5 timer-program circuits (Hkr/Mk1/Mk2/ZIP/
+Swb). See the "lux-timer-program-parameter-layout" memory for their
+selector/prefix values once this is extended.
+"""
+
+from dataclasses import dataclass
+
+from homeassistant.const import EntityCategory
+
+from .const import DeviceKey, SensorKey as SK
+from .model import LuxtronikTimerScheduleTextDescription
+
+
+@dataclass(frozen=True)
+class _TimerCircuit:
+    """Metadata for one timer-program circuit's schedule parameters.
+
+    The heat pump's mode selector picks one of three schedule shapes, each
+    backed by its own set of firmware parameters (the raw prefix each of
+    these covers, e.g. "ID_Einst_SuBwWO"):
+
+    - ``same_schedule_prefix`` ("WO" in the firmware): one schedule applies
+      every day of the week.
+    - ``weekday_weekend_prefix`` ("25"): one schedule for weekdays, a
+      separate one for the weekend.
+    - ``per_day_prefix`` ("TG"/"Tg", German "täglich"): a separate,
+      independently editable schedule for each individual day of the week.
+
+    Each prefix is also the parameter-name prefix: the firmware exposes the
+    actual start/end times as ``<prefix>_zeit_<row>_<slot>``, where ``row``
+    is the schedule slot within a day (0-based, up to `rows` per day) and
+    ``slot`` is an even number for the start time and that same number + 1
+    for its matching end time. For the weekday/weekend and per-day blocks,
+    ``slot`` also encodes which day-group the row belongs to
+    (``slot = 2 * column``, where ``column`` is 0/1 for weekday/weekend, or
+    0-6 for Monday-Sunday) -- see `_row_names` below.
+    """
+
+    #: Raw parameter name of the mode selector that picks which of the three
+    #: schedule shapes below is actually active on the device (its value is
+    #: one of "week", "5+2", or "days").
+    mode_selector_name: str
+    #: Number of independent start/end time slots available per day for
+    #: this circuit (3 or 5, depending on circuit -- see the
+    #: "lux-timer-program-parameter-layout" memory).
+    rows: int
+    same_schedule_prefix: str
+    weekday_weekend_prefix: str
+    per_day_prefix: str
+    device_key: DeviceKey
+
+
+# Numbers verified against a real diagnostics dump for parameters 162-667.
+_DHW_CIRCUIT = _TimerCircuit(
+    mode_selector_name="ID_Einst_SUBW_akt2",
+    rows=5,
+    same_schedule_prefix="ID_Einst_SuBwWO",
+    weekday_weekend_prefix="ID_Einst_SuBw25",
+    per_day_prefix="ID_Einst_SuBwTG",
+    device_key=DeviceKey.domestic_water,
+)
+
+_DHW_WEEKDAYS: tuple[tuple[SK, int], ...] = (
+    (SK.TIMER_DHW_SCHEDULE_MONDAY, 0),
+    (SK.TIMER_DHW_SCHEDULE_TUESDAY, 1),
+    (SK.TIMER_DHW_SCHEDULE_WEDNESDAY, 2),
+    (SK.TIMER_DHW_SCHEDULE_THURSDAY, 3),
+    (SK.TIMER_DHW_SCHEDULE_FRIDAY, 4),
+    (SK.TIMER_DHW_SCHEDULE_SATURDAY, 5),
+    (SK.TIMER_DHW_SCHEDULE_SUNDAY, 6),
+)
+
+
+def _row_names(prefix: str, rows: int, col: int) -> tuple[tuple[str, str], ...]:
+    """Build the ordered (start_name, end_name) pairs for one schedule block.
+
+    Matches the firmware's ``<prefix>_zeit_<row>_<slot>`` numbering, where
+    slot is ``2*col`` (start) / ``2*col + 1`` (end).
+    """
+    return tuple(
+        (f"{prefix}_zeit_{row}_{2 * col}", f"{prefix}_zeit_{row}_{2 * col + 1}")
+        for row in range(rows)
+    )
+
+
+def _build_circuit_entities(
+    circuit: _TimerCircuit,
+    week_key: SK,
+    weekday_key: SK,
+    weekend_key: SK,
+    day_keys: tuple[tuple[SK, int], ...],
+) -> list[LuxtronikTimerScheduleTextDescription]:
+    """Build the week/weekday/weekend/daily schedule entities for one circuit."""
+    entities = [
+        LuxtronikTimerScheduleTextDescription(
+            key=week_key,
+            device_key=circuit.device_key,
+            entity_category=EntityCategory.CONFIG,
+            mode_selector_name=circuit.mode_selector_name,
+            active_mode="week",
+            row_names=_row_names(circuit.same_schedule_prefix, circuit.rows, 0),
+        ),
+        LuxtronikTimerScheduleTextDescription(
+            key=weekday_key,
+            device_key=circuit.device_key,
+            entity_category=EntityCategory.CONFIG,
+            mode_selector_name=circuit.mode_selector_name,
+            active_mode="5+2",
+            row_names=_row_names(circuit.weekday_weekend_prefix, circuit.rows, 0),
+        ),
+        LuxtronikTimerScheduleTextDescription(
+            key=weekend_key,
+            device_key=circuit.device_key,
+            entity_category=EntityCategory.CONFIG,
+            mode_selector_name=circuit.mode_selector_name,
+            active_mode="5+2",
+            row_names=_row_names(circuit.weekday_weekend_prefix, circuit.rows, 1),
+        ),
+    ]
+    entities.extend(
+        LuxtronikTimerScheduleTextDescription(
+            key=day_key,
+            device_key=circuit.device_key,
+            entity_category=EntityCategory.CONFIG,
+            mode_selector_name=circuit.mode_selector_name,
+            active_mode="days",
+            row_names=_row_names(circuit.per_day_prefix, circuit.rows, day_index),
+        )
+        for day_key, day_index in day_keys
+    )
+    return entities
+
+
+TIMER_SCHEDULE_ENTITIES: list[LuxtronikTimerScheduleTextDescription] = (
+    _build_circuit_entities(
+        _DHW_CIRCUIT,
+        week_key=SK.TIMER_DHW_SCHEDULE_WEEK,
+        weekday_key=SK.TIMER_DHW_SCHEDULE_WEEKDAY,
+        weekend_key=SK.TIMER_DHW_SCHEDULE_WEEKEND,
+        day_keys=_DHW_WEEKDAYS,
+    )
+)

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -644,6 +644,38 @@
                 "name": "Away Mode Heating End Date"
             }
         },
+        "text": {
+            "timer_dhw_schedule_week": {
+                "name": "DHW Timer Schedule (Week)"
+            },
+            "timer_dhw_schedule_weekday": {
+                "name": "DHW Timer Schedule (Weekdays)"
+            },
+            "timer_dhw_schedule_weekend": {
+                "name": "DHW Timer Schedule (Weekend)"
+            },
+            "timer_dhw_schedule_monday": {
+                "name": "DHW Timer Schedule (Monday)"
+            },
+            "timer_dhw_schedule_tuesday": {
+                "name": "DHW Timer Schedule (Tuesday)"
+            },
+            "timer_dhw_schedule_wednesday": {
+                "name": "DHW Timer Schedule (Wednesday)"
+            },
+            "timer_dhw_schedule_thursday": {
+                "name": "DHW Timer Schedule (Thursday)"
+            },
+            "timer_dhw_schedule_friday": {
+                "name": "DHW Timer Schedule (Friday)"
+            },
+            "timer_dhw_schedule_saturday": {
+                "name": "DHW Timer Schedule (Saturday)"
+            },
+            "timer_dhw_schedule_sunday": {
+                "name": "DHW Timer Schedule (Sunday)"
+            }
+        },
         "select": {
             "thermal_desinfection_day": {
                 "name": "Thermal Desinfection Day",
@@ -826,6 +858,9 @@
         },
         "parameter_not_writable": {
             "message": "Parameter {parameter} rejected \u2014 only parameters with prefixes {prefixes} are writable"
+        },
+        "invalid_timer_schedule": {
+            "message": "Invalid timer schedule \"{value}\": expected \"HH:MM-HH:MM\" entries separated by \"/\", with at most {max_rows} entries"
         }
     },
     "issues": {

--- a/tests/test_lux_overrides.py
+++ b/tests/test_lux_overrides.py
@@ -154,6 +154,39 @@ class TestSecondsToHours:
         assert converter.to_heatpump(1.5) == 5400
 
 
+class TestTimeOfDay:
+    from custom_components.luxtronik2.lux_overrides import TimeOfDay
+
+    def test_from_heatpump_formats_hours_and_minutes(self):
+        assert self.TimeOfDay.from_heatpump(6 * 3600) == "06:00"
+        assert self.TimeOfDay.from_heatpump(22 * 3600 + 30 * 60) == "22:30"
+
+    def test_from_heatpump_includes_seconds_when_nonzero(self):
+        assert self.TimeOfDay.from_heatpump(6 * 3600 + 15) == "06:00:15"
+
+    def test_from_heatpump_non_int_returns_none(self):
+        assert self.TimeOfDay.from_heatpump("06:00") is None
+        assert self.TimeOfDay.from_heatpump(None) is None
+
+    def test_to_heatpump_parses_hours_and_minutes(self):
+        assert self.TimeOfDay.to_heatpump("06:00") == 6 * 3600
+        assert self.TimeOfDay.to_heatpump("22:30") == 22 * 3600 + 30 * 60
+
+    def test_to_heatpump_parses_seconds_when_present(self):
+        assert self.TimeOfDay.to_heatpump("06:00:15") == 6 * 3600 + 15
+
+    def test_to_heatpump_passes_through_int_for_backward_compatibility(self):
+        assert self.TimeOfDay.to_heatpump(21600) == 21600
+
+    def test_to_heatpump_non_str_non_int_returns_none(self):
+        assert self.TimeOfDay.to_heatpump(None) is None
+        assert self.TimeOfDay.to_heatpump(1.5) is None
+
+    def test_roundtrip(self):
+        raw = self.TimeOfDay.to_heatpump("07:30")
+        assert self.TimeOfDay.from_heatpump(raw) == "07:30"
+
+
 class TestFrequencyAutomatic:
     from custom_components.luxtronik2.lux_overrides import FrequencyAutomatic
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,264 @@
+"""Tests for the DHW timer-program schedule text entities."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from conftest import make_coordinator_data
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
+from homeassistant.exceptions import ServiceValidationError
+from luxtronik.parameters import Parameters
+import pytest
+
+from custom_components.luxtronik2.const import (
+    CONF_HA_SENSOR_PREFIX,
+    CONF_MAX_DATA_LENGTH,
+    DEFAULT_MAX_DATA_LENGTH,
+    DEFAULT_PORT,
+    DEFAULT_TIMEOUT,
+    DOMAIN,
+    SensorKey as SK,
+)
+from custom_components.luxtronik2.lux_overrides import update_Luxtronik_Parameters
+from custom_components.luxtronik2.timer_schedule_entities_predefined import (
+    TIMER_SCHEDULE_ENTITIES,
+)
+
+_ENTRY_DATA = {
+    CONF_HOST: "192.168.1.100",
+    CONF_PORT: DEFAULT_PORT,
+    CONF_TIMEOUT: DEFAULT_TIMEOUT,
+    CONF_MAX_DATA_LENGTH: DEFAULT_MAX_DATA_LENGTH,
+    CONF_HA_SENSOR_PREFIX: DOMAIN,
+}
+
+
+def _mock_entry():
+    entry = MagicMock()
+    entry.data = _ENTRY_DATA.copy()
+    return entry
+
+
+def _mock_coordinator(data=None, *, last_update_success: bool = True):
+    if data is None:
+        data = make_coordinator_data()
+    coord = MagicMock()
+    coord.data = data
+    coord.last_update_success = last_update_success
+    coord.entity_active.return_value = True
+    coord.get_device.return_value = MagicMock()
+    coord.async_write = AsyncMock(return_value=data)
+    return coord
+
+
+def _patch_entity_hass(entity):
+    entity.hass = MagicMock()
+    entity.hass.config.time_zone = "UTC"
+    entity.async_write_ha_state = MagicMock()
+    entity.async_schedule_update_ha_state = MagicMock()
+
+
+# ===========================================================================
+# Table integrity
+# ===========================================================================
+
+
+class TestTimerScheduleTable:
+    """Every generated row/selector name must resolve to a real Parameters
+    entry once lux_overrides has run, catching a prefix or row-math typo at
+    CI time instead of against a physical device."""
+
+    def test_names_exist_in_library(self):
+        update_Luxtronik_Parameters()
+
+        known_names = {p.name for p in Parameters.parameters.values()}
+        problems = []
+        for description in TIMER_SCHEDULE_ENTITIES:
+            names = [description.mode_selector_name]
+            for start_name, end_name in description.row_names:
+                names.extend([start_name, end_name])
+            for name in names:
+                if name not in known_names:
+                    problems.append(f"{description.key}: {name!r} not in Parameters")
+
+        assert not problems, "\n".join(problems)
+
+    def test_ten_dhw_entities_generated(self):
+        assert len(TIMER_SCHEDULE_ENTITIES) == 10
+
+    def test_row_counts_are_five_for_dhw(self):
+        for description in TIMER_SCHEDULE_ENTITIES:
+            assert len(description.row_names) == 5
+
+    def test_active_modes(self):
+        by_key = {d.key: d.active_mode for d in TIMER_SCHEDULE_ENTITIES}
+        assert by_key[SK.TIMER_DHW_SCHEDULE_WEEK] == "week"
+        assert by_key[SK.TIMER_DHW_SCHEDULE_WEEKDAY] == "5+2"
+        assert by_key[SK.TIMER_DHW_SCHEDULE_WEEKEND] == "5+2"
+        assert by_key[SK.TIMER_DHW_SCHEDULE_MONDAY] == "days"
+        assert by_key[SK.TIMER_DHW_SCHEDULE_SUNDAY] == "days"
+
+
+# ===========================================================================
+# _parse_schedule
+# ===========================================================================
+
+
+class TestParseSchedule:
+    def test_empty_string_is_no_rows(self):
+        from custom_components.luxtronik2.text import _parse_schedule
+
+        assert _parse_schedule("", 5) == []
+
+    def test_single_pair(self):
+        from custom_components.luxtronik2.text import _parse_schedule
+
+        assert _parse_schedule("06:00-22:00", 5) == [("06:00", "22:00")]
+
+    def test_multiple_pairs(self):
+        from custom_components.luxtronik2.text import _parse_schedule
+
+        assert _parse_schedule("06:00-22:00/07:30-22:00", 5) == [
+            ("06:00", "22:00"),
+            ("07:30", "22:00"),
+        ]
+
+    def test_too_many_pairs_raises(self):
+        from custom_components.luxtronik2.text import _parse_schedule
+
+        with pytest.raises(ServiceValidationError):
+            _parse_schedule("/".join(["06:00-07:00"] * 6), 5)
+
+    def test_malformed_pair_raises(self):
+        from custom_components.luxtronik2.text import _parse_schedule
+
+        with pytest.raises(ServiceValidationError):
+            _parse_schedule("6:00-22:00", 5)  # not zero-padded
+
+        with pytest.raises(ServiceValidationError):
+            _parse_schedule("06:00_22:00", 5)  # wrong separator
+
+
+# ===========================================================================
+# LuxtronikTimerScheduleText
+# ===========================================================================
+
+
+class TestLuxtronikTimerScheduleText:
+    def _make_entity(self, key=SK.TIMER_DHW_SCHEDULE_WEEK, parameters=None):
+        from custom_components.luxtronik2.text import LuxtronikTimerScheduleText
+
+        description = next(d for d in TIMER_SCHEDULE_ENTITIES if d.key == key)
+
+        data = make_coordinator_data(parameters=parameters or {})
+        coord = _mock_coordinator(data)
+        entry = _mock_entry()
+
+        with patch("homeassistant.helpers.frame.report_usage"):
+            entity = LuxtronikTimerScheduleText(
+                entry, coord, description, description.device_key
+            )
+        _patch_entity_hass(entity)
+        return entity, coord, description
+
+    def test_entity_id(self):
+        entity, _, description = self._make_entity()
+        assert entity.entity_id == f"text.{DOMAIN}_{description.key}"
+        assert entity._attr_unique_id == entity.entity_id
+
+    def test_native_max_matches_row_count(self):
+        entity, _, description = self._make_entity()
+        assert entity._attr_native_max == len(description.row_names) * 12 - 1
+
+    def test_handle_coordinator_update_renders_used_rows(self):
+        entity, _, description = self._make_entity()
+        start0, end0 = description.row_names[0]
+        start1, end1 = description.row_names[1]
+        data = make_coordinator_data(
+            parameters={
+                start0: "06:00",
+                end0: "22:00",
+                start1: "07:30",
+                end1: "22:00",
+            }
+        )
+        entity._handle_coordinator_update(data)
+        assert entity._attr_native_value == "06:00-22:00/07:30-22:00"
+
+    def test_handle_coordinator_update_skips_unset_rows(self):
+        entity, _, description = self._make_entity()
+        start0, end0 = description.row_names[0]
+        data = make_coordinator_data(parameters={start0: "00:00", end0: "00:00"})
+        entity._handle_coordinator_update(data)
+        assert entity._attr_native_value == ""
+
+    def test_handle_coordinator_update_none_data(self):
+        entity, coord, _ = self._make_entity()
+        coord.data = None
+        entity._handle_coordinator_update(None)  # should not crash
+
+    def test_available_when_mode_matches(self):
+        selector = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_WEEK
+        ).mode_selector_name
+        entity, _, _description = self._make_entity(parameters={selector: "week"})
+        assert entity.available is True
+
+    def test_unavailable_when_mode_does_not_match(self):
+        selector = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_WEEK
+        ).mode_selector_name
+        entity, _, _description = self._make_entity(parameters={selector: "5+2"})
+        assert entity.available is False
+
+    def test_unavailable_when_data_is_none(self):
+        entity, coord, _description = self._make_entity()
+        coord.data = None
+        assert entity.available is False
+
+    def test_unavailable_when_coordinator_unavailable(self):
+        selector = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_WEEK
+        ).mode_selector_name
+        entity, coord, _description = self._make_entity(parameters={selector: "week"})
+        coord.last_update_success = False
+        assert entity.available is False
+
+    @pytest.mark.asyncio
+    async def test_set_value_writes_only_changed_rows(self):
+        entity, coord, description = self._make_entity()
+        start0, end0 = description.row_names[0]
+        data = make_coordinator_data(parameters={start0: "06:00", end0: "22:00"})
+        coord.data = data
+        coord.async_write = AsyncMock(return_value=data)
+
+        await entity.async_set_value("06:00-22:00")
+
+        # Row 0 already matches; remaining rows get cleared (2 writes each).
+        assert coord.async_write.await_count == (len(description.row_names) - 1) * 2
+
+    @pytest.mark.asyncio
+    async def test_set_value_idempotent_when_unchanged(self):
+        entity, coord, description = self._make_entity()
+        start0, end0 = description.row_names[0]
+        row_values = {}
+        for s_name, e_name in description.row_names:
+            row_values[s_name] = "00:00"
+            row_values[e_name] = "00:00"
+        row_values[start0] = "06:00"
+        row_values[end0] = "22:00"
+        data = make_coordinator_data(parameters=row_values)
+        coord.data = data
+        coord.async_write = AsyncMock(return_value=data)
+
+        entity._handle_coordinator_update(data)
+        await entity.async_set_value(entity._attr_native_value)
+
+        coord.async_write.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_value_rejects_invalid_input(self):
+        entity, coord, _ = self._make_entity()
+        with pytest.raises(ServiceValidationError):
+            await entity.async_set_value("not-a-schedule")
+        coord.async_write.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds `TimeOfDay`/`TimerProgram` datatype overrides for Luxtronik parameters 162-667 (the six timer-program schedule blocks), classifying the ~500 raw start/end time parameters and their 6 mode selectors correctly instead of leaving them as `Unknown`.
- Adds a new `text` platform exposing the DHW (`Bw`) circuit's *active* timer-program schedule as 10 editable `"HH:MM-HH:MM/..."` entities (week / weekday / weekend / one per day), instead of hundreds of individual per-row time entities.
- Each schedule entity reads/writes its block's underlying parameters directly by raw name (bypassing the `LuxParameter` enum, which would need ~500 boilerplate members for this range), only writes rows whose value actually changed, and clears trailing rows when the string is shortened.
- Entities dynamically report `unavailable` when their circuit's mode selector isn't set to the schedule shape they represent, so only the currently active schedule is editable — no reload needed if the mode changes on the device.
- Only the DHW (`Bw`) circuit is wired up so far, to validate the approach before rolling out to the other 5 timer-program circuits (`Hkr`/`Mk1`/`Mk2`/`ZIP`/`Swb`); extending is additive per circuit.

## Test plan
- [x] `ruff check` / `ruff format --check` clean
- [x] `basedpyright` — 0 errors
- [x] `pytest --cov=custom_components.luxtronik2` — full suite passes, 99% coverage, new files at 100%
- [x] New `tests/test_text.py`: table-integrity check against the real `luxtronik.Parameters` registry, schedule-string parsing, entity rendering/availability/diff-based-write behavior
- [x] Manually tested against a live heat pump