### PR TITLE
fix(sensor): 🐛 override available property on SmartGrid status sensor

### DIFF
--- a/custom_components/luxtronik2/sensor.py
+++ b/custom_components/luxtronik2/sensor.py
@@ -220,6 +220,14 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity):
         """Init Luxtronik Status Sensor."""
         super().__init__(hass, entry, coordinator, description, device_info_ident)
         self._evu_tracker = LuxtronikEVUTracker()
+        self._smart_grid_available: bool = True
+
+    @property
+    def available(self) -> bool:
+        """SmartGrid status sensor is unavailable when SmartGrid is disabled."""
+        if self.entity_description.key == SensorKey.SMART_GRID_STATUS:
+            return super().available and self._smart_grid_available
+        return super().available
 
     @callback
     def _handle_coordinator_update(
@@ -301,10 +309,10 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity):
 
         # If SmartGrid is disabled, set sensor to unavailable
         if not smartgrid_enabled or smartgrid_enabled in [False, 0, "false", "False"]:
-            self._attr_available = False
+            self._smart_grid_available = False
             self._attr_native_value = None
         else:
-            self._attr_available = True
+            self._smart_grid_available = True
 
             evu = self._get_value(LC.C0031_EVU_UNLOCKED)
             evu2 = self._get_value(LC.C0185_EVU2)

--- a/tests/test_entity_platforms.py
+++ b/tests/test_entity_platforms.py
@@ -678,7 +678,7 @@ class TestSmartGridSensor:
     def test_smart_grid_disabled(self):
         entity, _ = self._make_smart_grid(sg_enabled=0)
         entity._handle_coordinator_update()
-        assert entity._attr_available is False
+        assert entity.available is False
         assert entity._attr_native_value is None
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -286,8 +286,27 @@ class TestSmartGridStatus:
     def test_smartgrid_disabled(self):
         entity = self._make_smartgrid_sensor(smartgrid_enabled=0)
         entity._handle_coordinator_update()
-        assert entity._attr_available is False
+        assert entity.available is False
         assert entity._attr_native_value is None
+
+    def test_smartgrid_enabled_is_available(self):
+        entity = self._make_smartgrid_sensor()
+        entity._handle_coordinator_update()
+        assert entity.available is True
+
+    def test_smartgrid_enabled_but_coordinator_update_failed(self):
+        entity = self._make_smartgrid_sensor()
+        entity._handle_coordinator_update()
+        entity.coordinator.last_update_success = False
+        assert entity.available is False
+
+    def test_other_status_sensor_available_tracks_coordinator_only(self):
+        entity = _make_status_sensor()
+        entity._handle_coordinator_update()
+        entity.coordinator.last_update_success = True
+        assert entity.available is True
+        entity.coordinator.last_update_success = False
+        assert entity.available is False
 
     def test_smartgrid_locked(self):
         entity = self._make_smartgrid_sensor(evu=1, evu2=0)


### PR DESCRIPTION
## Summary
- `CoordinatorEntity.available` is a property that shadows `_attr_available`, so the SmartGrid status sensor's `self._attr_available = False/True` writes in `_update_smart_grid_status` were dead code — the sensor never actually went unavailable when SmartGrid (P1030) was disabled, it just showed a stale/`None` value while claiming to be available.
- Fixes task C3 from the code-review remediation plan (`docs/superpowers/plans/2026-07-18-code-review-remediation.md`).

## Changes
- `custom_components/luxtronik2/sensor.py`: replaced the dead `_attr_available` writes with a plain `_smart_grid_available` instance flag, and added an `available` property override on `LuxtronikStatusSensorEntity` that ANDs `super().available` with that flag — scoped to `SensorKey.SMART_GRID_STATUS` only, so other status sensors sharing the class (status_time, status_line_1, status_line_2) are unaffected and keep behaving like a plain `CoordinatorEntity`. Follows the existing pattern in `text.py`'s `available` override.
- Tests: fixed two existing tests that were asserting the dead `_attr_available` attribute instead of the real `available` property (this is why the bug slipped through); added coverage for coordinator-failure-while-enabled and for non-SmartGrid sensors being unaffected.

## Test plan
- [x] `pytest -q` — 796 passed (793 baseline + 3 new)
- [x] `ruff check` / `ruff format --check` clean
- [x] `basedpyright` 0 errors
- [x] Confirmed the updated assertions fail against pre-fix code and pass after the fix (TDD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)