### PR TITLE
fix(sensor): 🐛 compute status text from coordinator data instead of sibling entity_ids

### DIFF
--- a/custom_components/luxtronik2/sensor.py
+++ b/custom_components/luxtronik2/sensor.py
@@ -4,14 +4,12 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
 
 from homeassistant.components.sensor import (
     ENTITY_ID_FORMAT,  # pyright: ignore[reportAttributeAccessIssue]
     SensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -26,6 +24,7 @@ from .const import (
     LuxCalculation as LC,
     LuxParameter as LP,
     LuxSmartGridStatus,
+    SensorAttrFormat,
     SensorAttrKey as SA,
     SensorKey,
 )
@@ -33,6 +32,7 @@ from .coordinator import LuxtronikCoordinator, LuxtronikCoordinatorData
 from .evu_helper import LuxtronikEVUTracker
 from .model import (
     LuxtronikCopSensorDescription,
+    LuxtronikEntityAttributeDescription,
     LuxtronikIndexSensorDescription,
     LuxtronikSensorDescription,
 )
@@ -278,34 +278,19 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity):
         self._enrich_extra_attributes()
         self.async_write_ha_state()
 
-    def _get_sensor_value(self, sensor_name: str) -> Any:
-        sensor = self.hass.states.get(sensor_name)
-        if sensor is not None:
-            return sensor.state
-        return None
-
-    def _get_sensor_attr(self, sensor_name: str, attr: str) -> Any:
-        sensor = self.hass.states.get(sensor_name)
-        if sensor is not None and attr in sensor.attributes:
-            return sensor.attributes[attr]
-        return None
-
     def _build_status_text(self) -> str:
-        status_time = self._get_sensor_attr(
-            f"sensor.{self._sensor_prefix}_status_time", SA.STATUS_TEXT
-        )
-        line_1_state = self._get_sensor_value(
-            f"sensor.{self._sensor_prefix}_status_line_1"
-        )
-        line_2_state = self._get_sensor_value(
-            f"sensor.{self._sensor_prefix}_status_line_2"
-        )
-        if status_time is None or status_time == STATE_UNAVAILABLE:
+        status_time_raw = self._get_value(LC.C0120_STATUS_TIME)
+        line_1_state = self._get_value(LC.C0117_STATUS_LINE_1)
+        line_2_state = self._get_value(LC.C0118_STATUS_LINE_2)
+        if status_time_raw is None or line_1_state is None or line_2_state is None:
             return ""
