### PR TITLE
fix(entities): remove redundant async_write_ha_state before super() call

### DIFF
--- a/custom_components/luxtronik2/climate.py
+++ b/custom_components/luxtronik2/climate.py
@@ -391,7 +391,6 @@ class LuxtronikThermostat(LuxtronikEntity[LuxtronikClimateDescription], ClimateE
         if key_tar != LuxParameter.UNSET:
             self._attr_target_temperature = get_sensor_data(data, key_tar)
 
-        self.async_write_ha_state()
         super()._handle_coordinator_update()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:

--- a/custom_components/luxtronik2/date.py
+++ b/custom_components/luxtronik2/date.py
@@ -102,7 +102,6 @@ class LuxtronikDateEntity(LuxtronikEntity[LuxtronikDateEntityDescription], DateE
         else:
             self._attr_native_value = None
 
-        self.async_write_ha_state()
         super()._handle_coordinator_update()
 
     async def async_set_value(self, value: date) -> None:

--- a/custom_components/luxtronik2/number.py
+++ b/custom_components/luxtronik2/number.py
@@ -136,7 +136,6 @@ class LuxtronikNumberEntity(LuxtronikEntity[LuxtronikNumberDescription], NumberE
         else:
             self._attr_native_value = value
 
-        self.async_write_ha_state()
         super()._handle_coordinator_update()
 
     async def async_set_native_value(self, value: float) -> None:

--- a/custom_components/luxtronik2/sensor.py
+++ b/custom_components/luxtronik2/sensor.py
@@ -206,7 +206,6 @@ class LuxtronikSensorEntity(LuxtronikEntity[LuxtronikSensorDescription], SensorE
         else:
             self._attr_native_value = value
 
-        self.async_write_ha_state()
         super()._handle_coordinator_update()
 
 

--- a/custom_components/luxtronik2/text.py
+++ b/custom_components/luxtronik2/text.py
@@ -137,7 +137,6 @@ class LuxtronikTimerScheduleText(
             pairs.append(f"{start}-{end}")
         self._attr_native_value = "/".join(pairs)
 
-        self.async_write_ha_state()
         super()._handle_coordinator_update()
 
     async def async_set_value(self, value: str) -> None:

--- a/custom_components/luxtronik2/water_heater.py
+++ b/custom_components/luxtronik2/water_heater.py
@@ -219,7 +219,6 @@ class LuxtronikWaterHeater(  # type: ignore  # pyright: ignore[reportIncompatibl
             data, descr.luxtronik_key_target_temperature.value
         )
 
-        self.async_write_ha_state()
         super()._handle_coordinator_update()
 
     async def _async_set_lux_mode(self, lux_mode: str) -> None:


### PR DESCRIPTION
## Summary
- `LuxtronikEntity._handle_coordinator_update` (base.py) already ends with `self.async_write_ha_state()`
- Six platform overrides (`sensor.py`, `number.py`, `date.py`, `climate.py`, `text.py`, `water_heater.py`) called `self.async_write_ha_state()` explicitly right before calling `super()._handle_coordinator_update()`, so HA state was written twice on every coordinator poll
- Removes the redundant manual call in each; the single `super()` call now does the one write

Resolves task M3 of the code-review remediation plan.

## Test plan
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `basedpyright` — 0 errors
- [x] `pytest --cov=custom_components.luxtronik2` — 829 passed, 100% coverage (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)