### PR TITLE
fix: 🐛 remove private platform_translations HA API usage

### DIFF
--- a/custom_components/luxtronik2/base.py
+++ b/custom_components/luxtronik2/base.py
@@ -90,7 +90,6 @@ class LuxtronikEntity[DescriptionT: LuxtronikEntityDescription](  # type: ignore
         # --- everything below uses the FINAL description ---
         self._attr_translation_key = description.translation_key
         self._attr_cache = {}
-        self._device_info_ident = device_info_ident
         self._attr_device_info = coordinator.get_device(device_info_ident)
 
         self._attr_extra_state_attributes = {
@@ -117,10 +116,6 @@ class LuxtronikEntity[DescriptionT: LuxtronikEntityDescription](  # type: ignore
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
-        # Force device name:
-        self._attr_device_info = self.coordinator.get_device(
-            self._device_info_ident, self.platform
-        )
 
         try:
             last_state = await self.async_get_last_state()

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -16,7 +16,6 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from packaging.version import InvalidVersion, Version
 
@@ -265,57 +264,43 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
     def get_device(
         self,
         key: DeviceKey = DeviceKey.heatpump,
-        platform: EntityPlatform | None = None,
     ) -> DeviceInfo:
         if key not in self.device_infos:
-            self._create_device_infos(self.hass, self._config, platform)
+            self._create_device_infos(self.hass, self._config)
         device_info = self.device_infos.get(key)
         if device_info is None:
             return DeviceInfo(
                 identifiers={(DOMAIN, f"{self.unique_id}_{key.value}".lower())}
             )
-        if device_info.get("name") == key:
-            device_info["name"] = self._build_device_name(key, platform)
         return device_info
 
     def _create_device_infos(
         self,
         hass: HomeAssistant,
         config: Mapping[str, Any],
-        platform: EntityPlatform | None = None,
     ):
         host = config[CONF_HOST]
         self.device_infos[DeviceKey.heatpump] = self._build_device_info(
-            DeviceKey.heatpump, host, platform
+            DeviceKey.heatpump, host
         )
         via = (
             DOMAIN,
             f"{self.unique_id}_{DeviceKey.heatpump}".lower(),
         )
         self.device_infos[DeviceKey.heating] = self._build_device_info(
-            DeviceKey.heating, host, platform, via
+            DeviceKey.heating, host, via
         )
         self.device_infos[DeviceKey.domestic_water] = self._build_device_info(
-            DeviceKey.domestic_water, host, platform, via
+            DeviceKey.domestic_water, host, via
         )
         self.device_infos[DeviceKey.cooling] = self._build_device_info(
-            DeviceKey.cooling, host, platform, via
+            DeviceKey.cooling, host, via
         )
-
-    def _build_device_name(
-        self, key: DeviceKey, platform: EntityPlatform | None = None
-    ) -> str:
-        if platform is None:
-            return str(key.value)
-        return platform.platform_data.platform_translations.get(
-            f"component.{DOMAIN}.entity.device.{key.value}.name"
-        ) or str(key.value)
 
     def _build_device_info(
         self,
         key: DeviceKey,
         host: str,
-        platform: EntityPlatform | None = None,
         via_device: tuple[str, str] | None = None,
     ) -> DeviceInfo:
         device_info = DeviceInfo(
@@ -326,7 +311,8 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
                 )
             },
             entry_type=None,
-            name=self._build_device_name(key, platform),
+            name=str(key.value),
+            translation_key=key.value,
             configuration_url=f"http://{host}/",
             connections={
                 (

--- a/custom_components/luxtronik2/sensor.py
+++ b/custom_components/luxtronik2/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.translation import async_get_cached_translations
 
 from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
@@ -286,6 +287,11 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity):
             return sensor.attributes[attr]
         return None
 
+    def _get_entity_translations(self) -> dict[str, str]:
+        return async_get_cached_translations(
+            self.hass, self.hass.config.language, "entity", DOMAIN
+        )
+
     def _build_status_text(self) -> str:
         status_time = self._get_sensor_attr(
             f"sensor.{self._sensor_prefix}_status_time", SA.STATUS_TEXT
@@ -302,10 +308,11 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity):
             return ""
         if line_2_state is None or line_2_state == STATE_UNAVAILABLE:
             return ""
-        line_1 = self.platform.platform_data.platform_translations.get(
+        translations = self._get_entity_translations()
+        line_1 = translations.get(
             f"component.{DOMAIN}.entity.sensor.status_line_1.state.{line_1_state}"
         )
-        line_2 = self.platform.platform_data.platform_translations.get(
+        line_2 = translations.get(
             f"component.{DOMAIN}.entity.sensor.status_line_2.state.{line_2_state}"
         )
         # Show evu end time if available

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1248,14 +1248,20 @@ class TestCoordinatorGetDeviceFallback:
         result = LuxtronikCoordinator.get_device(coord, DeviceKey.heatpump)
         assert "identifiers" in result
 
-    def test_build_device_name_with_platform(self):
-        coord = MagicMock()
-        platform = MagicMock()
-        platform.platform_data.platform_translations.get.return_value = "My Heatpump"
-        result = LuxtronikCoordinator._build_device_name(
-            coord, DeviceKey.heatpump, platform
+    def test_build_device_info_sets_translation_key(self):
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_SoftStand": "V3.90.1",
+                "ID_WEB_Code_WP_akt": "LWP 10",
+            },
+            parameters={
+                "ID_WP_SerienNummer_DATUM": 20230101,
+                "ID_WP_SerienNummer_HEX": 255,
+            },
         )
-        assert result == "My Heatpump"
+        device_info = coord._build_device_info(DeviceKey.heatpump, "192.168.1.1")
+        assert device_info["translation_key"] == DeviceKey.heatpump.value
+        assert device_info["name"] == DeviceKey.heatpump.value
 
 
 # ===========================================================================

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT, STATE_UNAVAILABLE
 
@@ -175,8 +175,7 @@ def _make_status_sensor(data=None, description=None):
         hass, entry, coord, description, DeviceKey.heatpump
     )
     _patch_entity(entity)
-    entity.platform = MagicMock()
-    entity.platform.platform_data.platform_translations = {}
+    entity._get_entity_translations = MagicMock(return_value={})
     return entity
 
 
@@ -406,13 +405,31 @@ class TestBuildStatusText:
             return None
 
         entity.hass.states.get.side_effect = get_side_effect
-        entity.platform.platform_data.platform_translations = {
+        entity._get_entity_translations.return_value = {
             f"component.{DOMAIN}.entity.sensor.status_line_1.state.heatpump_running": "HP Running",
             f"component.{DOMAIN}.entity.sensor.status_line_2.state.heating": "Heating",
         }
         result = entity._build_status_text()
         assert "HP Running" in result
         assert "Heating" in result
+
+    def test_get_entity_translations_uses_public_helper(self):
+        """_get_entity_translations must use the public translation helper, not
+        the private platform.platform_data.platform_translations attribute."""
+        entity = _make_status_sensor()
+        entity._get_entity_translations = (
+            LuxtronikStatusSensorEntity._get_entity_translations.__get__(entity)
+        )
+        entity.hass.config.language = "en"
+        with patch(
+            "custom_components.luxtronik2.sensor.async_get_cached_translations"
+        ) as mock_get_translations:
+            mock_get_translations.return_value = {"some.key": "value"}
+            result = entity._get_entity_translations()
+        mock_get_translations.assert_called_once_with(
+            entity.hass, "en", "entity", DOMAIN
+        )
+        assert result == {"some.key": "value"}
 
     def test_returns_empty_when_line1_unavailable(self):
         entity = _make_status_sensor()


### PR DESCRIPTION
## Summary
- Removes all use of the internal `platform.platform_data.platform_translations` attribute (flagged as M6 in the code review remediation plan), which is not part of Home Assistant's public API and could break without warning on any core release.
- Device names (`coordinator.py`) now use `DeviceInfo.translation_key`, resolved by HA core's own `device_registry.async_get_or_create` — no manual lookup needed.
- Status-line text (`sensor.py`) now goes through a small `_get_entity_translations()` helper backed by the public `homeassistant.helpers.translation.async_get_cached_translations`.
- Drops the now-unneeded second `get_device(self.platform)` call in `base.py`'s `async_added_to_hass` and the dead `_device_info_ident` attribute it depended on.
- No translation file changes needed — the existing `translations/*.json` key structure (`entity.device.<key>.name`, `entity.sensor.status_line_1.state.<value>`) already matches what the public APIs expect.

## Test plan
- [x] Updated/added unit tests (TDD): `_build_device_info` sets `translation_key`; `_get_entity_translations` calls the public helper with correct args (regression guard against reintroducing the private API).
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `basedpyright` 0 errors
- [x] Full test suite: 830 passed, 100% coverage on `custom_components.luxtronik2` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)