-        if line_1_state is None or line_1_state == STATE_UNAVAILABLE:
-            return ""
-        if line_2_state is None or line_2_state == STATE_UNAVAILABLE:
-            return ""
+        status_time = self.formatted_data(
+            LuxtronikEntityAttributeDescription(
+                key=SA.STATUS_TEXT,
+                luxtronik_key=LC.C0120_STATUS_TIME,
+                format=SensorAttrFormat.HOUR_MINUTE,
+            )
+        )
         line_1 = self.platform.platform_data.platform_translations.get(
             f"component.{DOMAIN}.entity.sensor.status_line_1.state.{line_1_state}"
         )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 from conftest import make_coordinator_data
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT, STATE_UNAVAILABLE
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 
 from custom_components.luxtronik2.binary_sensor import LuxtronikBinarySensorEntity
 from custom_components.luxtronik2.const import (
@@ -22,7 +22,6 @@ from custom_components.luxtronik2.const import (
     LuxSmartGridStatus,
     LuxStatus1Option,
     LuxStatus3Option,
-    SensorAttrKey as SA,
     SensorKey,
 )
 from custom_components.luxtronik2.lux_overrides import parameters_to_add_update
@@ -364,48 +363,38 @@ class TestSmartGridStatus:
 # ===========================================================================
 
 
+def _status_text_data(**calc_overrides):
+    calculations = {
+        "ID_WEB_HauptMenuStatus_Zeit": 4980,  # 1h 23m
+        "ID_WEB_HauptMenuStatus_Zeile1": "heatpump_running",
+        "ID_WEB_HauptMenuStatus_Zeile2": "heating",
+    }
+    calculations.update(calc_overrides)
+    return make_coordinator_data(calculations=calculations)
+
+
 class TestBuildStatusText:
     def test_returns_empty_when_status_time_none(self):
-        entity = _make_status_sensor()
-        entity.hass.states.get.return_value = None
+        data = _status_text_data(**{"ID_WEB_HauptMenuStatus_Zeit": None})
+        entity = _make_status_sensor(data)
         result = entity._build_status_text()
         assert result == ""
 
-    def test_returns_empty_when_status_time_unavailable(self):
-        entity = _make_status_sensor()
-        mock_state = MagicMock()
-        mock_state.state = STATE_UNAVAILABLE
-        mock_state.attributes = {SA.STATUS_TEXT: STATE_UNAVAILABLE}
+    def test_returns_empty_when_line1_none(self):
+        data = _status_text_data(**{"ID_WEB_HauptMenuStatus_Zeile1": None})
+        entity = _make_status_sensor(data)
+        result = entity._build_status_text()
+        assert result == ""
 
-        def get_side_effect(sensor_name):
-            if "status_time" in sensor_name:
-                return mock_state
-            return None
-
-        entity.hass.states.get.side_effect = get_side_effect
+    def test_returns_empty_when_line2_none(self):
+        data = _status_text_data(**{"ID_WEB_HauptMenuStatus_Zeile2": None})
+        entity = _make_status_sensor(data)
         result = entity._build_status_text()
         assert result == ""
 
     def test_returns_full_text_when_all_present(self):
-        entity = _make_status_sensor()
-        entity._sensor_prefix = DOMAIN
+        entity = _make_status_sensor(_status_text_data())
         entity._attr_native_value = LuxOperationMode.heating
-
-        def get_side_effect(sensor_name):
-            mock = MagicMock()
-            if "status_time" in sensor_name:
-                mock.state = "01:23"
-                mock.attributes = {SA.STATUS_TEXT: "01:23"}
-                return mock
-            if "status_line_1" in sensor_name:
-                mock.state = "heatpump_running"
-                return mock
-            if "status_line_2" in sensor_name:
-                mock.state = "heating"
-                return mock
-            return None
-
-        entity.hass.states.get.side_effect = get_side_effect
         entity.platform.platform_data.platform_translations = {
             f"component.{DOMAIN}.entity.sensor.status_line_1.state.heatpump_running": "HP Running",
             f"component.{DOMAIN}.entity.sensor.status_line_2.state.heating": "Heating",
@@ -413,85 +402,20 @@ class TestBuildStatusText:
         result = entity._build_status_text()
         assert "HP Running" in result
         assert "Heating" in result
+        assert "1:23" in result
 
-    def test_returns_empty_when_line1_unavailable(self):
-        entity = _make_status_sensor()
-        entity._sensor_prefix = DOMAIN
-
-        def get_side_effect(sensor_name):
-            mock = MagicMock()
-            if "status_time" in sensor_name:
-                mock.state = "01:23"
-                mock.attributes = {SA.STATUS_TEXT: "01:23"}
-                return mock
-            if "status_line_1" in sensor_name:
-                mock.state = STATE_UNAVAILABLE
-                return mock
-            return MagicMock(state="ok")
-
-        entity.hass.states.get.side_effect = get_side_effect
-        result = entity._build_status_text()
-        assert result == ""
-
-    def test_returns_empty_when_line2_unavailable(self):
-        entity = _make_status_sensor()
-        entity._sensor_prefix = DOMAIN
-
-        def get_side_effect(sensor_name):
-            mock = MagicMock()
-            if "status_time" in sensor_name:
-                mock.state = "01:23"
-                mock.attributes = {SA.STATUS_TEXT: "01:23"}
-                return mock
-            if "status_line_1" in sensor_name:
-                mock.state = "heatpump_running"
-                return mock
-            if "status_line_2" in sensor_name:
-                mock.state = STATE_UNAVAILABLE
-                return mock
-            return None
-
-        entity.hass.states.get.side_effect = get_side_effect
-        result = entity._build_status_text()
-        assert result == ""
-
-
-# ===========================================================================
-# StatusSensor._get_sensor_value / _get_sensor_attr
-# ===========================================================================
-
-
-class TestSensorHelpers:
-    def test_get_sensor_value_existing(self):
-        entity = _make_status_sensor()
-        mock_state = MagicMock()
-        mock_state.state = "42"
-        entity.hass.states.get.return_value = mock_state
-        assert entity._get_sensor_value("sensor.test") == "42"
-
-    def test_get_sensor_value_missing(self):
-        entity = _make_status_sensor()
+    def test_reflects_sibling_entity_renames(self):
+        """Status text is unaffected by the sibling sensor entities being renamed."""
+        entity = _make_status_sensor(_status_text_data())
         entity.hass.states.get.return_value = None
-        assert entity._get_sensor_value("sensor.test") is None
-
-    def test_get_sensor_attr_existing(self):
-        entity = _make_status_sensor()
-        mock_state = MagicMock()
-        mock_state.attributes = {"foo": "bar"}
-        entity.hass.states.get.return_value = mock_state
-        assert entity._get_sensor_attr("sensor.test", "foo") == "bar"
-
-    def test_get_sensor_attr_missing_sensor(self):
-        entity = _make_status_sensor()
-        entity.hass.states.get.return_value = None
-        assert entity._get_sensor_attr("sensor.test", "foo") is None
-
-    def test_get_sensor_attr_missing_attr(self):
-        entity = _make_status_sensor()
-        mock_state = MagicMock()
-        mock_state.attributes = {}
-        entity.hass.states.get.return_value = mock_state
-        assert entity._get_sensor_attr("sensor.test", "foo") is None
+        entity.platform.platform_data.platform_translations = {
+            f"component.{DOMAIN}.entity.sensor.status_line_1.state.heatpump_running": "HP Running",
+            f"component.{DOMAIN}.entity.sensor.status_line_2.state.heating": "Heating",
+        }
+        result = entity._build_status_text()
+        assert "HP Running" in result
+        assert "Heating" in result
+        entity.hass.states.get.assert_not_called()
 
 
 # ===========================================================================


### PR DESCRIPTION
## 🐛 Bug fix

- `LuxtronikStatusSensorEntity._build_status_text()` previously built `sensor.{prefix}_status_time` / `_status_line_1` / `_status_line_2` entity_ids and read them via `hass.states.get(...)`. Home Assistant explicitly allows users to rename entities, so after a rename the status text silently broke (returned empty).
- All the underlying data is already available in `coordinator.data` via the same `LuxCalculation` keys (`C0120_STATUS_TIME`, `C0117_STATUS_LINE_1`, `C0118_STATUS_LINE_2`) the sibling sensors use, so the status text is now computed directly from the coordinator, reusing the base class's `formatted_data()` / `SensorAttrFormat.HOUR_MINUTE` for the time formatting to match prior output.
- Removed the now-dead `_get_sensor_value` / `_get_sensor_attr` helpers.

Resolves task I7 from `docs/superpowers/plans/2026-07-18-code-review-remediation.md`.

## Test plan

- [x] `tests/test_sensor.py::TestBuildStatusText` rewritten to exercise coordinator data instead of mocking `hass.states`; added a test asserting `hass.states.get` is never called (regression guard for the rename bug).
- [x] `ruff check` / `ruff format --check` clean
- [x] `basedpyright` — 0 errors
- [x] Full test suite: 819 passed, 100% coverage on `custom_components.luxtronik2`
- [x] `codespell` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)