### PR TITLE
test(coordinator): add real-hass integration test harness (I11)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,55 @@
+"""Repo-root conftest: loads pytest-homeassistant-custom-component explicitly.
+
+The plugin autoloads via a pytest11 entry point on every pytest run once
+installed, but importing it on Windows fails immediately (imports `fcntl`,
+Unix-only) before any test collects. `-p no:homeassistant` in pyproject.toml
+blocks that autoload; this file loads the plugin back explicitly, with
+Windows compatibility shims applied first. pytest only honors
+`pytest_plugins` in the rootdir conftest, so this cannot live in
+tests/conftest.py.
+"""
+
+import sys
+import types
+
+if sys.platform == "win32":
+    if "fcntl" not in sys.modules:
+        fake_fcntl = types.ModuleType("fcntl")
+        fake_fcntl.LOCK_SH = 1
+        fake_fcntl.LOCK_EX = 2
+        fake_fcntl.LOCK_NB = 4
+        fake_fcntl.LOCK_UN = 8
+        fake_fcntl.flock = lambda *args, **kwargs: None
+        fake_fcntl.lockf = lambda *args, **kwargs: None
+        fake_fcntl.fcntl = lambda *args, **kwargs: 0
+        fake_fcntl.ioctl = lambda *args, **kwargs: 0
+        sys.modules["fcntl"] = fake_fcntl
+
+    if "resource" not in sys.modules:
+        fake_resource = types.ModuleType("resource")
+        fake_resource.RLIMIT_NOFILE = 7
+        fake_resource.RLIM_INFINITY = -1
+        fake_resource.getrlimit = lambda *args, **kwargs: (8192, 8192)
+        fake_resource.setrlimit = lambda *args, **kwargs: None
+        sys.modules["resource"] = fake_resource
+
+    import socket as _socket_mod
+
+    _orig_socketpair = _socket_mod.socketpair
+
+    def _shimmed_socketpair(*args, **kwargs):
+        blocked = getattr(_socket_mod.socket, "__module__", "") == "pytest_socket"
+        if not blocked:
+            return _orig_socketpair(*args, **kwargs)
+        import pytest_socket
+
+        pytest_socket.enable_socket()
+        try:
+            return _orig_socketpair(*args, **kwargs)
+        finally:
+            pytest_socket.socket_allow_hosts(["127.0.0.1"])
+            pytest_socket.disable_socket(allow_unix_socket=True)
+
+    _socket_mod.socketpair = _shimmed_socketpair
+
+pytest_plugins = "pytest_homeassistant_custom_component.plugins"

--- a/custom_components/luxtronik2/climate.py
+++ b/custom_components/luxtronik2/climate.py
@@ -347,6 +347,7 @@ class LuxtronikThermostat(LuxtronikEntity[LuxtronikClimateDescription], ClimateE
             immediate=False,
             function=self._async_write_temperature,
         )
+        self.async_on_remove(self._debouncer_set_temp.async_shutdown)
 
         self._pending_temperature: float | None = None
 

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -78,6 +78,7 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         hass: HomeAssistant,
         client: Luxtronik,
         config: Mapping[str, Any],
+        config_entry: ConfigEntry | None = None,
     ) -> None:
         """Initialize Luxtronik Client."""
 
@@ -96,6 +97,7 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
             hass,
             LOGGER,
             name=DOMAIN,
+            config_entry=config_entry,
             update_method=self._async_update_data,
             update_interval=update_interval,
         )
@@ -214,9 +216,19 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
 
     @staticmethod
     async def connect(  # pragma: no cover
-        hass: HomeAssistant, config_entry: ConfigEntry | dict[str, Any]
+        hass: HomeAssistant,
+        config_entry: ConfigEntry | dict[str, Any],
+        entry: ConfigEntry | None = None,
     ) -> LuxtronikCoordinator:
-        """Connect to heatpump."""
+        """Connect to heatpump.
+
+        `config_entry` supplies the connection settings (host/port/etc.) and
+        may be a plain dict (e.g. during config-flow validation, before an
+        entry exists). `entry` is the actual ConfigEntry to tie the resulting
+        coordinator to, when one exists - callers can't rely on `config_entry`
+        for that since it may already be a merged data dict rather than the
+        entry itself (see `connect_and_get_coordinator`).
+        """
         config: dict[Any, Any] | MappingProxyType[str, Any] | None = None
         if isinstance(config_entry, ConfigEntry):
             config = config_entry.data
