### PR TITLE
chore(manifest): 🔧 remove unused http dependency (M11)

### DIFF
--- a/custom_components/luxtronik2/manifest.json
+++ b/custom_components/luxtronik2/manifest.json
@@ -9,7 +9,6 @@
   ],
   "config_flow": true,
   "dependencies": [
-    "http",
     "network"
   ],
   "dhcp": [

--- a/docs/superpowers/plans/2026-07-18-code-review-remediation.md
+++ b/docs/superpowers/plans/2026-07-18-code-review-remediation.md
@@ -304,6 +304,6 @@ Mark tasks here as they land (edit this file in the same PR as the fix):
 
 - [x] C1  - [x] C2  - [x] C3
 - [ ] I1  - [x] I2  - [x] I3  - [ ] I3b  - [ ] I4  - [x] I5  - [x] I6  - [x] I7  - [ ] I8  - [ ] I9  - [ ] I10  - [x] I11
-- [ ] M1  - [ ] M2  - [x] M3  - [x] M4  - [ ] M5  - [x] M6  - [x] M7  - [ ] M8  - [ ] M9  - [ ] M10  - [ ] M11  - [ ] M12
+- [ ] M1  - [ ] M2  - [x] M3  - [x] M4  - [ ] M5  - [x] M6  - [x] M7  - [ ] M8  - [ ] M9  - [ ] M10  - [x] M11  - [ ] M12
 
 Recovery note (2026-07-18): this file was found deleted mid-session with no git history (it was never committed) and was reconstructed from the content captured earlier in the same conversation. If you're reading this and something looks off versus the actual code state, re-verify line numbers/snippets against the current `main` rather than trusting this doc blindly — several tasks (I11, M3, M4) landed after the original review and their line refs above are stale by design (see the note at the top of this section).


### PR DESCRIPTION
## 🧹 Summary
- Removes the unused `http` entry from `manifest.json`'s `dependencies` — the integration registers no HA views/APIs, so nothing references `hass.http` or `homeassistant.components.http`.
- Verified the `packaging>=26.2` requirement has no conflict with HA core's `packaging>=23.1` constraint (no change needed there).
- Marks task M11 done in `docs/superpowers/plans/2026-07-18-code-review-remediation.md`.

## ✅ Test plan
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `basedpyright` — 0 errors
- [x] Full test suite: 828 passed, 100% coverage on `custom_components.luxtronik2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)