### PR TITLE
fix(entities): remove pointless update_before_add on coordinator entities

### DIFF
--- a/custom_components/luxtronik2/binary_sensor.py
+++ b/custom_components/luxtronik2/binary_sensor.py
@@ -52,8 +52,7 @@ async def async_setup_entry(
                 coordinator.entity_active(description)
                 and key_exists(coordinator.data, description.luxtronik_key)
             )
-        ],
-        True,
+        ]
     )
 
 

--- a/custom_components/luxtronik2/climate.py
+++ b/custom_components/luxtronik2/climate.py
@@ -237,8 +237,7 @@ async def async_setup_entry(
                 coordinator.entity_active(description)
                 and key_exists(coordinator.data, description.luxtronik_key)
             )
-        ],
-        True,
+        ]
     )
 
 

--- a/custom_components/luxtronik2/date.py
+++ b/custom_components/luxtronik2/date.py
@@ -55,8 +55,7 @@ async def async_setup_entry(  # pragma: no cover
                 coordinator.entity_active(description)
                 and key_exists(coordinator.data, description.luxtronik_key)
             )
-        ],
-        True,
+        ]
     )
 
 

--- a/custom_components/luxtronik2/number.py
+++ b/custom_components/luxtronik2/number.py
@@ -67,8 +67,7 @@ async def async_setup_entry(
                 coordinator.entity_active(description)
                 and key_exists(coordinator.data, description.luxtronik_key)
             )
-        ],
-        True,
+        ]
     )
 
 

--- a/custom_components/luxtronik2/select.py
+++ b/custom_components/luxtronik2/select.py
@@ -85,8 +85,7 @@ async def async_setup_entry(
                 coordinator.entity_active(desc)
                 and key_exists(coordinator.data, desc.luxtronik_key)
             )
-        ],
-        True,
+        ]
     )
 
 

--- a/custom_components/luxtronik2/sensor.py
+++ b/custom_components/luxtronik2/sensor.py
@@ -82,8 +82,7 @@ async def async_setup_entry(
                 coordinator.entity_active(description)
                 and key_exists(coordinator.data, description.luxtronik_key)
             )
-        ],
-        True,
+        ]
     )
 
     async_add_entities(
@@ -108,8 +107,7 @@ async def async_setup_entry(
                     )
                 )
             )
-        ],
-        True,
+        ]
     )
 
     async_add_entities(
@@ -119,8 +117,7 @@ async def async_setup_entry(
             )
             for description in SENSORS_INDEX
             if coordinator.entity_active(description)
-        ],
-        True,
+        ]
     )
 
     async_add_entities(
@@ -134,8 +131,7 @@ async def async_setup_entry(
                 and key_exists(coordinator.data, description.numerator_key)
                 and key_exists(coordinator.data, description.denominator_key)
             )
-        ],
-        True,
+        ]
     )
 
 

--- a/custom_components/luxtronik2/switch.py
+++ b/custom_components/luxtronik2/switch.py
@@ -56,8 +56,7 @@ async def async_setup_entry(
                 coordinator.entity_active(description)
                 and key_exists(coordinator.data, description.luxtronik_key)
             )
-        ],
-        True,
+        ]
     )
 
 

--- a/custom_components/luxtronik2/text.py
+++ b/custom_components/luxtronik2/text.py
@@ -49,8 +49,7 @@ async def async_setup_entry(  # pragma: no cover
                     coordinator.data, f"parameters.{description.mode_selector_name}"
                 )
             )
-        ],
-        True,
+        ]
     )
 
 

--- a/custom_components/luxtronik2/update.py
+++ b/custom_components/luxtronik2/update.py
@@ -60,7 +60,7 @@ async def async_setup_entry(
     )
     entities = [update_entity]
 
-    async_add_entities(entities, True)
+    async_add_entities(entities)
 
 
 class LuxtronikUpdateEntity(  # type: ignore  # pyright: ignore[reportIncompatibleVariableOverride]

--- a/custom_components/luxtronik2/water_heater.py
+++ b/custom_components/luxtronik2/water_heater.py
@@ -122,8 +122,7 @@ async def async_setup_entry(
                 coordinator.entity_active(description)
                 and key_exists(coordinator.data, description.luxtronik_key)
             )
-        ],
-        True,
+        ]
     )
 
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -220,7 +220,7 @@ class TestClimateUnavailableKeys:
             patch("custom_components.luxtronik2.climate.LOGGER") as mock_logger,
         ):
             await async_setup_entry(
-                MagicMock(), entry, lambda entities, update: added.extend(entities)
+                MagicMock(), entry, lambda entities: added.extend(entities)
             )
             mock_logger.debug.assert_called()
 
@@ -239,7 +239,7 @@ class TestClimateUnavailableKeys:
             "custom_components.luxtronik2.climate.key_exists", return_value=True
         ):
             await async_setup_entry(
-                MagicMock(), entry, lambda entities, update: added.extend(entities)
+                MagicMock(), entry, lambda entities: added.extend(entities)
             )
         assert len(added) == len(THERMOSTATS_SMART)
 

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -128,7 +128,7 @@ class TestWaterHeaterUnavailableKeys:
             patch("custom_components.luxtronik2.water_heater.LOGGER") as mock_logger,
         ):
             await async_setup_entry(
-                MagicMock(), entry, lambda entities, update: added.extend(entities)
+                MagicMock(), entry, lambda entities: added.extend(entities)
             )
             mock_logger.debug.assert_called()
 


### PR DESCRIPTION
## Summary
- Task M4 from the code-review remediation plan: `async_add_entities([...], True)` in every platform's `async_setup_entry` was requesting a per-entity `async_update()` call right after registration, even though every entity here is a `CoordinatorEntity` subclass whose state comes from the shared coordinator poll — the extra call is a no-op wasted refresh.
- Dropped the trailing `True` (`update_before_add`) argument in all 10 platforms: `binary_sensor.py`, `climate.py`, `date.py`, `number.py`, `select.py`, `sensor.py` (4 call sites), `switch.py`, `text.py`, `update.py`, `water_heater.py`.
- Updated `test_climate.py` and `test_water_heater.py` fake `async_add_entities` callbacks to the new single-arg signature.

## Test plan
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `basedpyright` 0 errors
- [x] Full test suite: 824 passed, 100% coverage on `custom_components.luxtronik2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)