### PR TITLE
fix(model): make visibility drive entity_registry_enabled_default

### DIFF
--- a/custom_components/luxtronik2/model.py
+++ b/custom_components/luxtronik2/model.py
@@ -88,7 +88,9 @@ class LuxtronikEntityDescription(EntityDescription, frozen_or_thawed=True):
     max_firmware_version: Version | None = None
 
     extra_attributes: tuple[LuxtronikEntityAttributeDescription, ...] = ()
-    entity_registry_enabled_default: bool = True
+    entity_registry_enabled_default: bool | None = (  # pyright: ignore[reportIncompatibleVariableOverride]
+        None
+    )
     state_class: str | None = None
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -27,6 +27,7 @@ from custom_components.luxtronik2.const import (
     LuxMode,
     LuxOperationMode,
     LuxParameter as LP,
+    LuxVisibility as LV,
     SensorAttrFormat,
     SensorAttrKey as SA,
     SensorKey,
@@ -562,6 +563,88 @@ class TestBaseEntityRegistryEnabledDefault:
         _patch_entity(entity)
         assert entity.entity_description.entity_registry_enabled_default is False
         coord.entity_visible.assert_called()
+
+    def test_default_omitted_falls_back_to_coordinator_visibility_when_not_visible(
+        self,
+    ):
+        """Regression test for C2: a description that does NOT explicitly set
+        entity_registry_enabled_default (i.e. relies on the dataclass default)
+        must still have its enabled-default driven by coordinator.entity_visible()
+        when the heat pump reports the entity's visibility flag as not visible.
+
+        Before the fix, LuxtronikEntityDescription.entity_registry_enabled_default
+        defaulted to `bool = True`, so the `is None` branch in
+        LuxtronikEntity.__init__ never fired for real (non-test-authored)
+        descriptions, and this assertion failed with True != False.
+        """
+        coord = _mock_coordinator()
+        coord.entity_visible.return_value = False
+        desc = LuxtronikSensorDescription(
+            key=SensorKey.FLOW_OUT_TEMPERATURE,
+            luxtronik_key=LC.C0011_FLOW_OUT_TEMPERATURE,
+            device_key=DeviceKey.heatpump,
+            visibility=LV.V0005_COOLING,
+            # entity_registry_enabled_default intentionally omitted
+        )
+        entity = LuxtronikSensorEntity(
+            MagicMock(), _mock_entry(), coord, desc, DeviceKey.heatpump
+        )
+        _patch_entity(entity)
+        assert entity.entity_description.entity_registry_enabled_default is False
+        coord.entity_visible.assert_called()
+
+    def test_default_omitted_stays_enabled_when_coordinator_reports_visible(self):
+        """Sanity check for the same fallback: when the coordinator reports the
+        entity IS visible, the omitted-default description ends up enabled."""
+        coord = _mock_coordinator()
+        coord.entity_visible.return_value = True
+        desc = LuxtronikSensorDescription(
+            key=SensorKey.FLOW_OUT_TEMPERATURE,
+            luxtronik_key=LC.C0011_FLOW_OUT_TEMPERATURE,
+            device_key=DeviceKey.heatpump,
+            visibility=LV.V0005_COOLING,
+        )
+        entity = LuxtronikSensorEntity(
+            MagicMock(), _mock_entry(), coord, desc, DeviceKey.heatpump
+        )
+        _patch_entity(entity)
+        assert entity.entity_description.entity_registry_enabled_default is True
+
+    def test_explicit_false_wins_over_visibility(self):
+        """Explicit False must keep winning even when the coordinator reports
+        the entity as visible (i.e. explicit values are never overridden)."""
+        coord = _mock_coordinator()
+        coord.entity_visible.return_value = True
+        desc = LuxtronikSensorDescription(
+            key=SensorKey.FLOW_OUT_TEMPERATURE,
+            luxtronik_key=LC.C0011_FLOW_OUT_TEMPERATURE,
+            device_key=DeviceKey.heatpump,
+            entity_registry_enabled_default=False,
+        )
+        entity = LuxtronikSensorEntity(
+            MagicMock(), _mock_entry(), coord, desc, DeviceKey.heatpump
+        )
+        _patch_entity(entity)
+        assert entity.entity_description.entity_registry_enabled_default is False
+        coord.entity_visible.assert_not_called()
+
+    def test_explicit_true_wins_over_visibility(self):
+        """Explicit True must keep winning even when the coordinator reports
+        the entity as not visible (i.e. explicit values are never overridden)."""
+        coord = _mock_coordinator()
+        coord.entity_visible.return_value = False
+        desc = LuxtronikSensorDescription(
+            key=SensorKey.FLOW_OUT_TEMPERATURE,
+            luxtronik_key=LC.C0011_FLOW_OUT_TEMPERATURE,
+            device_key=DeviceKey.heatpump,
+            entity_registry_enabled_default=True,
+        )
+        entity = LuxtronikSensorEntity(
+            MagicMock(), _mock_entry(), coord, desc, DeviceKey.heatpump
+        )
+        _patch_entity(entity)
+        assert entity.entity_description.entity_registry_enabled_default is True
+        coord.entity_visible.assert_not_called()
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- `LuxtronikEntityDescription.entity_registry_enabled_default` was typed `bool = True` in `model.py`, so the `is None` fallback in `base.py` (`LuxtronikEntity.__init__`) that consults `coordinator.entity_visible(...)` never fired in production — only a test manually passing `None` exercised it.
- Changed the field to `bool | None = None` (with a `# pyright: ignore[reportIncompatibleVariableOverride]` matching the existing style in `model.py`/`update.py`, since HA's `EntityDescription` declares this field as plain `bool`). `base.py`'s resolution logic needed no changes — it becomes live.
- Audited every `*_entities_predefined.py` file (number, select, sensor, switch — 39 explicit occurrences total) for explicit `entity_registry_enabled_default=`: all are `=False` and were left untouched. No explicit `=True` occurrences exist anywhere, so no predefined-file edits were needed.

## Behavior change
Entities not visible on a given heat pump model will now correctly default to *disabled* in the entity registry, instead of always defaulting to enabled. This only affects **new installs / newly-added entities** — HA only applies `entity_registry_enabled_default` at first registration, so existing users' registry entries are unaffected.

## Test plan
- [x] New regression tests in `tests/test_base.py::TestBaseEntityRegistryEnabledDefault`: omitted default falls back to `coordinator.entity_visible()` when not visible; stays enabled when visible; explicit `True`/`False` both win over visibility (verified via `entity_visible.assert_not_called()`)
- [x] `ruff check` / `ruff format --check` clean
- [x] `basedpyright` — 0 errors, 0 warnings, 0 notes
- [x] Full test suite: 797/797 passing (up from 793 baseline), 100% coverage maintained

Resolves task C2 from `docs/superpowers/plans/2026-07-18-code-review-remediation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)