### PR TITLE
fix(climate): guard hvac/preset mode mapping against unknown values

### DIFF
--- a/custom_components/luxtronik2/climate.py
+++ b/custom_components/luxtronik2/climate.py
@@ -217,11 +217,11 @@ async def async_setup_entry(
         is_smart_thermostat,
     )
 
-    THERMOSTATS = THERMOSTATS_SMART if is_smart_thermostat else THERMOSTATS_OTHER
+    thermostats = THERMOSTATS_SMART if is_smart_thermostat else THERMOSTATS_OTHER
 
     unavailable_keys = [
         i.luxtronik_key
-        for i in THERMOSTATS
+        for i in thermostats
         if not key_exists(coordinator.data, i.luxtronik_key)
     ]
     if unavailable_keys:
@@ -232,7 +232,7 @@ async def async_setup_entry(
     async_add_entities(
         [
             LuxtronikThermostat(hass, entry, coordinator, description)
-            for description in THERMOSTATS
+            for description in thermostats
             if (
                 coordinator.entity_active(description)
                 and key_exists(coordinator.data, description.luxtronik_key)
@@ -360,10 +360,19 @@ class LuxtronikThermostat(LuxtronikEntity[LuxtronikClimateDescription], ClimateE
             return
 
         mode = get_sensor_data(data, self.entity_description.luxtronik_key.value)
-        self._attr_hvac_mode = (
-            None if mode is None else self.entity_description.hvac_mode_mapping[mode]
-        )
-        self._attr_preset_mode = None if mode is None else HVAC_PRESET_MAPPING[mode]
+        if mode is None:
+            self._attr_hvac_mode = None
+            self._attr_preset_mode = None
+        else:
+            hvac_mode = self.entity_description.hvac_mode_mapping.get(mode)
+            if hvac_mode is None:
+                LOGGER.warning("Unknown hvac mode %s, unable to map", mode)
+            self._attr_hvac_mode = hvac_mode
+
+            preset_mode = HVAC_PRESET_MAPPING.get(mode)
+            if preset_mode is None:
+                LOGGER.warning("Unknown preset mode %s, unable to map", mode)
+            self._attr_preset_mode = preset_mode
         self._attr_current_lux_operation = lux_action = get_sensor_data(
             data, self.entity_description.luxtronik_key_current_action.value
         )

--- a/docs/superpowers/plans/2026-07-18-code-review-remediation.md
+++ b/docs/superpowers/plans/2026-07-18-code-review-remediation.md
@@ -304,6 +304,6 @@ Mark tasks here as they land (edit this file in the same PR as the fix):
 
 - [x] C1  - [x] C2  - [x] C3
 - [ ] I1  - [x] I2  - [x] I3  - [ ] I3b  - [ ] I4  - [x] I5  - [x] I6  - [x] I7  - [ ] I8  - [ ] I9  - [ ] I10  - [x] I11
-- [ ] M1  - [ ] M2  - [x] M3  - [x] M4  - [ ] M5  - [x] M6  - [ ] M7  - [ ] M8  - [ ] M9  - [ ] M10  - [ ] M11  - [ ] M12
+- [ ] M1  - [ ] M2  - [x] M3  - [x] M4  - [ ] M5  - [x] M6  - [x] M7  - [ ] M8  - [ ] M9  - [ ] M10  - [ ] M11  - [ ] M12
 
 Recovery note (2026-07-18): this file was found deleted mid-session with no git history (it was never committed) and was reconstructed from the content captured earlier in the same conversation. If you're reading this and something looks off versus the actual code state, re-verify line numbers/snippets against the current `main` rather than trusting this doc blindly — several tasks (I11, M3, M4) landed after the original review and their line refs above are stale by design (see the note at the top of this section).

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -326,3 +326,58 @@ class TestClimateTemperatureKeyBranches:
         thermostat._handle_coordinator_update(data)
         thermostat.hass.states.get.assert_called_with("sensor.living_room_temp")
         assert thermostat._attr_current_temperature == 21.5
+
+
+# ===========================================================================
+# climate.py — unmapped mode value (M7 regression)
+# ===========================================================================
+
+
+class TestClimateUnmappedMode:
+    def test_missing_mode_sets_hvac_and_preset_none(self):
+        """No mode reported (e.g. key absent) clears both hvac and preset mode."""
+        coord = _mock_coordinator()
+        entry = _mock_entry()
+        hass = MagicMock()
+
+        thermostat = LuxtronikThermostat(hass, entry, coord, THERMOSTATS[0])
+        _patch_entity(thermostat)
+        data = make_coordinator_data(
+            parameters={},
+            calculations={"ID_WEB_WP_BZ_akt": LuxOperationMode.heating},
+        )
+        thermostat._handle_coordinator_update(data)
+        assert thermostat._attr_hvac_mode is None
+        assert thermostat._attr_preset_mode is None
+
+    def test_unmapped_mode_does_not_raise(self):
+        """An unexpected mode value must not raise KeyError from the coordinator listener."""
+        coord = _mock_coordinator()
+        entry = _mock_entry()
+        hass = MagicMock()
+
+        thermostat = LuxtronikThermostat(hass, entry, coord, THERMOSTATS[0])
+        _patch_entity(thermostat)
+        data = make_coordinator_data(
+            parameters={"ID_Ba_Hz_akt": "unexpected_mode"},
+            calculations={"ID_WEB_WP_BZ_akt": LuxOperationMode.heating},
+        )
+        thermostat._handle_coordinator_update(data)
+        assert thermostat._attr_hvac_mode is None
+        assert thermostat._attr_preset_mode is None
+
+    def test_mapped_mode_still_works(self):
+        """Known modes keep resolving to their mapped hvac/preset mode."""
+        coord = _mock_coordinator()
+        entry = _mock_entry()
+        hass = MagicMock()
+
+        thermostat = LuxtronikThermostat(hass, entry, coord, THERMOSTATS[0])
+        _patch_entity(thermostat)
+        data = make_coordinator_data(
+            parameters={"ID_Ba_Hz_akt": LuxMode.party},
+            calculations={"ID_WEB_WP_BZ_akt": LuxOperationMode.heating},
+        )
+        thermostat._handle_coordinator_update(data)
+        assert thermostat._attr_hvac_mode == HVAC_MODE_MAPPING_HEAT[LuxMode.party]
+        assert thermostat._attr_preset_mode == HVAC_PRESET_MAPPING[LuxMode.party]


### PR DESCRIPTION
## Summary
- `LuxtronikThermostat._handle_coordinator_update` looked up `hvac_mode_mapping[mode]` and `HVAC_PRESET_MAPPING[mode]` with plain dict indexing, so an unexpected mode string reported by the device raised `KeyError` inside the coordinator listener instead of degrading gracefully.
- The local `THERMOSTATS = THERMOSTATS_SMART if is_smart_thermostat else THERMOSTATS_OTHER` in `async_setup_entry` shadowed the module-level `THERMOSTATS` constant, which was confusing to read even though it wasn't causing a functional bug.

## Changes
- Use `.get(mode)` for both mappings, logging a warning and falling back to `None` on an unknown mode instead of crashing.
- Rename the local variable to `thermostats` so it no longer shadows the module constant.
- Add regression tests (`TestClimateUnmappedMode`) covering missing mode, unmapped mode, and the known-mode happy path.

This resolves task **M7** from `docs/superpowers/plans/2026-07-18-code-review-remediation.md`.

## Test plan
- [x] `pytest tests/test_climate.py -q` (30 passed)
- [x] `pytest --cov=custom_components.luxtronik2 -q` (828 passed, 100% coverage, no regression)
- [x] `ruff check` / `ruff format --check` clean
- [x] `basedpyright` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)