### PR TITLE
fix(init): resolve write-service target to a specific config entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dmypy.json
 #Mac
 .DS_Store
 check_coverage.py
+
+# Git worktrees (local scratch, not part of the repo)
+.worktrees/

--- a/custom_components/luxtronik2/__init__.py
+++ b/custom_components/luxtronik2/__init__.py
@@ -3,10 +3,18 @@
 # region Imports
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT, Platform as P
+from homeassistant.const import (
+    ATTR_CONFIG_ENTRY_ID,
+    ATTR_DEVICE_ID,
+    CONF_HOST,
+    CONF_PORT,
+    CONF_TIMEOUT,
+    Platform as P,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, issue_registry as ir
@@ -138,21 +146,94 @@ def setup_hass_services(hass: HomeAssistant, entry: LuxtronikConfigEntry):
                 },
             )
 
-        # Find the first available coordinator
-        for config_entry in hass.config_entries.async_entries(DOMAIN):
-            if config_entry.state is ConfigEntryState.LOADED and hasattr(
-                config_entry, "runtime_data"
-            ):
-                coordinator = config_entry.runtime_data
-                await coordinator.async_write(parameter, value)
-                return
-        LOGGER.error(
-            "No active Luxtronik coordinator found for service call"
-        )  # pragma: no cover
+        target_entry = _resolve_write_target(hass, service.data)
+        if target_entry is None:  # pragma: no cover
+            LOGGER.error("No active Luxtronik coordinator found for service call")
+            return
+
+        coordinator = target_entry.runtime_data
+        await coordinator.async_write(parameter, value)
 
     hass.services.async_register(
         DOMAIN, SERVICE_WRITE, write_parameter, schema=SERVICE_WRITE_SCHEMA
     )
+
+
+def _resolve_write_target(
+    hass: HomeAssistant, service_data: Mapping[str, Any]
+) -> LuxtronikConfigEntry | None:
+    """Resolve which loaded Luxtronik config entry a `write` service call targets.
+
+    An explicit `device_id` or `config_entry_id` in the service call data pins
+    the write to that specific heat pump; `device_id` takes precedence if both
+    are given. With no explicit target, falls back to the single loaded config
+    entry (pre-existing single-pump behavior) - but raises rather than
+    guessing when more than one entry is loaded, since silently picking one
+    would risk writing a parameter to the wrong physical heat pump.
+
+    Returns None only when no target was given and no entry is loaded at all.
+    """
+    device_id = service_data.get(ATTR_DEVICE_ID)
+    config_entry_id = service_data.get(ATTR_CONFIG_ENTRY_ID)
+
+    if device_id:
+        device = dr.async_get(hass).async_get(device_id)
+        entry_id = next(
+            (
+                candidate_id
+                for candidate_id in (device.config_entries if device else ())
+                if (candidate := hass.config_entries.async_get_entry(candidate_id))
+                and candidate.domain == DOMAIN
+            ),
+            None,
+        )
+        if entry_id is None:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_write_target",
+                translation_placeholders={"target": f"device_id={device_id}"},
+            )
+        target_entry = hass.config_entries.async_get_entry(entry_id)
+    elif config_entry_id:
+        target_entry = hass.config_entries.async_get_entry(config_entry_id)
+        if target_entry is None or target_entry.domain != DOMAIN:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_write_target",
+                translation_placeholders={
+                    "target": f"config_entry_id={config_entry_id}"
+                },
+            )
+    else:
+        loaded_entries = [
+            entry
+            for entry in hass.config_entries.async_entries(DOMAIN)
+            if entry.state is ConfigEntryState.LOADED and hasattr(entry, "runtime_data")
+        ]
+        if len(loaded_entries) > 1:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="ambiguous_write_target",
+                translation_placeholders={"count": str(len(loaded_entries))},
+            )
+        return loaded_entries[0] if loaded_entries else None
+
+    if (
+        target_entry is None
+        or target_entry.state is not ConfigEntryState.LOADED
+        or not hasattr(target_entry, "runtime_data")
+    ):
+        target = (
+            f"device_id={device_id}"
+            if device_id
+            else f"config_entry_id={config_entry_id}"
+        )
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_write_target",
+            translation_placeholders={"target": target},
+        )
+    return target_entry
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: LuxtronikConfigEntry) -> bool:

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -7,7 +7,7 @@ from enum import Enum, StrEnum
 import logging
 from typing import Final
 
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_CONFIG_ENTRY_ID, ATTR_DEVICE_ID, Platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import StateType
 import voluptuous as vol