@@ -247,6 +259,7 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
             hass=hass,
             client=client,
             config=config,
+            config_entry=entry,
         )
 
     def get_device(
@@ -740,8 +753,10 @@ async def connect_and_get_coordinator(
     host: str = config_data.get(CONF_HOST, "")
     port = config_data.get(CONF_PORT, DEFAULT_PORT)
 
+    entry = config if isinstance(config, ConfigEntry) else None
+
     try:  # pragma: no cover
-        coordinator = await LuxtronikCoordinator.connect(hass, config_data)
+        coordinator = await LuxtronikCoordinator.connect(hass, config_data, entry)
         LOGGER.info("Luxtronik connect to device %s:%s successful!", host, port)
 
         if isinstance(config, ConfigEntry):

--- a/custom_components/luxtronik2/number.py
+++ b/custom_components/luxtronik2/number.py
@@ -106,6 +106,7 @@ class LuxtronikNumberEntity(LuxtronikEntity[LuxtronikNumberDescription], NumberE
             immediate=False,
             function=self._async_set_native_value,
         )
+        self.async_on_remove(self._debouncer.async_shutdown)
 
         # Store pending value for debounced write
         self._pending_value: float | None = None

--- a/custom_components/luxtronik2/water_heater.py
+++ b/custom_components/luxtronik2/water_heater.py
@@ -167,6 +167,7 @@ class LuxtronikWaterHeater(  # type: ignore  # pyright: ignore[reportIncompatibl
             immediate=False,
             function=self._async_write_temperature,
         )
+        self.async_on_remove(self._debouncer_set_temp.async_shutdown)
         self._pending_temperature: float | None = None
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,4 @@ ignore-words-list = "hass"
 testpaths = ["tests"]
 pythonpath = ["."]
 asyncio_mode = "auto"
+addopts = ["-p", "no:homeassistant"]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from conftest import make_coordinator_data
 from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
@@ -16,6 +15,7 @@ from homeassistant.const import (
 )
 import pytest
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2.base import LuxtronikEntity
 from custom_components.luxtronik2.const import (
     CONF_HA_SENSOR_PREFIX,

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import replace as dc_replace
 from unittest.mock import MagicMock, patch
 
-from conftest import make_coordinator_data
 from homeassistant.components.climate import (
     PRESET_AWAY,
     PRESET_BOOST,
@@ -17,6 +16,7 @@ from homeassistant.components.climate import (
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 import pytest
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2.climate import (
     HVAC_ACTION_MAPPING_COOL,
     HVAC_ACTION_MAPPING_HEAT,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-from conftest import make_coordinator_data
 import pytest
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2.common import (
     async_get_mac_address,
     convert_to_int_if_possible,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,7 +6,6 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from conftest import make_coordinator_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.exceptions import HomeAssistantError
@@ -14,6 +13,7 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 from packaging.version import Version
 import pytest
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2.const import (
     CONF_UPDATE_INTERVAL,
     DEFAULT_PORT,

--- a/tests/test_cop_sensor.py
+++ b/tests/test_cop_sensor.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from conftest import make_coordinator_data
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2.const import (
     CONF_HA_SENSOR_PREFIX,
     CONF_MAX_DATA_LENGTH,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-from conftest import FakeSensorItem
 from homeassistant.const import CONF_HOST
 import pytest
 
+from conftest import FakeSensorItem
 from custom_components.luxtronik2.const import DEFAULT_PORT
 from custom_components.luxtronik2.diagnostics import _dump_items
 

--- a/tests/test_entity_platforms.py
+++ b/tests/test_entity_platforms.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from datetime import date, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from conftest import make_coordinator_data
 from homeassistant.components.climate import (
     PRESET_AWAY,
     PRESET_BOOST,
@@ -18,6 +17,7 @@ from homeassistant.components.climate import (
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT, UnitOfTemperature
 import pytest
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2.const import (
     CONF_HA_SENSOR_PREFIX,
     CONF_MAX_DATA_LENGTH,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from conftest import make_coordinator_data
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT, Platform as P
 from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
 import pytest
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2 import (
     _async_update_config_entry,
     _fix_select_entity_unique_ids,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from conftest import make_coordinator_data
 from homeassistant.const import Platform
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2.const import (
     DeviceKey,
     LuxParameter,

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from datetime import date
 from unittest.mock import AsyncMock, MagicMock
 
-from conftest import make_coordinator_data
 from homeassistant.components.number import NumberDeviceClass, NumberMode
 from homeassistant.const import (
     CONF_HOST,
@@ -17,6 +16,7 @@ from homeassistant.const import (
 )
 import pytest
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2.const import (
     CONF_HA_SENSOR_PREFIX,
     CONF_MAX_DATA_LENGTH,

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
-from conftest import make_coordinator_data
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 import pytest
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2.const import (
     CONF_HA_SENSOR_PREFIX,
     CONF_MAX_DATA_LENGTH,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
-from conftest import make_coordinator_data
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT, STATE_UNAVAILABLE
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2.binary_sensor import LuxtronikBinarySensorEntity
 from custom_components.luxtronik2.const import (
     CONF_HA_SENSOR_PREFIX,

--- a/tests/test_setup_integration.py
+++ b/tests/test_setup_integration.py
@@ -1,0 +1,267 @@
+"""Harness-based integration tests using a real `hass` (I11).
+
+Unlike the rest of the suite (MagicMock hass + fake sensor containers), these
+tests run against `pytest-homeassistant-custom-component`'s real HomeAssistant
+core so bugs where "HA ignores this attribute" or "a property shadows an
+instance attribute" (the C2/C3/I4 class) are actually caught. Only the socket
+layer is mocked: `custom_components.luxtronik2.coordinator.Luxtronik` is
+replaced with `FakeLuxtronikClient`, which reuses the fake sensor containers
+already defined in `tests/conftest.py`. Everything else - config entries,
+entity registry, platform setup, services - runs for real.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.luxtronik2.const import (
+    CONF_HA_SENSOR_PREFIX,
+    CONFIG_ENTRY_VERSION,
+    DEFAULT_PORT,
+    DOMAIN,
+    SERVICE_WRITE,
+    SensorKey,
+)
+from tests.conftest import (
+    DEFAULT_CALCULATIONS,
+    DEFAULT_PARAMETERS,
+    DEFAULT_VISIBILITIES,
+    FakeSensorGroup,
+)
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+class FakeLuxtronikClient:
+    """Stand-in for `lux_helper.Luxtronik` - the socket layer, and nothing else.
+
+    Constructed with the exact keyword arguments `LuxtronikCoordinator.connect`
+    passes to the real client, so it can be swapped in via a single
+    `monkeypatch.setattr("custom_components.luxtronik2.coordinator.Luxtronik", ...)`.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        socket_timeout: float,
+        max_data_length: int,
+        safe: bool = False,
+        parameters: dict[str, Any] | None = None,
+        calculations: dict[str, Any] | None = None,
+        visibilities: dict[str, Any] | None = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.parameters = FakeSensorGroup(
+            parameters if parameters is not None else DEFAULT_PARAMETERS.copy()
+        )
+        self.calculations = FakeSensorGroup(
+            calculations if calculations is not None else DEFAULT_CALCULATIONS.copy()
+        )
+        self.visibilities = FakeSensorGroup(
+            visibilities if visibilities is not None else DEFAULT_VISIBILITIES.copy()
+        )
+        self.connected = False
+        self.disconnected = False
+        self.fail_read = False
+
+    def connect(self) -> None:
+        self.connected = True
+
+    def read(self) -> None:
+        if self.fail_read:
+            raise OSError("simulated read failure")
+
+    def write(self) -> None:
+        pass
+
+    def disconnect(self) -> None:
+        self.disconnected = True
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, client: FakeLuxtronikClient) -> None:
+    monkeypatch.setattr(
+        "custom_components.luxtronik2.coordinator.Luxtronik",
+        lambda **kwargs: client,
+    )
+
+
+def _make_entry(**data_overrides: Any) -> MockConfigEntry:
+    data = {
+        CONF_HOST: "192.168.1.100",
+        CONF_PORT: DEFAULT_PORT,
+        CONF_HA_SENSOR_PREFIX: DOMAIN,
+    }
+    data.update(data_overrides)
+    return MockConfigEntry(domain=DOMAIN, version=CONFIG_ENTRY_VERSION, data=data)
+
+
+async def test_setup_entry_registers_entities_with_visibility_driven_defaults(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """async_setup_entry loads the entry and registers entities (regression net for C2).
+
+    ID_Visi_SysEin_EVUSperre=0 makes the EVU_UNLOCKED binary sensor invisible on
+    this (fake) heat pump model, so it must land in the registry disabled by
+    default; a sibling entity with no visibility flag (EVU2) must stay enabled.
+    """
+    visibilities = DEFAULT_VISIBILITIES.copy()
+    visibilities["ID_Visi_SysEin_EVUSperre"] = 0
+    client = FakeLuxtronikClient(
+        host="192.168.1.100",
+        port=DEFAULT_PORT,
+        socket_timeout=10,
+        max_data_length=1024,
+        visibilities=visibilities,
+    )
+    _patch_client(monkeypatch, client)
+
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    ent_reg = er.async_get(hass)
+    invisible_entity_id = f"binary_sensor.{DOMAIN}_{SensorKey.EVU_UNLOCKED}"
+    visible_entity_id = f"binary_sensor.{DOMAIN}_{SensorKey.EVU2}"
+
+    invisible_entry = ent_reg.entities.get(invisible_entity_id)
+    visible_entry = ent_reg.entities.get(visible_entity_id)
+    assert invisible_entry is not None
+    assert visible_entry is not None
+
+    assert invisible_entry.unique_id == invisible_entity_id
+    assert visible_entry.unique_id == visible_entity_id
+
+    assert invisible_entry.disabled_by is not None
+    assert visible_entry.disabled_by is None
+
+
+async def test_failed_refresh_makes_entities_unavailable(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed coordinator refresh must surface as unavailable entities (C3-class regression net)."""
+    client = FakeLuxtronikClient(
+        host="192.168.1.100", port=DEFAULT_PORT, socket_timeout=10, max_data_length=1024
+    )
+    _patch_client(monkeypatch, client)
+
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = f"binary_sensor.{DOMAIN}_{SensorKey.EVU2}"
+    assert hass.states.get(entity_id).state != "unavailable"
+
+    client.fail_read = True
+    coordinator = entry.runtime_data
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "unavailable"
+
+
+async def test_number_set_native_value_writes_converted_raw_value(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A number entity's set_value service round-trips to a raw client write (I3/I4 regression net)."""
+    client = FakeLuxtronikClient(
+        host="192.168.1.100", port=DEFAULT_PORT, socket_timeout=10, max_data_length=1024
+    )
+    _patch_client(monkeypatch, client)
+
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = f"number.{DOMAIN}_{SensorKey.DHW_TARGET_TEMPERATURE}"
+    assert hass.states.get(entity_id) is not None
+
+    await hass.services.async_call(
+        "number",
+        "set_value",
+        {"entity_id": entity_id, "value": 55.0},
+        blocking=True,
+    )
+    # The write is debounced (0.5s cooldown, non-immediate) before it reaches
+    # the client - the service call above only schedules it.
+    await asyncio.sleep(0.6)
+    await hass.async_block_till_done()
+
+    assert client.parameters.get("ID_Soll_BWS_akt").value == 55.0
+    assert float(hass.states.get(entity_id).state) == 55.0
+
+
+async def test_unload_disconnects_client_and_unregisters_service(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unloading the only config entry disconnects the client and removes the service."""
+    client = FakeLuxtronikClient(
+        host="192.168.1.100", port=DEFAULT_PORT, socket_timeout=10, max_data_length=1024
+    )
+    _patch_client(monkeypatch, client)
+
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.services.has_service(DOMAIN, SERVICE_WRITE)
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert client.disconnected is True
+    assert not hass.services.has_service(DOMAIN, SERVICE_WRITE)
+
+
+async def test_migration_from_v1_reaches_current_version(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Setting up a v1 entry runs the real async_migrate_entry up to CONFIG_ENTRY_VERSION (I10 regression net).
+
+    Going through `hass.config_entries.async_setup` (rather than calling
+    `async_migrate_entry` directly) matters: HA only allows
+    `async_config_entry_first_refresh` - used by the v1 step's
+    `connect_and_get_coordinator` call - while the entry is in
+    `SETUP_IN_PROGRESS`, which only the real setup flow puts it in.
+    """
+    client = FakeLuxtronikClient(
+        host="192.168.1.100", port=DEFAULT_PORT, socket_timeout=10, max_data_length=1024
+    )
+    _patch_client(monkeypatch, client)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        data={CONF_HOST: "192.168.1.100", CONF_PORT: DEFAULT_PORT},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == CONFIG_ENTRY_VERSION
+    # The v1 step hardcodes the legacy prefix "luxtronik" (not the domain
+    # "luxtronik2"); later steps only fill CONF_HA_SENSOR_PREFIX in if it's
+    # still absent, so a v1 entry keeps "luxtronik" through to the latest
+    # version.
+    assert entry.data[CONF_HA_SENSOR_PREFIX] == "luxtronik"

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from conftest import make_coordinator_data
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 from homeassistant.exceptions import ServiceValidationError
 from luxtronik.parameters import Parameters
 import pytest
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2.const import (
     CONF_HA_SENSOR_PREFIX,
     CONF_MAX_DATA_LENGTH,

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from conftest import make_coordinator_data
 from homeassistant.components.update import UpdateEntityFeature
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT, STATE_UNAVAILABLE
 import pytest
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2.const import (
     CONF_HA_SENSOR_PREFIX,
     CONF_MAX_DATA_LENGTH,

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from conftest import make_coordinator_data
 from homeassistant.components.water_heater import (
     STATE_ELECTRIC,
     STATE_HEAT_PUMP,
@@ -13,6 +12,7 @@ from homeassistant.components.water_heater import (
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT, STATE_OFF
 import pytest
 
+from conftest import make_coordinator_data
 from custom_components.luxtronik2.const import (
     CONF_HA_SENSOR_PREFIX,
     CONF_MAX_DATA_LENGTH,


### PR DESCRIPTION
## Summary
- Implements task **I11** from `docs/superpowers/plans/2026-07-18-code-review-remediation.md`: a thin, harness-based integration-test layer using `pytest-homeassistant-custom-component`'s real `hass` fixture, in addition to (not replacing) the existing MagicMock-based unit suite.
- Adds `tests/test_setup_integration.py` with 5 scenarios: config-entry setup with visibility-driven registry enabled/disabled defaults (C2 regression net), a failed coordinator refresh making entities unavailable (C3-class regression net), a number entity `set_value` round-tripping to a raw client write (I3/I4 regression net), config-entry unload (client disconnect + service unregistration), and the v1→latest migration path (I10 regression net).
- Adds a repo-root `conftest.py` that loads the plugin explicitly (pytest only allows `pytest_plugins` in the rootdir conftest) with Windows-only compatibility shims (`fcntl`/`resource` stubs, a `socket.socketpair` patch) - these are no-ops on Linux/CI.
- Blocks the plugin's default pytest11 autoload via `-p no:homeassistant` in `pyproject.toml`'s `addopts`, since on Windows merely installing the package breaks every plain `pytest` invocation (it imports `homeassistant.runner` → the Unix-only `fcntl` module) before any test collects.
- Fixes `LuxtronikCoordinator` to pass its `ConfigEntry` into `DataUpdateCoordinator` explicitly instead of relying on the `current_entry` ContextVar fallback - the real `hass` fixture surfaced this as a hard `RuntimeError` (Home Assistant already flags the fallback as deprecated, breaking in 2026.8), so this is a genuine forward-compatibility fix, not test-only scaffolding.
- Mechanically reorders imports in the existing test files (`ruff check --fix`): adding the root `conftest.py` makes `conftest` a first-party module, which changes how ruff's isort classifies the pre-existing `from conftest import ...` line in every test file.

## Test plan
- [x] `ruff check custom_components/luxtronik2 tests` - clean
- [x] `ruff format --check custom_components/luxtronik2 tests` - clean
- [x] `basedpyright --pythonpath ... custom_components/luxtronik2` - 0 errors
- [x] `pytest --cov=custom_components.luxtronik2` - 829 passed, 100% coverage, no regression
- [x] Plain `pytest` (no extra flags) confirmed to still pass on Windows after the harness install (per I11's Windows setup notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)