### PR TITLE
fix(config_flow): drop deprecated OptionsFlowWithConfigEntry base

### DIFF
--- a/custom_components/luxtronik2/config_flow.py
+++ b/custom_components/luxtronik2/config_flow.py
@@ -506,15 +506,17 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> config_entries.OptionsFlow:
         """Get default options flow."""
-        return LuxtronikOptionsFlowHandler(config_entry)
+        return LuxtronikOptionsFlowHandler()
 
 
-class LuxtronikOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
+class LuxtronikOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a Luxtronik options flow."""
 
     def _get_value(self, key: str, default=None):
         """Return a value from Luxtronik."""
-        return self.options.get(key, self.config_entry.data.get(key, default))
+        return self.config_entry.options.get(
+            key, self.config_entry.data.get(key, default)
+        )
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -528,7 +530,7 @@ class LuxtronikOptionsFlowHandler(config_entries.OptionsFlowWithConfigEntry):
         """Handle the user options step."""
         try:
             if user_input is not None:
-                new_options = dict(self.options)
+                new_options = dict(self.config_entry.options)
                 value = user_input.get(CONF_HA_SENSOR_INDOOR_TEMPERATURE)
                 if value:
                     new_options[CONF_HA_SENSOR_INDOOR_TEMPERATURE] = value

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -480,6 +480,9 @@ class TestAsyncStepDhcp:
 class _TestableOptionsFlow(LuxtronikOptionsFlowHandler):
     """Subclass that makes config_entry directly accessible without hass."""
 
+    def __init__(self, config_entry):
+        self._config_entry = config_entry
+
     @property  # type: ignore[override]
     def config_entry(self):
         return self._config_entry
@@ -491,8 +494,7 @@ def _make_options_flow(entry=None):
         entry = MagicMock()
         entry.data = {CONF_HOST: "1.2.3.4", CONF_PORT: 8889}
         entry.options = {}
-    with patch("homeassistant.config_entries.report_usage"):
-        flow = _TestableOptionsFlow(entry)
+    flow = _TestableOptionsFlow(entry)
     return flow
 
 


### PR DESCRIPTION
## Summary
- `LuxtronikOptionsFlowHandler` now subclasses plain `homeassistant.config_entries.OptionsFlow` instead of the deprecated `OptionsFlowWithConfigEntry`, which HA is phasing out.
- `self.config_entry` is auto-populated by core, so the entry-passing constructor and the `self.options` shim are removed in favor of reading `self.config_entry.options` / `self.config_entry.data` directly.
- `async_get_options_flow` now returns `LuxtronikOptionsFlowHandler()` with no constructor arg.
- Updated the `_TestableOptionsFlow` test helper to match the new no-arg base constructor (the `report_usage` patch it existed for is gone too).

Resolves task I2 from `docs/superpowers/plans/2026-07-18-code-review-remediation.md`.

## Test plan
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `basedpyright` 0 errors
- [x] Full test suite: 818 passed, 100% coverage on `custom_components.luxtronik2` (unchanged)
- [x] Existing options-flow tests pass unmodified in behavior/assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)