@@ -92,6 +92,8 @@ SERVICE_WRITE_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_PARAMETER): cv.string,
         vol.Required(ATTR_VALUE): vol.Any(cv.Number, cv.string),  # pyright: ignore[reportAttributeAccessIssue]
+        vol.Optional(ATTR_DEVICE_ID): cv.string,
+        vol.Optional(ATTR_CONFIG_ENTRY_ID): cv.string,
     }
 )
 

--- a/custom_components/luxtronik2/services.yaml
+++ b/custom_components/luxtronik2/services.yaml
@@ -9,6 +9,7 @@ write:
       data:
         parameter: "ID_Ba_Bw_akt"
         value: "Automatic"
+        device_id: <device id of the Luxtronik heat pump>
 
   fields:
     parameter:
@@ -25,3 +26,23 @@ write:
       example: "Automatic"
       selector:
         text:
+    device_id:
+      name: Heat pump device
+      description: >-
+        Which Luxtronik heat pump to write to. Required if more than one
+        heat pump is configured; can be omitted when only a single heat
+        pump is set up.
+      required: false
+      selector:
+        device:
+          filter:
+            - integration: luxtronik2
+    config_entry_id:
+      name: Heat pump config entry
+      description: >-
+        Alternative to device_id: the config entry ID of the Luxtronik heat
+        pump to write to.
+      required: false
+      selector:
+        config_entry:
+          integration: luxtronik2

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -1133,6 +1133,12 @@
         },
         "parameter_not_writable": {
             "message": "Parametr {parameter} odm\u00edtnut \u2014 zapisovat lze pouze parametry s p\u0159edponami {prefixes}"
+        },
+        "ambiguous_write_target": {
+            "message": "Je nakonfigurov\u00e1no v\u00edce tepeln\u00fdch \u010derpadel Luxtronik ({count} na\u010dteno) \u2014 zadejte device_id nebo config_entry_id pro v\u00fdb\u011br c\u00edle z\u00e1pisu"
+        },
+        "invalid_write_target": {
+            "message": "Nepoda\u0159ilo se naj\u00edt na\u010dten\u00e9 tepeln\u00e9 \u010derpadlo Luxtronik pro c\u00edl {target}"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -1136,6 +1136,12 @@
         },
         "parameter_not_writable": {
             "message": "Parameter {parameter} abgelehnt \u2014 nur Parameter mit Pr\u00e4fixen {prefixes} sind beschreibbar"
+        },
+        "ambiguous_write_target": {
+            "message": "Es sind mehrere Luxtronik-W\u00e4rmepumpen konfiguriert ({count} geladen) \u2014 bitte device_id oder config_entry_id angeben, um das Ziel auszuw\u00e4hlen"
+        },
+        "invalid_write_target": {
+            "message": "Es konnte keine geladene Luxtronik-W\u00e4rmepumpe f\u00fcr das Ziel {target} ermittelt werden"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -1163,6 +1163,12 @@
         "parameter_not_writable": {
             "message": "Parameter {parameter} rejected \u2014 only parameters with prefixes {prefixes} are writable"
         },
+        "ambiguous_write_target": {
+            "message": "Multiple Luxtronik heat pumps are configured ({count} loaded) \u2014 specify device_id or config_entry_id to select which one to write to"
+        },
+        "invalid_write_target": {
+            "message": "Could not resolve a loaded Luxtronik heat pump for target {target}"
+        },
         "invalid_timer_schedule": {
             "message": "Invalid timer schedule \"{value}\": expected \"HH:MM-HH:MM\" entries separated by \"/\", with at most {max_rows} entries"
         }

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -1139,6 +1139,12 @@
         },
         "parameter_not_writable": {
             "message": "Parameter {parameter} geweigerd \u2014 alleen parameters met prefixen {prefixes} zijn schrijfbaar"
+        },
+        "ambiguous_write_target": {
+            "message": "Er zijn meerdere Luxtronik-warmtepompen geconfigureerd ({count} geladen) \u2014 geef device_id of config_entry_id op om te bepalen welke moet worden beschreven"
+        },
+        "invalid_write_target": {
+            "message": "Kon geen geladen Luxtronik-warmtepomp vinden voor doel {target}"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -1154,6 +1154,12 @@
         },
         "parameter_not_writable": {
             "message": "Parametr {parameter} odrzucony \u2014 tylko parametry z prefiksami {prefixes} s\u0105 zapisywalne"
+        },
+        "ambiguous_write_target": {
+            "message": "Skonfigurowano wi\u0119cej ni\u017c jedn\u0105 pomp\u0119 ciep\u0142a Luxtronik ({count} za\u0142adowanych) \u2014 podaj device_id lub config_entry_id, aby wybra\u0107 cel zapisu"
+        },
+        "invalid_write_target": {
+            "message": "Nie uda\u0142o si\u0119 znale\u017a\u0107 za\u0142adowanej pompy ciep\u0142a Luxtronik dla celu {target}"
         }
     },
     "issues": {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,6 +21,8 @@ from custom_components.luxtronik2 import (
     update_listener,
 )
 from custom_components.luxtronik2.const import (
+    ATTR_CONFIG_ENTRY_ID,
+    ATTR_DEVICE_ID,
     ATTR_PARAMETER,
     ATTR_VALUE,
     CONF_HA_SENSOR_PREFIX,
@@ -761,3 +763,323 @@ class TestWriteParameterService:
         assert exc_info.value.translation_key == "invalid_parameter_name"
         assert exc_info.value.translation_domain == DOMAIN
         assert exc_info.value.translation_placeholders == {"parameter": "None"}
+
+
+# ===========================================================================
+# write_parameter service handler - multi config entry target selection
+# ===========================================================================
+
+
+def _mock_loaded_config_entry(entry_id: str, hass) -> MagicMock:
+    """Build a MagicMock config entry that looks LOADED with runtime_data."""
+    from homeassistant.config_entries import ConfigEntryState
+
+    entry = MagicMock()
+    entry.entry_id = entry_id
+    entry.domain = DOMAIN
+    entry.state = ConfigEntryState.LOADED
+    entry.runtime_data = _mock_coordinator(hass)
+    return entry
+
+
+class TestWriteParameterServiceTargetSelection:
+    """The write service must target a specific config entry when several
+    heat pumps (config entries) are loaded, instead of silently picking the
+    first one returned by hass.config_entries.async_entries()."""
+
+    def _setup(self):
+        hass = MagicMock()
+        hass.services.has_service = MagicMock(return_value=False)
+        entry = _mock_entry()
+        setup_hass_services(hass, entry)
+        handler = hass.services.async_register.call_args[0][2]
+        return hass, handler
+
+    @pytest.mark.asyncio
+    async def test_write_multi_entry_with_config_entry_id_targets_correct_entry(self):
+        """A config_entry_id target must select that exact entry, even when
+        it is not first in hass.config_entries.async_entries()."""
+        hass, handler = self._setup()
+
+        entry_1 = _mock_loaded_config_entry("entry_1", hass)
+        entry_2 = _mock_loaded_config_entry("entry_2", hass)
+        hass.config_entries.async_entries = MagicMock(return_value=[entry_1, entry_2])
+        hass.config_entries.async_get_entry = MagicMock(
+            side_effect=lambda eid: {"entry_1": entry_1, "entry_2": entry_2}.get(eid)
+        )
+
+        service = MagicMock()
+        service.data = {
+            ATTR_PARAMETER: "ID_Einst_BWS_akt",
+            ATTR_VALUE: "42",
+            ATTR_CONFIG_ENTRY_ID: "entry_2",
+        }
+
+        await handler(service)
+
+        entry_2.runtime_data.async_write.assert_awaited_once_with(
+            "ID_Einst_BWS_akt", 42
+        )
+        entry_1.runtime_data.async_write.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_write_multi_entry_with_device_id_targets_correct_entry(self):
+        """A device_id target must be resolved via the device registry to the
+        config entry that owns that device, then write to that entry only."""
+        hass, handler = self._setup()
+
+        entry_1 = _mock_loaded_config_entry("entry_1", hass)
+        entry_2 = _mock_loaded_config_entry("entry_2", hass)
+        hass.config_entries.async_entries = MagicMock(return_value=[entry_1, entry_2])
+        hass.config_entries.async_get_entry = MagicMock(
+            side_effect=lambda eid: {"entry_1": entry_1, "entry_2": entry_2}.get(eid)
+        )
+
+        device = MagicMock()
+        device.config_entries = {"entry_2"}
+        device_registry = MagicMock()
+        device_registry.async_get = MagicMock(return_value=device)
+
+        service = MagicMock()
+        service.data = {
+            ATTR_PARAMETER: "ID_Einst_BWS_akt",
+            ATTR_VALUE: "42",
+            ATTR_DEVICE_ID: "device_xyz",
+        }
+
+        with patch(
+            "custom_components.luxtronik2.dr.async_get", return_value=device_registry
+        ):
+            await handler(service)
+
+        device_registry.async_get.assert_called_once_with("device_xyz")
+        entry_2.runtime_data.async_write.assert_awaited_once_with(
+            "ID_Einst_BWS_akt", 42
+        )
+        entry_1.runtime_data.async_write.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_write_multi_entry_no_target_raises_ambiguous(self):
+        """With no device_id/config_entry_id and more than one loaded entry,
+        the service must refuse to guess and raise instead of silently
+        writing to whichever entry happens to come first."""
+        hass, handler = self._setup()
+
+        entry_1 = _mock_loaded_config_entry("entry_1", hass)
+        entry_2 = _mock_loaded_config_entry("entry_2", hass)
+        hass.config_entries.async_entries = MagicMock(return_value=[entry_1, entry_2])
+
+        service = MagicMock()
+        service.data = {
+            ATTR_PARAMETER: "ID_Einst_BWS_akt",
+            ATTR_VALUE: "42",
+        }
+
+        with pytest.raises(ServiceValidationError) as exc_info:
+            await handler(service)
+
+        assert exc_info.value.translation_key == "ambiguous_write_target"
+        assert exc_info.value.translation_domain == DOMAIN
+        entry_1.runtime_data.async_write.assert_not_awaited()
+        entry_2.runtime_data.async_write.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_write_no_target_single_entry_still_works(self):
+        """Backward compatibility: a single-heat-pump setup with no explicit
+        target must keep working exactly as before."""
+        hass, handler = self._setup()
+
+        entry_1 = _mock_loaded_config_entry("entry_1", hass)
+        hass.config_entries.async_entries = MagicMock(return_value=[entry_1])
+
+        service = MagicMock()
+        service.data = {
+            ATTR_PARAMETER: "ID_Einst_BWS_akt",
+            ATTR_VALUE: "42",
+        }
+
+        await handler(service)
+
+        entry_1.runtime_data.async_write.assert_awaited_once_with(
+            "ID_Einst_BWS_akt", 42
+        )
+
+    @pytest.mark.asyncio
+    async def test_write_unknown_device_id_raises(self):
+        """A device_id that does not resolve to any known device must raise,
+        not silently fall through to writing the wrong entry."""
+        hass, handler = self._setup()
+
+        entry_1 = _mock_loaded_config_entry("entry_1", hass)
+        hass.config_entries.async_entries = MagicMock(return_value=[entry_1])
+        hass.config_entries.async_get_entry = MagicMock(
+            side_effect=lambda eid: {"entry_1": entry_1}.get(eid)
+        )
+
+        device_registry = MagicMock()
+        device_registry.async_get = MagicMock(return_value=None)
+
+        service = MagicMock()
+        service.data = {
+            ATTR_PARAMETER: "ID_Einst_BWS_akt",
+            ATTR_VALUE: "42",
+            ATTR_DEVICE_ID: "does_not_exist",
+        }
+
+        with (
+            patch(
+                "custom_components.luxtronik2.dr.async_get",
+                return_value=device_registry,
+            ),
+            pytest.raises(ServiceValidationError) as exc_info,
+        ):
+            await handler(service)
+
+        assert exc_info.value.translation_key == "invalid_write_target"
+        assert exc_info.value.translation_domain == DOMAIN
+        entry_1.runtime_data.async_write.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_write_device_id_from_other_integration_raises(self):
+        """A device_id belonging to a device from a different integration
+        (not a Luxtronik config entry) must raise, not fall back to picking
+        an arbitrary Luxtronik entry."""
+        hass, handler = self._setup()
+
+        entry_1 = _mock_loaded_config_entry("entry_1", hass)
+        hass.config_entries.async_entries = MagicMock(return_value=[entry_1])
+
+        other_entry = MagicMock()
+        other_entry.entry_id = "other_entry"
+        other_entry.domain = "some_other_integration"
+
+        hass.config_entries.async_get_entry = MagicMock(
+            side_effect=lambda eid: {
+                "entry_1": entry_1,
+                "other_entry": other_entry,
+            }.get(eid)
+        )
+
+        device = MagicMock()
+        device.config_entries = {"other_entry"}
+        device_registry = MagicMock()
+        device_registry.async_get = MagicMock(return_value=device)
+
+        service = MagicMock()
+        service.data = {
+            ATTR_PARAMETER: "ID_Einst_BWS_akt",
+            ATTR_VALUE: "42",
+            ATTR_DEVICE_ID: "device_of_other_integration",
+        }
+
+        with (
+            patch(
+                "custom_components.luxtronik2.dr.async_get",
+                return_value=device_registry,
+            ),
+            pytest.raises(ServiceValidationError) as exc_info,
+        ):
+            await handler(service)
+
+        assert exc_info.value.translation_key == "invalid_write_target"
+        assert exc_info.value.translation_domain == DOMAIN
+        entry_1.runtime_data.async_write.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_write_unknown_config_entry_id_raises(self):
+        """A config_entry_id that does not resolve to a loaded Luxtronik
+        entry must raise rather than silently targeting a different entry."""
+        hass, handler = self._setup()
+
+        entry_1 = _mock_loaded_config_entry("entry_1", hass)
+        hass.config_entries.async_entries = MagicMock(return_value=[entry_1])
+        hass.config_entries.async_get_entry = MagicMock(return_value=None)
+
+        service = MagicMock()
+        service.data = {
+            ATTR_PARAMETER: "ID_Einst_BWS_akt",
+            ATTR_VALUE: "42",
+            ATTR_CONFIG_ENTRY_ID: "does_not_exist",
+        }
+
+        with pytest.raises(ServiceValidationError) as exc_info:
+            await handler(service)
+
+        assert exc_info.value.translation_key == "invalid_write_target"
+        assert exc_info.value.translation_domain == DOMAIN
+        entry_1.runtime_data.async_write.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_write_config_entry_id_not_loaded_raises(self):
+        """A config_entry_id that belongs to this integration but whose entry
+        is not currently loaded (e.g. disabled, failed setup) must raise
+        rather than write through a coordinator that may not exist."""
+        hass, handler = self._setup()
+
+        from homeassistant.config_entries import ConfigEntryState
+
+        entry_1 = _mock_loaded_config_entry("entry_1", hass)
+        hass.config_entries.async_entries = MagicMock(return_value=[entry_1])
+
+        unloaded_entry = MagicMock()
+        unloaded_entry.entry_id = "entry_unloaded"
+        unloaded_entry.domain = DOMAIN
+        unloaded_entry.state = ConfigEntryState.NOT_LOADED
+        del unloaded_entry.runtime_data
+
+        hass.config_entries.async_get_entry = MagicMock(
+            side_effect=lambda eid: {
+                "entry_1": entry_1,
+                "entry_unloaded": unloaded_entry,
+            }.get(eid)
+        )
+
+        service = MagicMock()
+        service.data = {
+            ATTR_PARAMETER: "ID_Einst_BWS_akt",
+            ATTR_VALUE: "42",
+            ATTR_CONFIG_ENTRY_ID: "entry_unloaded",
+        }
+
+        with pytest.raises(ServiceValidationError) as exc_info:
+            await handler(service)
+
+        assert exc_info.value.translation_key == "invalid_write_target"
+        assert exc_info.value.translation_domain == DOMAIN
+        entry_1.runtime_data.async_write.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_write_device_id_takes_precedence_over_config_entry_id(self):
+        """When both device_id and config_entry_id are given, device_id wins
+        (documented precedence) rather than the two silently disagreeing."""
+        hass, handler = self._setup()
+
+        entry_1 = _mock_loaded_config_entry("entry_1", hass)
+        entry_2 = _mock_loaded_config_entry("entry_2", hass)
+        hass.config_entries.async_entries = MagicMock(return_value=[entry_1, entry_2])
+        hass.config_entries.async_get_entry = MagicMock(
+            side_effect=lambda eid: {"entry_1": entry_1, "entry_2": entry_2}.get(eid)
+        )
+
+        device = MagicMock()
+        device.config_entries = {"entry_2"}
+        device_registry = MagicMock()
+        device_registry.async_get = MagicMock(return_value=device)
+
+        service = MagicMock()
+        service.data = {
+            ATTR_PARAMETER: "ID_Einst_BWS_akt",
+            ATTR_VALUE: "42",
+            ATTR_DEVICE_ID: "device_xyz",
+            ATTR_CONFIG_ENTRY_ID: "entry_1",
+        }
+
+        with patch(
+            "custom_components.luxtronik2.dr.async_get", return_value=device_registry
+        ):
+            await handler(service)
+
+        entry_2.runtime_data.async_write.assert_awaited_once_with(
+            "ID_Einst_BWS_akt", 42
+        )
+        entry_1.runtime_data.async_write.assert_not_awaited()


### PR DESCRIPTION
## Summary
- `luxtronik2.write` used to write to whichever config entry happened to be first in `hass.config_entries.async_entries(DOMAIN)` — with two or more heat pumps configured, a service call could silently write a parameter to the wrong physical device.
- Adds optional `device_id` / `config_entry_id` targeting to the service schema, resolved via `homeassistant.helpers.device_registry`. Backward compatible: single-pump users with no target keep working unchanged; multi-pump users with no target now get a clear `ServiceValidationError` instead of a silent wrong-device write.
- Adds device/config_entry selectors to `services.yaml`, and the two new error messages to all 5 locale files (`en`, `de`, `nl`, `cs`, `pl`).

Addresses task **C1** (Critical) from `docs/superpowers/plans/2026-07-18-code-review-remediation.md`.

## Test plan
- [x] `pytest` — 793/793 passing
- [x] `pytest --cov=custom_components.luxtronik2` — 100% coverage, no regression
- [x] `ruff check` / `ruff format --check` — clean
- [x] `basedpyright` — 0 errors
- [x] New tests cover: multi-entry write via `device_id`, multi-entry write via `config_entry_id`, no-target ambiguity raises, no-target single-entry still works, unknown/foreign device_id, unknown/not-loaded config_entry_id, device_id takes precedence over config_entry_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)