### PR TITLE
fix(coordinator): 🐛 raise on write read-back mismatch and batch schedule writes

### DIFF
--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -168,6 +168,22 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
             await self.async_refresh()
             LOGGER.debug("Coordinator data refreshed!")
 
+            # async_refresh() swallows failures internally (logs, does not
+            # raise) rather than propagating them, so self.data may still be
+            # the stale pre-write snapshot here. Comparing newly-written
+            # values against stale data would almost always look like a
+            # mismatch, misleadingly implying the device rejected the write
+            # when only the confirming read failed. Surface that distinctly
+            # instead of running the confirm comparison against stale data.
+            if not self.last_update_success:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="write_confirmation_unavailable",
+                    translation_placeholders={
+                        "parameters": ", ".join(parameter for parameter, _ in pairs)
+                    },
+                )
+
             # Confirm each value after the read
             mismatches: list[str] = []
             for parameter, value in pairs:

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -53,6 +53,23 @@ from .model import LuxtronikCoordinatorData, LuxtronikEntityDescription
 # endregion Imports
 
 
+def _write_confirmed(written: Any, confirmed: Any) -> bool:
+    """Return True if a write's post-refresh read-back matches what was written.
+
+    Datatype conversion (raw int -> float/enum/etc., see `lux_helper.py`'s
+    vendored `to_heatpump`/`from_heatpump`) can change a value's type between
+    what an entity passes to `async_write`/`async_write_many` and what a
+    refresh reads back afterwards, so a plain `==` is too strict. Numeric
+    values are additionally compared after rounding to 1 decimal place to
+    absorb floating point noise from 0.1-step datatypes (e.g. Celsius: raw / 10).
+    """
+    if written == confirmed:
+        return True
+    if isinstance(written, (int, float)) and isinstance(confirmed, (int, float)):
+        return round(float(written), 1) == round(float(confirmed), 1)
+    return False
+
+
 class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
     """Representation of a Luxtronik Coordinator."""
 
@@ -111,12 +128,39 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
                 raise UpdateFailed(f"Error fetching data: {err}") from err
 
     async def async_write(self, parameter: str, value: Any) -> LuxtronikCoordinatorData:
+        """Write a single parameter to the heat pump and confirm it stuck.
+
+        Thin wrapper around `async_write_many` for the common single-parameter
+        write case; see that method for the write/refresh/confirm logic.
+        """
+        return await self.async_write_many([(parameter, value)])
+
+    async def async_write_many(
+        self, pairs: list[tuple[str, Any]]
+    ) -> LuxtronikCoordinatorData:
+        """Write multiple parameters in one queued batch, then refresh once.
+
+        All pairs are queued via `parameters.set` before a single
+        `client.write()` flushes them to the device, and the coordinator
+        refreshes exactly once afterwards - avoiding an up-to-N-serial-refresh
+        pattern a naive per-parameter write loop would cause (e.g. editing a
+        multi-row timer schedule).
+
+        After the refresh, each written value is compared against what the
+        device reports back; on any mismatch (rejected or clamped write) a
+        `HomeAssistantError` is raised so the UI surfaces the failure and the
+        entity re-syncs to the device's actual value instead of silently
+        keeping the optimistic one.
+        """
         try:
             async with self._lock:
-                await self.hass.async_add_executor_job(
-                    self.client.parameters.set, parameter, value
+                for parameter, value in pairs:
+                    await self.hass.async_add_executor_job(
+                        self.client.parameters.set, parameter, value
+                    )
+                LOGGER.debug(
+                    "Done: self.client.parameters.set (%d parameter(s))", len(pairs)
                 )
-                LOGGER.debug("Done: self.client.parameters.set")
                 await self.hass.async_add_executor_job(self.client.write)
                 LOGGER.debug("Done: self.client.write")
 
@@ -124,16 +168,31 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
             await self.async_refresh()
             LOGGER.debug("Coordinator data refreshed!")
 
-            # Confirm the value after the read
-            confirmed_value = self.get_value(f"{CONF_PARAMETERS}.{parameter}")
-            LOGGER.info(
-                'LuxtronikDevice.write finished %s value: "%s" (confirmed: "%s")',
-                parameter,
-                value,
-                confirmed_value,
-            )
+            # Confirm each value after the read
+            mismatches: list[str] = []
+            for parameter, value in pairs:
+                confirmed_value = self.get_value(f"{CONF_PARAMETERS}.{parameter}")
+                LOGGER.info(
+                    'LuxtronikDevice.write finished %s value: "%s" (confirmed: "%s")',
+                    parameter,
+                    value,
+                    confirmed_value,
+                )
+                if not _write_confirmed(value, confirmed_value):
+                    mismatches.append(
+                        f"{parameter} (wrote {value!r}, device reports {confirmed_value!r})"
+                    )
+
+            if mismatches:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="write_confirmation_mismatch",
+                    translation_placeholders={"details": "; ".join(mismatches)},
+                )
 
             return self.data
