### PR TITLE
chore(model): remove dead code flagged in code review (M1)

### DIFF
--- a/custom_components/luxtronik2/base.py
+++ b/custom_components/luxtronik2/base.py
@@ -19,7 +19,6 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
-from homeassistant.util.dt import utcnow
 
 from .common import get_sensor_data
 from .const import (
@@ -49,7 +48,6 @@ class LuxtronikEntity[DescriptionT: LuxtronikEntityDescription](  # type: ignore
     """Luxtronik base device."""
 
     entity_description: DescriptionT
-    next_update: datetime | None = None
     _attr_state: Any = None  # Any: values come from luxtronik library (untyped)
 
     _entity_component_unrecorded_attributes = frozenset(
@@ -160,12 +158,6 @@ class LuxtronikEntity[DescriptionT: LuxtronikEntityDescription](  # type: ignore
 
     def _restore_attr_value(self, value: Any | None) -> Any:
         return value
-
-    def should_update(self) -> bool:
-        """Determine if the entity should update based on next_update."""
-        if self.entity_description.update_interval is None:
-            return True
-        return self.next_update is None or self.next_update <= utcnow()
 
     async def _data_update(self, event):
         self._handle_coordinator_update()

--- a/custom_components/luxtronik2/binary_sensor.py
+++ b/custom_components/luxtronik2/binary_sensor.py
@@ -87,9 +87,6 @@ class LuxtronikBinarySensorEntity(  # type: ignore  # pyright: ignore[reportInco
         self, data: LuxtronikCoordinatorData | None = None
     ) -> None:
         """Handle updated data from the coordinator."""
-        # if not self.should_update():
-        #    return
-
         data = self.coordinator.data if data is None else data
         if data is None:
             return

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -85,7 +85,6 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         self.client = client
         self._config = config
         self.device_infos = dict[str, DeviceInfo]()
-        self.update_reason_write = False
 
         update_interval: timedelta = DEFAULT_UPDATE_INTERVAL
         raw = config.get(CONF_UPDATE_INTERVAL)

--- a/custom_components/luxtronik2/model.py
+++ b/custom_components/luxtronik2/model.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from decimal import Decimal
 
 from homeassistant.components.binary_sensor import BinarySensorEntityDescription
@@ -31,7 +31,6 @@ from luxtronik import Calculations, Parameters, Visibilities
 from packaging.version import Version
 
 from .const import (
-    UPDATE_INTERVAL_VERY_SLOW,
     DeviceKey,
     # FirmwareVersionMinor,
     LuxCalculation,
@@ -70,10 +69,6 @@ class LuxtronikEntityDescription(EntityDescription, frozen_or_thawed=True):
 
     has_entity_name: bool = True
 
-    # Bug in python: Have to assign a value:
-    platform = Platform.AIR_QUALITY
-
-    update_interval: timedelta | None = None
     icon_by_state: dict[StateType | date | datetime | Decimal, str] | None = None
     device_key: DeviceKey = DeviceKey.heatpump
     luxtronik_key: LuxParameter | LuxCalculation = LuxParameter.UNSET
@@ -143,7 +138,6 @@ class LuxtronikNumberDescription(
     """Class describing Luxtronik number sensor entities."""
 
     platform = Platform.NUMBER
-    update_interval: timedelta | None = UPDATE_INTERVAL_VERY_SLOW
     factor: float | None = None
     native_precision: int | None = None
     mode: NumberMode = NumberMode.AUTO
@@ -174,7 +168,6 @@ class LuxtronikSwitchDescription(
     """Class describing Luxtronik switch entities."""
 
     platform = Platform.SWITCH
-    update_interval: timedelta = UPDATE_INTERVAL_VERY_SLOW
     on_state: str | bool = True
     on_states: list[str] | None = None
     off_state: str | bool = False
@@ -203,16 +196,6 @@ class LuxtronikClimateDescription(
     min_temp: float | None = None
     max_temp: float | None = None
     temperature_unit: str = UnitOfTemperature.CELSIUS
-
-
-def metaclass_resolver(*classes):
-    metaclass = tuple(set(type(cls) for cls in classes))
-    metaclass = (
-        metaclass[0]
-        if len(metaclass) == 1
-        else type("_".join(mcls.__name__ for mcls in metaclass), metaclass, {})
-    )  # class M_C
-    return metaclass("_".join(cls.__name__ for cls in classes), classes, {})
 
 
 class LuxtronikWaterHeaterDescription(

--- a/custom_components/luxtronik2/number.py
+++ b/custom_components/luxtronik2/number.py
@@ -115,9 +115,6 @@ class LuxtronikNumberEntity(LuxtronikEntity[LuxtronikNumberDescription], NumberE
         self, data: LuxtronikCoordinatorData | None = None
     ) -> None:
         """Handle updated data from the coordinator."""
-        # if not self.should_update():
-        #    return
-
         data = self.coordinator.data if data is None else data
         if data is None:
             return

--- a/custom_components/luxtronik2/number_entities_predefined.py
+++ b/custom_components/luxtronik2/number_entities_predefined.py
@@ -191,7 +191,6 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         native_max_value=5.0,
         native_step=0.5,
         mode=NumberMode.BOX,
-        update_interval=None,
     ),
     LuxtronikNumberDescription(
         key=SensorKey.PUMP_OPTIMIZATION_TIME,
@@ -495,7 +494,6 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         native_max_value=65.0,
         native_step=0.5,
         max_firmware_version=Version("3.90.0"),
-        update_interval=None,
     ),
     # Bug #280 since firmware 3.90.1 different set point
     LuxtronikNumberDescription(
@@ -509,7 +507,6 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         native_max_value=65.0,
         native_step=0.5,
         min_firmware_version=Version("3.90.1"),
-        update_interval=None,
     ),
     LuxtronikNumberDescription(
         key=SensorKey.DHW_HYSTERESIS,

--- a/custom_components/luxtronik2/select.py
+++ b/custom_components/luxtronik2/select.py
@@ -203,21 +203,6 @@ class LuxtronikThermalDesinfectionDaySelector(  # type: ignore  # pyright: ignor
                 )
                 self._handle_coordinator_update(updated_data)
 
-    async def async_update(self) -> None:
-        """Read current day from heat pump and update selected option."""
-        data = self.coordinator.data
-        if data is None:
-            return
-
-        selected_day = "none"
-        for day, param_enum in DAY_NAME_TO_PARAM.items():
-            param = param_enum.value
-            if str(get_sensor_data(data, param)) == "1":
-                selected_day = day
-                break
-
-        self._attr_current_option = selected_day
-
 
 class LuxtronikModeSelector(
     LuxtronikEntity[LuxtronikSelectEntityDescription], SelectEntity

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -15,9 +15,6 @@ from homeassistant.const import (
 
 from .const import (
     SECOND_TO_HOUR_FACTOR,
-    UPDATE_INTERVAL_NORMAL,
-    UPDATE_INTERVAL_SLOW,
-    UPDATE_INTERVAL_VERY_SLOW,
     DeviceKey,
     LuxCalculation as LC,
     LuxOperationMode,
@@ -54,14 +51,12 @@ SENSORS_STATUS: list[descr] = [
             attr(SA.EVU_DAYS, LC.UNSET, None, True),
         ),
         options=[e.value for e in LuxOperationMode],
-        update_interval=UPDATE_INTERVAL_NORMAL,
     ),
     descr(
         key=SensorKey.SMART_GRID_STATUS,
         luxtronik_key=LC.UNSET,  # Calculated from EVU and EVU2 inputs
         device_class=SensorDeviceClass.ENUM,
         options=[e.value for e in LuxSmartGridStatus],
-        update_interval=UPDATE_INTERVAL_NORMAL,
     ),
 ]
 
@@ -136,7 +131,6 @@ SENSORS: list[descr] = [
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         entity_registry_enabled_default=False,
-        update_interval=UPDATE_INTERVAL_NORMAL,
     ),
     descr(
         key=SensorKey.OUTDOOR_TEMPERATURE,
@@ -144,7 +138,6 @@ SENSORS: list[descr] = [
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        update_interval=UPDATE_INTERVAL_SLOW,
     ),
     descr(
         key=SensorKey.OUTDOOR_TEMPERATURE_AVERAGE,
@@ -153,7 +146,6 @@ SENSORS: list[descr] = [
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         entity_registry_enabled_default=False,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.COMPRESSOR1_IMPULSES,
@@ -173,7 +165,6 @@ SENSORS: list[descr] = [
         visibility=LV.V0080_COMPRESSOR1_OPERATION_HOURS,
         factor=SECOND_TO_HOUR_FACTOR,
         native_precision=2,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.COMPRESSOR2_IMPULSES,
@@ -193,7 +184,6 @@ SENSORS: list[descr] = [
         visibility=LV.V0083_COMPRESSOR2_OPERATION_HOURS,
         factor=SECOND_TO_HOUR_FACTOR,
         native_precision=2,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.OPERATION_HOURS,
@@ -203,7 +193,6 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfTime.HOURS,
         factor=SECOND_TO_HOUR_FACTOR,
         native_precision=2,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.HEAT_AMOUNT_COUNTER,
@@ -213,7 +202,6 @@ SENSORS: list[descr] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         native_precision=1,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.HEAT_AMOUNT_FLOW_RATE,
@@ -223,7 +211,6 @@ SENSORS: list[descr] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfVolumeFlowRateExt.LITER_PER_HOUR,
         native_precision=1,
-        update_interval=UPDATE_INTERVAL_NORMAL,
     ),
     descr(
         key=SensorKey.HEAT_SOURCE_FLOW_RATE,
@@ -233,7 +220,6 @@ SENSORS: list[descr] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfVolumeFlowRateExt.LITER_PER_HOUR,
         native_precision=1,
-        update_interval=UPDATE_INTERVAL_NORMAL,
     ),
     descr(
         key=SensorKey.HOT_GAS_TEMPERATURE,
@@ -308,7 +294,6 @@ SENSORS: list[descr] = [
         visibility=LV.V0086_ADDITIONAL_HEAT_GENERATOR_OPERATION_HOURS,
         factor=SECOND_TO_HOUR_FACTOR,
         native_precision=2,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.ADDITIONAL_HEAT_GENERATOR2_OPERATION_HOURS,
@@ -319,7 +304,6 @@ SENSORS: list[descr] = [
         visibility=LV.V0087_ADDITIONAL_HEAT_GENERATOR2_OPERATION_HOURS,
         factor=SECOND_TO_HOUR_FACTOR,
         native_precision=2,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER,
@@ -332,7 +316,6 @@ SENSORS: list[descr] = [
         visibility=LV.V0324_ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER,
         factor=0.01,
         native_precision=1,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.SECOND_HEAT_GENERATOR_AMOUNT_COUNTER,
@@ -345,7 +328,6 @@ SENSORS: list[descr] = [
         factor=0.1,
         native_precision=1,
         # min_firmware_version_minor=FirmwareVersionMinor.minor_90,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.ANALOG_OUT1,
@@ -554,7 +536,6 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfTime.HOURS,
         factor=SECOND_TO_HOUR_FACTOR,
         native_precision=2,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.HEAT_AMOUNT_HEATING,
@@ -565,7 +546,6 @@ SENSORS: list[descr] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         native_precision=1,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.HEAT_ENERGY_INPUT,
@@ -580,7 +560,6 @@ SENSORS: list[descr] = [
         # the remaining /10 noted for this parameter ("kWh/10" raw unit).
         factor=0.1,
         # min_firmware_version_minor=FirmwareVersionMinor.minor_89,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.FLOW_OUT_TEMPERATURE_EXTERNAL,
@@ -631,7 +610,6 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfTime.HOURS,
         factor=SECOND_TO_HOUR_FACTOR,
         native_precision=2,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.DHW_HEAT_AMOUNT,
@@ -642,7 +620,6 @@ SENSORS: list[descr] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         native_precision=1,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.DHW_ENERGY_INPUT,
@@ -657,7 +634,6 @@ SENSORS: list[descr] = [
         # the remaining /10 noted for this parameter ("kWh/10" raw unit).
         factor=0.1,
         # min_firmware_version_minor=FirmwareVersionMinor.minor_89,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.SOLAR_COLLECTOR_TEMPERATURE,
@@ -687,7 +663,6 @@ SENSORS: list[descr] = [
         factor=SECOND_TO_HOUR_FACTOR,
         native_precision=2,
         visibility=LV.V0038_SOLAR_COLLECTOR,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     # endregion Domestic water
     # region Cooling
@@ -700,7 +675,6 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfTime.HOURS,
         factor=SECOND_TO_HOUR_FACTOR,
         native_precision=2,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     descr(
         key=SensorKey.COOLING_ENERGY_INPUT,
@@ -715,7 +689,6 @@ SENSORS: list[descr] = [
         # the remaining /10 noted for this parameter ("kWh/10" raw unit).
         factor=0.1,
         # min_firmware_version_minor=FirmwareVersionMinor.minor_88,
-        update_interval=UPDATE_INTERVAL_VERY_SLOW,
     ),
     # endregion Cooling
 ]

--- a/custom_components/luxtronik2/switch.py
+++ b/custom_components/luxtronik2/switch.py
@@ -89,9 +89,6 @@ class LuxtronikSwitchEntity(LuxtronikEntity[LuxtronikSwitchDescription], SwitchE
         self, data: LuxtronikCoordinatorData | None = None
     ) -> None:
         """Handle updated data from the coordinator."""
-        # if not self.should_update():
-        #    return
-
         data = self.coordinator.data if data is None else data
         if data is None:
             return

--- a/custom_components/luxtronik2/switch_entities_predefined.py
+++ b/custom_components/luxtronik2/switch_entities_predefined.py
@@ -3,7 +3,6 @@
 from homeassistant.const import EntityCategory
 
 from .const import (
-    UPDATE_INTERVAL_NORMAL,
     DeviceKey,
     LuxMode,
     LuxParameter as LP,
@@ -70,7 +69,6 @@ SWITCHES: list[LuxtronikSwitchDescription] = [
         device_class=None,
         on_state=LuxMode.automatic,
         off_state=LuxMode.off,
-        update_interval=UPDATE_INTERVAL_NORMAL,
     ),
     LuxtronikSwitchDescription(
         device_key=DeviceKey.heating,
@@ -113,7 +111,6 @@ SWITCHES: list[LuxtronikSwitchDescription] = [
             LuxMode.holidays,
         ],
         off_state=LuxMode.off,
-        update_interval=UPDATE_INTERVAL_NORMAL,
     ),
     # endregion Domestic water
     # region Cooling
@@ -124,7 +121,6 @@ SWITCHES: list[LuxtronikSwitchDescription] = [
         device_class=None,
         on_state=LuxMode.automatic,
         off_state=LuxMode.off,
-        update_interval=UPDATE_INTERVAL_NORMAL,
     ),
     # endregion Cooling
 ]

--- a/docs/superpowers/plans/2026-07-18-code-review-remediation.md
+++ b/docs/superpowers/plans/2026-07-18-code-review-remediation.md
@@ -304,6 +304,6 @@ Mark tasks here as they land (edit this file in the same PR as the fix):
 
 - [x] C1  - [x] C2  - [x] C3
 - [ ] I1  - [x] I2  - [x] I3  - [ ] I3b  - [ ] I4  - [x] I5  - [x] I6  - [x] I7  - [ ] I8  - [ ] I9  - [ ] I10  - [x] I11
-- [ ] M1  - [ ] M2  - [x] M3  - [x] M4  - [ ] M5  - [x] M6  - [x] M7  - [ ] M8  - [ ] M9  - [ ] M10  - [ ] M11  - [ ] M12
+- [x] M1  - [ ] M2  - [x] M3  - [x] M4  - [ ] M5  - [x] M6  - [x] M7  - [ ] M8  - [ ] M9  - [ ] M10  - [ ] M11  - [ ] M12
 
 Recovery note (2026-07-18): this file was found deleted mid-session with no git history (it was never committed) and was reconstructed from the content captured earlier in the same conversation. If you're reading this and something looks off versus the actual code state, re-verify line numbers/snippets against the current `main` rather than trusting this doc blindly — several tasks (I11, M3, M4) landed after the original review and their line refs above are stale by design (see the note at the top of this section).

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.const import (
@@ -132,51 +132,6 @@ class TestBaseHandleCoordinatorUpdate:
         entity = _make_sensor_entity(data, desc)
         LuxtronikEntity._handle_coordinator_update(entity, data)
         assert entity._attr_icon == "mdi:default"
-
-
-# ===========================================================================
-# should_update
-# ===========================================================================
-
-
-class TestShouldUpdate:
-    def test_no_interval_always_true(self):
-        entity = _make_sensor_entity()
-        assert entity.should_update() is True
-
-    def test_with_interval_and_no_next_update(self):
-        desc = LuxtronikSensorDescription(
-            key=SensorKey.FLOW_OUT_TEMPERATURE,
-            luxtronik_key=LC.C0011_FLOW_OUT_TEMPERATURE,
-            device_key=DeviceKey.heatpump,
-            update_interval=timedelta(seconds=60),
-        )
-        entity = _make_sensor_entity(description=desc)
-        entity.next_update = None
-        assert entity.should_update() is True
-
-    def test_with_interval_and_future_next_update(self):
-        desc = LuxtronikSensorDescription(
-            key=SensorKey.FLOW_OUT_TEMPERATURE,
-            luxtronik_key=LC.C0011_FLOW_OUT_TEMPERATURE,
-            device_key=DeviceKey.heatpump,
-            update_interval=timedelta(seconds=60),
-        )
-        entity = _make_sensor_entity(description=desc)
-        # Set next_update far in the future (UTC) so should_update returns False
-        entity.next_update = datetime.now(UTC) + timedelta(hours=1)
-        assert entity.should_update() is False
-
-    def test_with_interval_and_past_next_update(self):
-        desc = LuxtronikSensorDescription(
-            key=SensorKey.FLOW_OUT_TEMPERATURE,
-            luxtronik_key=LC.C0011_FLOW_OUT_TEMPERATURE,
-            device_key=DeviceKey.heatpump,
-            update_interval=timedelta(seconds=60),
-        )
-        entity = _make_sensor_entity(description=desc)
-        entity.next_update = datetime.now(UTC) - timedelta(hours=1)
-        assert entity.should_update() is True
 
 
 # ===========================================================================

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -83,7 +83,6 @@ def _make_coordinator_direct(data=None):
     coord.client = MagicMock()
     coord._config = {"host": "1.2.3.4", "port": 8889}
     coord.device_infos = {}
-    coord.update_reason_write = False
     coord.async_request_refresh = AsyncMock()
     coord.async_refresh = AsyncMock()
     coord.update_interval = DEFAULT_UPDATE_INTERVAL

--- a/tests/test_entity_platforms.py
+++ b/tests/test_entity_platforms.py
@@ -836,12 +836,6 @@ class TestThermalDesinfectionDaySelector:
         await entity.async_select_option("wednesday")
         assert entity._attr_current_option == "wednesday"
 
-    @pytest.mark.asyncio
-    async def test_async_update(self):
-        entity, _ = self._make_tdi_selector({"ID_Einst_BwTDI_akt_FR": 1})
-        await entity.async_update()
-        assert entity._attr_current_option == "friday"
-
 
 # ===========================================================================
 # LuxtronikModeSelector

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -21,7 +21,6 @@ from custom_components.luxtronik2.model import (
     LuxtronikSwitchDescription,
     LuxtronikUpdateEntityDescription,
     LuxtronikWaterHeaterDescription,
-    metaclass_resolver,
 )
 
 
@@ -44,7 +43,6 @@ class TestLuxtronikEntityDescription:
         assert desc.device_key == DeviceKey.heatpump
         assert desc.luxtronik_key == LuxParameter.UNSET
         assert desc.visibility == LuxVisibility.UNSET
-        assert desc.update_interval is None
         assert desc.icon_by_state is None
         assert desc.extra_attributes == ()
         assert desc.min_firmware_version is None
@@ -104,48 +102,6 @@ class TestLuxtronikBinarySensorDescription:
         )
         assert desc.on_state == "active"
         assert desc.on_states == ["active", "running"]
-
-
-# ===========================================================================
-# metaclass_resolver (model.py lines 182-188)
-# ===========================================================================
-
-
-class TestMetaclassResolver:
-    def test_single_metaclass(self):
-        class A:
-            pass
-
-        result = metaclass_resolver(A)
-        assert isinstance(result, type)
-        assert issubclass(type(result), type)
-
-    def test_multiple_same_metaclass(self):
-        class A:
-            pass
-
-        class B:
-            pass
-
-        result = metaclass_resolver(A, B)
-        assert isinstance(result, type)
-
-    def test_different_metaclasses(self):
-        class MetaA(type):
-            pass
-
-        class MetaB(type):
-            pass
-
-        class A(metaclass=MetaA):
-            pass
-
-        class B(metaclass=MetaB):
-            pass
-
-        result = metaclass_resolver(A, B)
-        assert isinstance(result, type)
-        assert issubclass(type(type(result)), type)
 
 
 class TestLuxtronikSwitchDescription:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -96,7 +96,6 @@ def _make_coordinator_direct(data=None):
     coord.client = MagicMock()
     coord._config = {"host": "1.2.3.4", "port": 8889}
     coord.device_infos = {}
-    coord.update_reason_write = False
     coord.async_request_refresh = MagicMock()
     coord.async_refresh = MagicMock()
     coord.update_interval = DEFAULT_UPDATE_INTERVAL

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -89,65 +89,6 @@ class TestSelectDataNone:
 
 
 # ===========================================================================
-# select.py — async_update
-# ===========================================================================
-
-
-class TestThermalDesinfectionAsyncUpdate:
-    def _make_entity(self, coord=None):
-        desc = LuxtronikSelectEntityDescription(
-            key=SensorKey.THERMAL_DESINFECTION_DAY,
-            device_key=DeviceKey.domestic_water,
-            luxtronik_key=LuxDaySelectorParameter.MONDAY,  # pyright: ignore[reportArgumentType]
-        )
-        if coord is None:
-            coord = _mock_coordinator()
-        entry = _mock_entry()
-        entity = LuxtronikThermalDesinfectionDaySelector(
-            entry, coord, desc, DeviceKey.domestic_water
-        )
-        _patch_entity(entity)
-        return entity
-
-    @pytest.mark.asyncio
-    async def test_async_update_data_none(self):
-        entity = self._make_entity()
-        entity.coordinator.data = None
-        await entity.async_update()
-        # Should return early, current_option unchanged
-
-    @pytest.mark.asyncio
-    async def test_async_update_no_day_selected(self):
-        coord = _mock_coordinator()
-        entity = self._make_entity(coord)
-        # All day parameters return "0" by default (mock)
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "custom_components.luxtronik2.select.get_sensor_data",
-                lambda data, key: "0",
-            )
-            await entity.async_update()
-        assert entity._attr_current_option == "none"
-
-    @pytest.mark.asyncio
-    async def test_async_update_day_selected(self):
-        coord = _mock_coordinator()
-        entity = self._make_entity(coord)
-        wednesday_param = LuxDaySelectorParameter.WEDNESDAY.value
-
-        def fake_sensor_data(data, key):
-            return "1" if key == wednesday_param else "0"
-
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(
-                "custom_components.luxtronik2.select.get_sensor_data",
-                fake_sensor_data,
-            )
-            await entity.async_update()
-        assert entity._attr_current_option == "wednesday"
-
-
-# ===========================================================================
 # _build_pv_mode_selector_description
 # ===========================================================================
 


### PR DESCRIPTION
## Summary
- Removes cleanup item **M1** from the code review remediation plan (`docs/superpowers/plans/2026-07-18-code-review-remediation.md`): dead code that was never exercised in production and misled contributors.
- Deleted: `metaclass_resolver` (model.py, unused); the inert per-entity `update_interval` field plus `should_update`/`next_update` machinery in `base.py`/`model.py` and every `update_interval=` kwarg in `*_entities_predefined.py` (all call sites were already commented out); `update_reason_write` (coordinator.py, set but never read); the `platform = Platform.AIR_QUALITY` placeholder; `LuxtronikThermalDesinfectionDaySelector.async_update` (coordinator entities don't poll — the day is already kept in sync via `_handle_coordinator_update`).
- Removed the now-dead tests that only covered the deleted code, and marked M1 done in the remediation plan.

## Test plan
- [x] `ruff check custom_components/luxtronik2 tests` — clean
- [x] `ruff format --check custom_components/luxtronik2 tests` — clean
- [x] `basedpyright --pythonpath ... custom_components/luxtronik2` — 0 errors
- [x] `pytest --cov=custom_components.luxtronik2` — 817 passed, coverage unchanged at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)