### PR TITLE
fix(base): 🐛 restore-path early return and unavailable-sentinel bugs

### DIFF
--- a/custom_components/luxtronik2/base.py
+++ b/custom_components/luxtronik2/base.py
@@ -8,7 +8,12 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any
 
-from homeassistant.const import UnitOfTemperature, UnitOfTime
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    UnitOfTemperature,
+    UnitOfTime,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -119,16 +124,21 @@ class LuxtronikEntity[DescriptionT: LuxtronikEntityDescription](  # type: ignore
 
         try:
             last_state = await self.async_get_last_state()
-            if last_state is None:
-                return
-            self._attr_state = last_state.state
+            if last_state is not None and last_state.state not in (
+                STATE_UNAVAILABLE,
+                STATE_UNKNOWN,
+            ):
+                self._attr_state = last_state.state
 
-            for attr in self.entity_description.extra_attributes:
-                if not attr.restore_on_startup or attr.key not in last_state.attributes:
-                    continue
-                self._attr_cache[attr.key] = self._restore_attr_value(
-                    last_state.attributes[attr.key]
-                )
+                for attr in self.entity_description.extra_attributes:
+                    if (
+                        not attr.restore_on_startup
+                        or attr.key not in last_state.attributes
+                    ):
+                        continue
+                    self._attr_cache[attr.key] = self._restore_attr_value(
+                        last_state.attributes[attr.key]
+                    )
 
             last_extra_data = await self.async_get_last_extra_data()
             if last_extra_data is not None:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,6 +10,8 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
     CONF_TIMEOUT,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     UnitOfTime,
 )
 import pytest
@@ -440,14 +442,67 @@ class TestAsyncAddedToHass:
         assert entity._attr_cache[SA.TIMER_HEATPUMP_ON] == "restored_value"
 
     @pytest.mark.asyncio
-    async def test_no_last_state_returns_early(self):
+    async def test_no_last_state_still_runs_tail_setup(self):
+        """First-ever add (no previous state) must still run the tail of the method:
+        dispatcher hookup and the initial _handle_coordinator_update call."""
         entity = _make_sensor_entity()
         entity.async_get_last_state = AsyncMock(return_value=None)
         entity.async_get_last_extra_data = AsyncMock(return_value=None)
+        entity.async_on_remove = MagicMock()
+        entity.entity_id = "sensor.test_entity"
         entity.platform = MagicMock()
 
-        await LuxtronikEntity.async_added_to_hass(entity)
-        # Should not crash
+        with patch(
+            "custom_components.luxtronik2.base.async_dispatcher_connect"
+        ) as mock_connect:
+            await LuxtronikEntity.async_added_to_hass(entity)
+
+        mock_connect.assert_called_once()
+        # coordinator.data is truthy (set in _mock_coordinator), so the initial
+        # _handle_coordinator_update call must have run and written HA state.
+        entity.async_write_ha_state.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_unavailable_state_not_restored(self):
+        """A previous state of STATE_UNAVAILABLE must not overwrite _attr_state."""
+        entity = _make_sensor_entity()
+        freshly_computed_state = entity._attr_state
+        last_state = MagicMock()
+        last_state.state = STATE_UNAVAILABLE
+        last_state.attributes = {}
+        entity.async_get_last_state = AsyncMock(return_value=last_state)
+        entity.async_get_last_extra_data = AsyncMock(return_value=None)
+        entity.async_on_remove = MagicMock()
+        entity.entity_id = "sensor.test_entity"
+        entity.platform = MagicMock()
+        entity.coordinator.data = None
+
+        with patch("custom_components.luxtronik2.base.async_dispatcher_connect"):
+            await LuxtronikEntity.async_added_to_hass(entity)
+
+        assert entity._attr_state == freshly_computed_state
+        assert entity._attr_state != STATE_UNAVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_unknown_state_not_restored(self):
+        """A previous state of STATE_UNKNOWN must not overwrite _attr_state."""
+        entity = _make_sensor_entity()
+        freshly_computed_state = entity._attr_state
+        last_state = MagicMock()
+        last_state.state = STATE_UNKNOWN
+        last_state.attributes = {}
+        entity.async_get_last_state = AsyncMock(return_value=last_state)
+        entity.async_get_last_extra_data = AsyncMock(return_value=None)
+        entity.async_on_remove = MagicMock()
+        entity.entity_id = "sensor.test_entity"
+        entity.platform = MagicMock()
+        entity.coordinator.data = None
+
+        with patch("custom_components.luxtronik2.base.async_dispatcher_connect"):
+            await LuxtronikEntity.async_added_to_hass(entity)
+
+        assert entity._attr_state == freshly_computed_state
+        assert entity._attr_state != STATE_UNKNOWN
 
     @pytest.mark.asyncio
     async def test_restores_extra_data(self):


### PR DESCRIPTION
## Summary
- Implements task I6 from `docs/superpowers/plans/2026-07-18-code-review-remediation.md`.
- `LuxtronikEntity.async_added_to_hass` no longer returns early when there's no previous state — first-time entity adds now get the dispatcher hookup and the initial `_handle_coordinator_update` call, matching restart behavior.
- Restoring `_attr_state` / `extra_attributes` is now skipped when the previous state is HA's own `STATE_UNAVAILABLE`/`STATE_UNKNOWN` sentinel, since that string was leaking into `update.py`'s `installed_version` reporting.

## Test plan
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `basedpyright` 0 errors
- [x] Full suite: 795 passed
- [x] New tests: first-add-with-no-state runs tail setup (dispatcher connect + coordinator update); `"unavailable"`/`"unknown"` previous state is not restored into `_attr_state`; normal-state restore path unchanged (regression guard)
- [x] Task-scoped review: Approved (spec compliant, no Critical/Important findings)
- [x] Final whole-branch review: Ready to merge (backward-compat checked against the one other `async_added_to_hass` override in `update.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)