+        except HomeAssistantError:
+            raise
         except Exception as err:
             raise LuxtronikWriteError(f"Write error: {err}") from err
 

--- a/custom_components/luxtronik2/text.py
+++ b/custom_components/luxtronik2/text.py
@@ -146,19 +146,27 @@ class LuxtronikTimerScheduleText(
 
         Rows beyond the supplied entries are cleared to 00:00-00:00 so a
         shortened string actually removes the trailing rows on the device,
-        rather than leaving stale values in effect.
+        rather than leaving stale values in effect. Changed start/end values
+        (up to 10 for a 5-row block) are queued and written in a single
+        `async_write_many` batch, so the device sees one write cycle and the
+        coordinator refreshes once - instead of up to 10 sequential
+        `async_write` calls each triggering a full refresh.
         """
         row_names = self.entity_description.row_names
         pairs = _parse_schedule(value, len(row_names))
 
         data = self.coordinator.data
+        writes: list[tuple[str, str]] = []
         for index, (start_name, end_name) in enumerate(row_names):
             start, end = (
                 pairs[index] if index < len(pairs) else (_UNSET_TIME, _UNSET_TIME)
             )
             if get_sensor_data(data, f"parameters.{start_name}") != start:
-                data = await self.coordinator.async_write(start_name, start)
+                writes.append((start_name, start))
             if get_sensor_data(data, f"parameters.{end_name}") != end:
-                data = await self.coordinator.async_write(end_name, end)
+                writes.append((end_name, end))
+
+        if writes:
+            data = await self.coordinator.async_write_many(writes)
 
         self._handle_coordinator_update(data)

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -1142,6 +1142,9 @@
         },
         "write_confirmation_mismatch": {
             "message": "Tepeln\u00e9 \u010derpadlo Luxtronik nepotvrdilo zapsan\u00e9 hodnoty: {details}"
+        },
+        "write_confirmation_unavailable": {
+            "message": "Hodnoty {parameters} byly zaps\u00e1ny do tepeln\u00e9ho \u010derpadla Luxtronik, ale potvrzuj\u00edc\u00ed obnoven\u00ed selhalo \u2014 v\u00fdsledek nebylo mo\u017en\u00e9 potvrdit"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -1139,6 +1139,9 @@
         },
         "invalid_write_target": {
             "message": "Nepoda\u0159ilo se naj\u00edt na\u010dten\u00e9 tepeln\u00e9 \u010derpadlo Luxtronik pro c\u00edl {target}"
+        },
+        "write_confirmation_mismatch": {
+            "message": "Tepeln\u00e9 \u010derpadlo Luxtronik nepotvrdilo zapsan\u00e9 hodnoty: {details}"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -1142,6 +1142,9 @@
         },
         "invalid_write_target": {
             "message": "Es konnte keine geladene Luxtronik-W\u00e4rmepumpe f\u00fcr das Ziel {target} ermittelt werden"
+        },
+        "write_confirmation_mismatch": {
+            "message": "Die Luxtronik-W\u00e4rmepumpe hat die geschriebenen Werte nicht best\u00e4tigt: {details}"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -1145,6 +1145,9 @@
         },
         "write_confirmation_mismatch": {
             "message": "Die Luxtronik-W\u00e4rmepumpe hat die geschriebenen Werte nicht best\u00e4tigt: {details}"
+        },
+        "write_confirmation_unavailable": {
+            "message": "{parameters} wurde(n) an die Luxtronik-W\u00e4rmepumpe geschrieben, aber die best\u00e4tigende Aktualisierung ist fehlgeschlagen \u2014 das Ergebnis konnte nicht best\u00e4tigt werden"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -1171,6 +1171,9 @@
         },
         "invalid_timer_schedule": {
             "message": "Invalid timer schedule \"{value}\": expected \"HH:MM-HH:MM\" entries separated by \"/\", with at most {max_rows} entries"
+        },
+        "write_confirmation_mismatch": {
+            "message": "Luxtronik heat pump did not confirm the written value(s): {details}"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -1174,6 +1174,9 @@
         },
         "write_confirmation_mismatch": {
             "message": "Luxtronik heat pump did not confirm the written value(s): {details}"
+        },
+        "write_confirmation_unavailable": {
+            "message": "Wrote {parameters} to the Luxtronik heat pump, but the confirming refresh failed — the result could not be confirmed"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -1148,6 +1148,9 @@
         },
         "write_confirmation_mismatch": {
             "message": "De Luxtronik-warmtepomp heeft de geschreven waarde(n) niet bevestigd: {details}"
+        },
+        "write_confirmation_unavailable": {
+            "message": "{parameters} is/zijn naar de Luxtronik-warmtepomp geschreven, maar de bevestigende vernieuwing is mislukt — het resultaat kon niet worden bevestigd"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -1145,6 +1145,9 @@
         },
         "invalid_write_target": {
             "message": "Kon geen geladen Luxtronik-warmtepomp vinden voor doel {target}"
+        },
+        "write_confirmation_mismatch": {
+            "message": "De Luxtronik-warmtepomp heeft de geschreven waarde(n) niet bevestigd: {details}"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -1163,6 +1163,9 @@
         },
         "write_confirmation_mismatch": {
             "message": "Pompa ciep\u0142a Luxtronik nie potwierdzi\u0142a zapisanych warto\u015bci: {details}"
+        },
+        "write_confirmation_unavailable": {
+            "message": "Zapisano {parameters} do pompy ciep\u0142a Luxtronik, ale od\u015bwie\u017cenie potwierdzaj\u0105ce nie powiod\u0142o si\u0119 \u2014 wyniku nie uda\u0142o si\u0119 potwierdzi\u0107"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -1160,6 +1160,9 @@
         },
         "invalid_write_target": {
             "message": "Nie uda\u0142o si\u0119 znale\u017a\u0107 za\u0142adowanej pompy ciep\u0142a Luxtronik dla celu {target}"
+        },
+        "write_confirmation_mismatch": {
+            "message": "Pompa ciep\u0142a Luxtronik nie potwierdzi\u0142a zapisanych warto\u015bci: {details}"
         }
     },
     "issues": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from conftest import make_coordinator_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from packaging.version import Version
 import pytest
@@ -794,6 +795,174 @@ class TestAsyncWrite:
         )
         with pytest.raises(LuxtronikWriteError):
             await coord.async_write("param", 1)
+
+    @pytest.mark.asyncio
+    async def test_write_mismatch_raises(self):
+        """If the device rejects/clamps a write, the read-back after refresh
+        will differ from what was written - this must surface as an error,
+        not just a debug log, so the UI re-syncs instead of showing a stale
+        optimistic value."""
+        coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock()
+
+        async def fake_refresh():
+            # Device clamped the write: asked for 42, device kept 40.
+            coord.data = LuxtronikCoordinatorData(
+                parameters={"test_param": (0, 40)},
+                calculations={},
+                visibilities={},
+            )
+
+        coord.async_refresh = fake_refresh
+
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await coord.async_write("test_param", 42)
+        assert not isinstance(exc_info.value, LuxtronikWriteError)
+        assert exc_info.value.translation_key == "write_confirmation_mismatch"
+
+    @pytest.mark.asyncio
+    async def test_write_match_with_float_rounding_does_not_raise(self):
+        """Confirmation must tolerate float noise from 0.1-step datatypes
+        (e.g. Celsius: raw/10) instead of raising on a spurious mismatch."""
+        coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock()
+
+        async def fake_refresh():
+            coord.data = LuxtronikCoordinatorData(
+                parameters={"test_param": (0, 21.500000000000004)},
+                calculations={},
+                visibilities={},
+            )
+
+        coord.async_refresh = fake_refresh
+
+        result = await coord.async_write("test_param", 21.5)
+        assert result is not None
+
+
+class TestAsyncWriteMany:
+    @pytest.mark.asyncio
+    async def test_queues_all_pairs_before_single_write_call(self):
+        coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock()
+
+        async def fake_refresh():
+            coord.data = LuxtronikCoordinatorData(
+                parameters={"p1": (0, "06:00"), "p2": (0, "22:00")},
+                calculations={},
+                visibilities={},
+            )
+
+        coord.async_refresh = fake_refresh
+
+        await coord.async_write_many([("p1", "06:00"), ("p2", "22:00")])
+
+        calls = coord.hass.async_add_executor_job.await_args_list
+        # Two parameters.set calls followed by exactly one client.write call.
+        assert calls[0].args[0] == coord.client.parameters.set
+        assert calls[0].args[1:] == ("p1", "06:00")
+        assert calls[1].args[0] == coord.client.parameters.set
+        assert calls[1].args[1:] == ("p2", "22:00")
+        assert calls[2].args == (coord.client.write,)
+        assert len(calls) == 3
+
+    @pytest.mark.asyncio
+    async def test_issues_single_refresh(self):
+        coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock()
+        coord.async_refresh = AsyncMock(
+            side_effect=lambda: setattr(
+                coord,
+                "data",
+                LuxtronikCoordinatorData(
+                    parameters={"p1": (0, "06:00"), "p2": (0, "22:00")},
+                    calculations={},
+                    visibilities={},
+                ),
+            )
+        )
+
+        await coord.async_write_many([("p1", "06:00"), ("p2", "22:00")])
+
+        coord.async_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_single_pair_matches_async_write_behavior(self):
+        coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock()
+
+        async def fake_refresh():
+            coord.data = LuxtronikCoordinatorData(
+                parameters={"test_param": (0, 42)},
+                calculations={},
+                visibilities={},
+            )
+
+        coord.async_refresh = fake_refresh
+        result = await coord.async_write_many([("test_param", 42)])
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_mismatch_reports_offending_parameter(self):
+        coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock()
+
+        async def fake_refresh():
+            coord.data = LuxtronikCoordinatorData(
+                parameters={"p1": (0, "06:00"), "p2": (0, "00:00")},
+                calculations={},
+                visibilities={},
+            )
+
+        coord.async_refresh = fake_refresh
+
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await coord.async_write_many([("p1", "06:00"), ("p2", "22:00")])
+        assert exc_info.value.translation_key == "write_confirmation_mismatch"
+        details = exc_info.value.translation_placeholders["details"]
+        assert "p2" in details
+        assert "p1" not in details
+
+
+class TestWriteConfirmed:
+    """Unit tests for the read-back comparison helper used by async_write /
+    async_write_many."""
+
+    def test_exact_match(self):
+        from custom_components.luxtronik2.coordinator import _write_confirmed
+
+        assert _write_confirmed("06:00", "06:00") is True
+
+    def test_exact_mismatch(self):
+        from custom_components.luxtronik2.coordinator import _write_confirmed
+
+        assert _write_confirmed("06:00", "07:00") is False
+
+    def test_int_vs_float_numeric_match(self):
+        from custom_components.luxtronik2.coordinator import _write_confirmed
+
+        assert _write_confirmed(42, 42.0) is True
+
+    def test_rounds_to_one_decimal_for_float_noise(self):
+        from custom_components.luxtronik2.coordinator import _write_confirmed
+
+        assert _write_confirmed(21.5, 21.500000000000004) is True
+
+    def test_numeric_mismatch_beyond_tolerance(self):
+        from custom_components.luxtronik2.coordinator import _write_confirmed
+
+        assert _write_confirmed(21.5, 21.7) is False
+
+    def test_bool_and_int_equivalence(self):
+        from custom_components.luxtronik2.coordinator import _write_confirmed
+
+        assert _write_confirmed(True, 1) is True
+        assert _write_confirmed(False, 0) is True
+
+    def test_type_mismatch_no_coercion(self):
+        from custom_components.luxtronik2.coordinator import _write_confirmed
+
+        assert _write_confirmed("42", 42) is False
 
 
 # ===========================================================================

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -87,6 +87,7 @@ def _make_coordinator_direct(data=None):
     coord.async_request_refresh = AsyncMock()
     coord.async_refresh = AsyncMock()
     coord.update_interval = DEFAULT_UPDATE_INTERVAL
+    coord.last_update_success = True
     if data is None:
         data = LuxtronikCoordinatorData(
             parameters={"ID_WEB_WP_BZ_akt": (0, 0)},
@@ -922,6 +923,54 @@ class TestAsyncWriteMany:
         details = exc_info.value.translation_placeholders["details"]
         assert "p2" in details
         assert "p1" not in details
+
+    @pytest.mark.asyncio
+    async def test_refresh_failure_raises_distinct_error_not_mismatch(self):
+        """DataUpdateCoordinator.async_refresh() swallows failures internally
+        (logs, does not raise) rather than propagating them. If the post-write
+        refresh fails, self.data stays at its stale pre-write value, and
+        comparing the newly-written value against stale data would almost
+        always look like a mismatch - misleadingly claiming the device
+        rejected the write when only the confirming read failed. This must
+        surface as a distinct error, not write_confirmation_mismatch, and the
+        mismatch comparison must not run against stale data at all."""
+        coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock()
+
+        async def fake_refresh():
+            # async_refresh() "succeeds" (returns normally, no exception) but
+            # leaves last_update_success False and self.data untouched/stale,
+            # exactly like a real transient socket hiccup during the read.
+            coord.last_update_success = False
+
+        coord.async_refresh = fake_refresh
+
+        with pytest.raises(HomeAssistantError) as exc_info:
+            await coord.async_write_many([("p1", "06:00")])
+
+        assert exc_info.value.translation_key == "write_confirmation_unavailable"
+        assert exc_info.value.translation_key != "write_confirmation_mismatch"
+
+    @pytest.mark.asyncio
+    async def test_refresh_success_with_flag_true_still_confirms_normally(self):
+        """Sanity check: when last_update_success is True (the normal case)
+        and the written value matches, async_write_many must still return
+        normally - no regression from the new check."""
+        coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock()
+
+        async def fake_refresh():
+            coord.last_update_success = True
+            coord.data = LuxtronikCoordinatorData(
+                parameters={"p1": (0, "06:00")},
+                calculations={},
+                visibilities={},
+            )
+
+        coord.async_refresh = fake_refresh
+
+        result = await coord.async_write_many([("p1", "06:00")])
+        assert result is not None
 
 
 class TestWriteConfirmed:

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -48,6 +48,7 @@ def _mock_coordinator(data=None, *, last_update_success: bool = True):
     coord.entity_active.return_value = True
     coord.get_device.return_value = MagicMock()
     coord.async_write = AsyncMock(return_value=data)
+    coord.async_write_many = AsyncMock(return_value=data)
     return coord
 
 
@@ -225,17 +226,37 @@ class TestLuxtronikTimerScheduleText:
         assert entity.available is False
 
     @pytest.mark.asyncio
-    async def test_set_value_writes_only_changed_rows(self):
+    async def test_set_value_writes_only_changed_rows_in_one_batch(self):
         entity, coord, description = self._make_entity()
         start0, end0 = description.row_names[0]
         data = make_coordinator_data(parameters={start0: "06:00", end0: "22:00"})
         coord.data = data
-        coord.async_write = AsyncMock(return_value=data)
+        coord.async_write_many = AsyncMock(return_value=data)
 
         await entity.async_set_value("06:00-22:00")
 
-        # Row 0 already matches; remaining rows get cleared (2 writes each).
-        assert coord.async_write.await_count == (len(description.row_names) - 1) * 2
+        # Row 0 already matches; remaining rows get cleared (2 writes each) -
+        # but all queued into a single async_write_many call (one refresh),
+        # not one async_write call per changed value.
+        coord.async_write_many.assert_awaited_once()
+        (pairs,), _kwargs = coord.async_write_many.await_args
+        assert len(pairs) == (len(description.row_names) - 1) * 2
+        coord.async_write.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_value_sends_expected_pairs(self):
+        entity, coord, description = self._make_entity()
+        start0, end0 = description.row_names[0]
+        start1, end1 = description.row_names[1]
+        data = make_coordinator_data(parameters={start0: "06:00", end0: "22:00"})
+        coord.data = data
+        coord.async_write_many = AsyncMock(return_value=data)
+
+        await entity.async_set_value("06:00-22:00/07:30-21:00")
+
+        (pairs,), _kwargs = coord.async_write_many.await_args
+        assert (start1, "07:30") in pairs
+        assert (end1, "21:00") in pairs
 
     @pytest.mark.asyncio
     async def test_set_value_idempotent_when_unchanged(self):
@@ -249,11 +270,12 @@ class TestLuxtronikTimerScheduleText:
         row_values[end0] = "22:00"
         data = make_coordinator_data(parameters=row_values)
         coord.data = data
-        coord.async_write = AsyncMock(return_value=data)
+        coord.async_write_many = AsyncMock(return_value=data)
 
         entity._handle_coordinator_update(data)
         await entity.async_set_value(entity._attr_native_value)
 
+        coord.async_write_many.assert_not_called()
         coord.async_write.assert_not_called()
 
     @pytest.mark.asyncio
@@ -262,3 +284,4 @@ class TestLuxtronikTimerScheduleText:
         with pytest.raises(ServiceValidationError):
             await entity.async_set_value("not-a-schedule")
         coord.async_write.assert_not_called()
+        coord.async_write_many.assert_not_called()


### PR DESCRIPTION
## 📋 Summary

Implements task I3 from the code-review remediation plan (`docs/superpowers/plans/2026-07-18-code-review-remediation.md`) — two related write-path fixes:

- **Confirm-after-write only logged, never raised.** `LuxtronikCoordinator.async_write` refreshed after a device write and read the value back, but only *logged* it — a rejected or clamped write silently kept the optimistic UI value until the next poll. `async_write`/new `async_write_many` now compare the read-back against what was written (post-datatype-conversion, with round-to-0.1 tolerance for temperature-style values) and raise a translated `HomeAssistantError` on mismatch, so the failure surfaces and the entity re-syncs to the device's actual value.
- **Timer-schedule edits did up to 10 serial full refreshes.** `text.py`'s `LuxtronikTimerScheduleText.async_set_value` called `async_write` once per changed start/end time (up to 10 calls), each triggering a full parameters+calculations+visibilities refresh. It now batches all changed pairs into one `async_write_many` call — one socket flush, one refresh.
- **Follow-up fix from task review:** the initial `async_write_many` unconditionally compared against post-refresh data, but HA core's `async_refresh()` swallows a failed refresh internally rather than raising, leaving `self.data` stale. A stale-refresh scenario would previously misreport a real write as a false `write_confirmation_mismatch`. Added a `last_update_success` check that raises a distinct `write_confirmation_unavailable` error instead, so "write rejected" and "couldn't confirm" are never conflated.

## ⚠️ Known, deliberately deferred gap

`number.py`, `climate.py`, and `water_heater.py` route writes through HA's `Debouncer(immediate=False)`, which swallows exceptions raised inside the debounced callback. This means the new write-confirmation errors don't reach the UI for those three platforms (switch/select/date/text/the `luxtronik2.write` service are unaffected — their entity values still self-correct on the next poll either way). Fixing this needs a consistent error-surfacing design across three platforms, so it's tracked as a new plan task, **I3b**, rather than folded into this branch.

## 🧪 Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `basedpyright` — 0 errors
- [x] Full test suite: 809/809 passing, 100% coverage on `custom_components.luxtronik2` (baseline was 793; +16 new tests)
- [x] New translations (`write_confirmation_mismatch`, `write_confirmation_unavailable`) added to all 5 locale files (en/de/nl/pl/cs)
- [x] Reviewed via implementer → task-review → fix → re-review cycle, then a final whole-branch review — all approved, no Critical/Important findings outstanding

🤖 Generated with [Claude Code](https://claude.com/claude-code)