### PR TITLE
fix(number): 🐛 stop bypassing NumberEntity unit conversion in state

### DIFF
--- a/custom_components/luxtronik2/number.py
+++ b/custom_components/luxtronik2/number.py
@@ -188,10 +188,6 @@ class LuxtronikNumberEntity(LuxtronikEntity[LuxtronikNumberDescription], NumberE
         return self.entity_description.native_max_value
 
     @property
-    def state(self) -> str | float | None:
-        return self._attr_native_value
-
-    @property
     def extra_state_attributes(self) -> dict[str, str]:
         """Return human-readable mode for DHW manual frequency entity."""
         if self.entity_description.key != SensorKey.DHW_MANUAL_FREQUENCY:

--- a/docs/superpowers/plans/2026-07-18-code-review-remediation.md
+++ b/docs/superpowers/plans/2026-07-18-code-review-remediation.md
@@ -16,7 +16,7 @@ This document is written so that any AI model or contributor can pick up a singl
   "C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m basedpyright --pythonpath "C:\Users\rhamm\anaconda3\envs\py314\python.exe" custom_components/luxtronik2
   ```
 - **Definition of done for every task**: basedpyright 0 errors, `ruff check` clean, `ruff format --check` clean, **full** test suite passes, coverage does not regress. Run coverage as `pytest --cov=custom_components.luxtronik2` — never scope `--cov` to a leaf submodule (it triggers a bcrypt/PyO3 re-init crash; see CLAUDE.md for the root cause).
-- **Git rules**: never commit on `main` — create a branch `fix/<description>` or `feat/<description>` first. **Never run `git commit` without explicit user approval.** Commit format: `<type>(<scope>): <gitmoji> <description>` (lowercase imperative), e.g. `fix(base): 🐛 restore visibility-driven enabled default`.
+- **Git rules**: never commit on `main` — create a branch `fix/<description>` or `feat/<description>` first, always starting from an up-to-date `origin/main` (`git fetch origin` then branch off `origin/main`) to prevent merge conflicts as much as possible. **Never run `git commit` without explicit user approval.** Commit format: `<type>(<scope>): <gitmoji> <description>` (lowercase imperative), e.g. `fix(base): 🐛 restore visibility-driven enabled default`.
 - **Line numbers in this document** were verified against commit `46b0c4b` and will drift as fixes land. Always re-locate the code by the quoted snippet or symbol name, not the line number alone.
 - **Tests-first**: for each behavioral fix, write a failing test that demonstrates the bug before changing the code (TDD). Existing tests live in `tests/`, one file per module (`tests/test_base.py`, `tests/test_sensor.py`, …).
 - **Architecture primer**: every platform follows a three-file pattern — `<platform>_entities_predefined.py` (static description lists), `model.py` (description dataclasses), `<platform>.py` (setup + entity classes subclassing `LuxtronikEntity` from `base.py`). `coordinator.py` holds `LuxtronikCoordinator` (a `DataUpdateCoordinator`) that owns the single socket connection to the heat pump. `lux_overrides.py` monkey-patches the upstream `luxtronik` PyPI library once per process. Config entries store the coordinator in `entry.runtime_data` (typed alias `LuxtronikConfigEntry` in `__init__.py`).
@@ -303,7 +303,7 @@ All four must be clean (0 lint findings, 0 format diffs, 0 type errors, all test
 Mark tasks here as they land (edit this file in the same PR as the fix):
 
 - [x] C1  - [x] C2  - [x] C3
-- [ ] I1  - [x] I2  - [x] I3  - [ ] I3b  - [ ] I4  - [x] I5  - [x] I6  - [x] I7  - [ ] I8  - [ ] I9  - [ ] I10  - [x] I11
+- [ ] I1  - [x] I2  - [x] I3  - [ ] I3b  - [x] I4  - [x] I5  - [x] I6  - [x] I7  - [ ] I8  - [ ] I9  - [ ] I10  - [x] I11
 - [x] M1  - [ ] M2  - [x] M3  - [x] M4  - [ ] M5  - [x] M6  - [x] M7  - [ ] M8  - [ ] M9  - [ ] M10  - [x] M11  - [ ] M12
 
 Recovery note (2026-07-18): this file was found deleted mid-session with no git history (it was never committed) and was reconstructed from the content captured earlier in the same conversation. If you're reading this and something looks off versus the actual code state, re-verify line numbers/snippets against the current `main` rather than trusting this doc blindly — several tasks (I11, M3, M4) landed after the original review and their line refs above are stale by design (see the note at the top of this section).

--- a/tests/test_setup_integration.py
+++ b/tests/test_setup_integration.py
@@ -16,9 +16,10 @@ import asyncio
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -206,6 +207,36 @@ async def test_number_set_native_value_writes_converted_raw_value(
 
     assert client.parameters.get("ID_Soll_BWS_akt").value == 55.0
     assert float(hass.states.get(entity_id).state) == 55.0
+
+
+async def test_number_temperature_state_converts_to_imperial_unit(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A temperature number entity's state respects hass's display unit (I4 regression net).
+
+    `LuxtronikNumberEntity` used to override `state` to return
+    `self._attr_native_value` unconditionally, bypassing `NumberEntity`'s
+    built-in unit conversion - imperial users would see the raw Celsius
+    number mislabeled as Fahrenheit.
+    """
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    client = FakeLuxtronikClient(
+        host="192.168.1.100", port=DEFAULT_PORT, socket_timeout=10, max_data_length=1024
+    )
+    _patch_client(monkeypatch, client)
+
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = f"number.{DOMAIN}_{SensorKey.DHW_TARGET_TEMPERATURE}"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    # Native value is 50.0 degC (see DEFAULT_PARAMETERS["ID_Soll_BWS_akt"]).
+    assert float(state.state) == pytest.approx(122.0)
+    assert state.attributes["unit_of_measurement"] == UnitOfTemperature.FAHRENHEIT
 
 
 async def test_unload_disconnects_client_and_unregisters_service(


### PR DESCRIPTION
## Summary
- `LuxtronikNumberEntity` overrode `state` to unconditionally return `self._attr_native_value`, bypassing `NumberEntity`'s built-in unit conversion (°C→°F for imperial users), display precision, and range validation. Deleted the override entirely.
- Git history showed the override's original purpose — special-casing DHW frequency `0` as `"Automatic"` — was already migrated to `extra_state_attributes` in a later commit, leaving only a harmful passthrough behind. That "Automatic" UX is unaffected by this change.
- `NumberEntity.state`/`.value` are `@final` in Home Assistant core, so the override was also a latent type-safety violation waiting to surface.

## Test plan
- [x] Added `tests/test_setup_integration.py::test_number_temperature_state_converts_to_imperial_unit` using the real `hass` test harness: sets `hass.config.units = US_CUSTOMARY_SYSTEM`, sets up the integration with a fake Luxtronik client reporting a 50.0 °C DHW target temperature, and asserts the entity's HA state converts to `122.0 °F`. Verified RED before the fix, GREEN after.
- [x] Existing `TestDHWManualFrequency` tests in `tests/test_number.py` still pass and remain meaningful (that entity has no `device_class`, so unit conversion is a no-op there by design — the new integration test covers the conversion path).
- [x] `pytest --cov=custom_components.luxtronik2` — 818 passed, 100% coverage, no regression.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `basedpyright` — 0 errors, 0 warnings, 0 notes.

Resolves task I4 in `docs/superpowers/plans/2026-07-18-code-review-remediation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)