### PR TITLE
fix(update): remove non-functional install feature flag

### DIFF
--- a/custom_components/luxtronik2/update.py
+++ b/custom_components/luxtronik2/update.py
@@ -70,7 +70,7 @@ class LuxtronikUpdateEntity(  # type: ignore  # pyright: ignore[reportIncompatib
 
     _attr_title = "Luxtronik Firmware Version"
     _attr_supported_features: UpdateEntityFeature = (  # pyright: ignore[reportIncompatibleVariableOverride]
-        UpdateEntityFeature.INSTALL | UpdateEntityFeature.RELEASE_NOTES
+        UpdateEntityFeature.RELEASE_NOTES
     )
     __firmware_version_available = None
     __firmware_version_changelog = None
@@ -163,7 +163,6 @@ class LuxtronikUpdateEntity(  # type: ignore  # pyright: ignore[reportIncompatib
             f"{self.coordinator.manufacturer} {self.coordinator.model} (Download ID {download_id})</a> a firmware update to "
             f'<a href="{download_url}" target="_blank" rel="noreferrer noopener">Firmware Version {self.__firmware_version_available}</a> is available.<br><br>'
             f'<a href="{manual_url}" target="_blank" rel="noreferrer noopener">Firmware Update Instructions</a><br><br>'
-            "The Install button below has no function. It only exists to provide this notification in Home Assistant.<br><br>"
             "Please contact Alpha Innotec support for more information.<br><br>"
             f"Change Log:<br><br>{self.__firmware_version_changelog}<br><br>"
             "Please use Google Translate or similar, if necessary."

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from conftest import make_coordinator_data
+from homeassistant.components.update import UpdateEntityFeature
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT, STATE_UNAVAILABLE
 import pytest
 
@@ -116,6 +117,19 @@ def _make_latest_entity():
         entity
     )
     return entity
+
+
+# ===========================================================================
+# supported_features
+# ===========================================================================
+
+
+def test_supported_features_excludes_install():
+    """INSTALL is unsupported (no async_install implemented); pressing it would
+    raise NotImplementedError. Only RELEASE_NOTES should be advertised."""
+    entity = _make_update_entity()
+    assert entity._attr_supported_features == UpdateEntityFeature.RELEASE_NOTES
+    assert not (entity._attr_supported_features & UpdateEntityFeature.INSTALL)
 
 
 # ===========================================================================
@@ -451,6 +465,7 @@ class TestReleaseNotes:
         assert "V3.91.0" in result
         assert "Bug fixes" in result
         assert "Alpha Innotec" in result
+        assert "Install button" not in result
 
     def test_returns_none_for_unknown_prefix(self):
         entity = _make_update_entity()


### PR DESCRIPTION
## Summary
- `UpdateEntityFeature.INSTALL` was advertised on the firmware update entity but `async_install` was never implemented, so pressing Install in the UI raised `NotImplementedError`. Removed the flag (kept `RELEASE_NOTES` — update notifications still appear).
- Removed the now-stale "The Install button below has no function..." sentence from the release-notes text.
- Task I5 from `docs/superpowers/plans/2026-07-18-code-review-remediation.md`.

## Test plan
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `basedpyright` — 0 errors
- [x] `pytest tests/test_update.py` — 37/37 passed (new `test_supported_features_excludes_install` + updated release-notes assertion)
- [x] Full suite reported by implementer: 819/819 passed, coverage unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)