### PR TITLE
fix(config_flow): 🐛 isolate flow state, stop aborting on transient errors, add manual escape

### DIFF
--- a/custom_components/luxtronik2/config_flow.py
+++ b/custom_components/luxtronik2/config_flow.py
@@ -41,14 +41,24 @@ from .schema_helper import build_options_schema, build_user_data_schema
 # endregion Imports
 
 SELECT_DEVICE_LABEL = "select_device_to_configure"
+MANUAL_ENTRY_VALUE = "__manual_entry__"
 
 
 class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Luxtronik heatpump controller config flow."""
 
     VERSION = CONFIG_ENTRY_VERSION
-    _all_devices: list[dict[str, Any]] = []
-    _available_devices: list[dict[str, Any]] = []
+
+    def __init__(self) -> None:
+        """Initialize the config flow with per-instance discovery state.
+
+        Must not be class-level: two flows running concurrently (e.g. two
+        users, or discovery + manual entry at the same time) would otherwise
+        share the same discovered-device lists.
+        """
+        super().__init__()
+        self._all_devices: list[dict[str, Any]] = []
+        self._available_devices: list[dict[str, Any]] = []
 
     def _build_config(
         self,
@@ -126,73 +136,87 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             LOGGER.info("Starting discovery of Luxtronik devices on network")
             device_list = await self._discover_devices()
+        except OSError as err:
+            LOGGER.warning("Device discovery failed due to a network error: %s", err)
+            return self.async_show_form(
+                step_id="manual_entry",
+                data_schema=build_user_data_schema(),
+                errors={"base": "cannot_connect"},
+            )
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("Could not handle config_flow.async_step_user")
+            return self.async_show_form(
+                step_id="manual_entry",
+                data_schema=build_user_data_schema(),
+                errors={"base": "unknown"},
+            )
 
-            configured_hosts_ports = {
-                (entry.data.get(CONF_HOST), entry.data.get(CONF_PORT))
-                for entry in self._async_current_entries()
+        configured_hosts_ports = {
+            (entry.data.get(CONF_HOST), entry.data.get(CONF_PORT))
+            for entry in self._async_current_entries()
+        }
+
+        self._all_devices = [
+            {
+                "host": host,
+                "port": port,
+                "configured": (host, port) in configured_hosts_ports,
             }
+            for host, port in device_list
+        ]
+        LOGGER.info("All discovered devices with config status: %s", self._all_devices)
 
-            self._all_devices = [
-                {
-                    "host": host,
-                    "port": port,
-                    "configured": (host, port) in configured_hosts_ports,
-                }
-                for host, port in device_list
+        self._available_devices = [d for d in self._all_devices if not d["configured"]]
+        LOGGER.info("Available (unconfigured) devices: %s", self._available_devices)
+
+        if self._available_devices:
+            device_options_list: list[selector.SelectOptionDict] = [
+                selector.SelectOptionDict(
+                    value=f"{d['host']}:{d['port']}",
+                    label=f"{d['host']}:{d['port']}",
+                )
+                for d in self._available_devices
             ]
-            LOGGER.info(
-                "All discovered devices with config status: %s", self._all_devices
+            # Manual entry must always be reachable, even while discovered
+            # devices are pending selection - a pump on another subnet
+            # can't be added otherwise.
+            device_options_list.append(
+                selector.SelectOptionDict(
+                    value=MANUAL_ENTRY_VALUE, label="Enter host manually"
+                )
             )
 
-            self._available_devices = [
-                d for d in self._all_devices if not d["configured"]
-            ]
-            LOGGER.info("Available (unconfigured) devices: %s", self._available_devices)
+            LOGGER.info("Presenting selection form for available devices")
+            LOGGER.info("device_options_list=%s", device_options_list)
 
-            if self._available_devices:
-                device_options_list = [
-                    f"{d['host']}:{d['port']}" for d in self._available_devices
-                ]
-
-                LOGGER.info("Presenting selection form for available devices")
-                LOGGER.info("device_options_list=%s", device_options_list)
-
-                return self.async_show_form(
-                    step_id="select_devices",
-                    data_schema=vol.Schema(
-                        {
-                            vol.Required(SELECT_DEVICE_LABEL): selector.SelectSelector(
-                                selector.SelectSelectorConfig(
-                                    options=device_options_list,
-                                    multiple=False,  # ✅ Only one device selectable
-                                    mode=selector.SelectSelectorMode.DROPDOWN,
-                                )
+            return self.async_show_form(
+                step_id="select_devices",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(SELECT_DEVICE_LABEL): selector.SelectSelector(
+                            selector.SelectSelectorConfig(
+                                options=device_options_list,
+                                multiple=False,  # ✅ Only one device selectable
+                                mode=selector.SelectSelectorMode.DROPDOWN,
                             )
-                        }
-                    ),
-                    description_placeholders={
-                        "configured": ", ".join(
-                            f"{d['host']}:{d['port']}"
-                            for d in self._all_devices
-                            if d["configured"]
                         )
-                    },
-                )
-
-            else:
-                LOGGER.info(
-                    "All discovered devices are already configured. Showing manual entry form."
-                )
-                return self.async_show_form(
-                    step_id="manual_entry", data_schema=build_user_data_schema()
-                )
-
-        except Exception as err:
-            LOGGER.error(
-                "Could not handle config_flow.async_step_user",
-                exc_info=err,
+                    }
+                ),
+                description_placeholders={
+                    "configured": ", ".join(
+                        f"{d['host']}:{d['port']}"
+                        for d in self._all_devices
+                        if d["configured"]
+                    )
+                },
             )
-            return self.async_abort(reason="unknown")
+
+        LOGGER.info(
+            "All discovered devices are already configured. Showing manual entry form."
+        )
+        return self.async_show_form(
+            step_id="manual_entry", data_schema=build_user_data_schema()
+        )
 
     async def async_step_select_devices(
         self, user_input: dict[str, Any] | None = None
@@ -204,6 +228,8 @@ class LuxtronikFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         device_str = user_input.get(SELECT_DEVICE_LABEL)
         if device_str is None:
             return self.async_abort(reason="unknown")
+        if device_str == MANUAL_ENTRY_VALUE:
+            return await self.async_step_manual_entry()
         host, port = device_str.split(":")
         config = self._build_config(host, int(port))
 

--- a/docs/superpowers/plans/2026-07-18-code-review-remediation.md
+++ b/docs/superpowers/plans/2026-07-18-code-review-remediation.md
@@ -303,7 +303,7 @@ All four must be clean (0 lint findings, 0 format diffs, 0 type errors, all test
 Mark tasks here as they land (edit this file in the same PR as the fix):
 
 - [x] C1  - [x] C2  - [x] C3
-- [ ] I1  - [x] I2  - [x] I3  - [ ] I3b  - [ ] I4  - [x] I5  - [x] I6  - [x] I7  - [ ] I8  - [ ] I9  - [ ] I10  - [x] I11
+- [ ] I1  - [x] I2  - [x] I3  - [ ] I3b  - [ ] I4  - [x] I5  - [x] I6  - [x] I7  - [x] I8  - [ ] I9  - [ ] I10  - [x] I11
 - [x] M1  - [ ] M2  - [x] M3  - [x] M4  - [ ] M5  - [x] M6  - [x] M7  - [ ] M8  - [ ] M9  - [ ] M10  - [x] M11  - [ ] M12
 
 Recovery note (2026-07-18): this file was found deleted mid-session with no git history (it was never committed) and was reconstructed from the content captured earlier in the same conversation. If you're reading this and something looks off versus the actual code state, re-verify line numbers/snippets against the current `main` rather than trusting this doc blindly — several tasks (I11, M3, M4) landed after the original review and their line refs above are stale by design (see the note at the top of this section).

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -10,6 +10,8 @@ from homeassistant.data_entry_flow import AbortFlow
 import pytest
 
 from custom_components.luxtronik2.config_flow import (
+    MANUAL_ENTRY_VALUE,
+    SELECT_DEVICE_LABEL,
     LuxtronikFlowHandler,
     LuxtronikOptionsFlowHandler,
 )
@@ -146,6 +148,47 @@ class TestSetUniqueIdOrAbort:
 
 
 # ===========================================================================
+# Instance isolation (I8)
+# ===========================================================================
+
+
+class TestFlowInstanceIsolation:
+    def test_device_lists_are_not_shared_across_flow_instances(self):
+        """`_all_devices`/`_available_devices` must be per-instance, not class-level.
+
+        Two concurrent flows (e.g. two users, or discovery + manual entry
+        running simultaneously) must never see each other's discovered
+        device lists.
+        """
+        flow1 = LuxtronikFlowHandler()
+        flow2 = LuxtronikFlowHandler()
+        assert flow1._available_devices is not flow2._available_devices
+        assert flow1._all_devices is not flow2._all_devices
+
+    @pytest.mark.asyncio
+    async def test_concurrent_discovery_does_not_cross_contaminate(self):
+        """Two flows discovering different devices must not see each other's results."""
+
+        def _prepare(flow, devices):
+            flow.hass = MagicMock()
+            flow.hass.async_add_executor_job = AsyncMock(return_value=devices)
+            flow._async_current_entries = MagicMock(return_value=[])
+            flow._async_migrate_data_from_custom_component_luxtronik2 = AsyncMock()
+            flow.async_show_form = MagicMock(return_value={"type": "form"})
+
+        flow1 = LuxtronikFlowHandler()
+        flow2 = LuxtronikFlowHandler()
+        _prepare(flow1, [("1.2.3.4", 8889)])
+        _prepare(flow2, [("5.6.7.8", 8888)])
+
+        await flow1.async_step_user()
+        await flow2.async_step_user()
+
+        assert [d["host"] for d in flow1._all_devices] == ["1.2.3.4"]
+        assert [d["host"] for d in flow2._all_devices] == ["5.6.7.8"]
+
+
+# ===========================================================================
 # async_step_user
 # ===========================================================================
 
@@ -193,14 +236,56 @@ class TestAsyncStepUser:
         flow.async_show_form.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_aborts_on_exception(self):
+    async def test_discovery_os_error_reshows_manual_form_with_cannot_connect(self):
+        """A transient network error during discovery must not kill the flow."""
+        flow = LuxtronikFlowHandler()
+        flow.hass = MagicMock()
+        flow.hass.async_add_executor_job = AsyncMock(
+            side_effect=OSError("network unreachable")
+        )
+        flow._async_migrate_data_from_custom_component_luxtronik2 = AsyncMock()
+        flow.async_show_form = MagicMock(return_value={"type": "form"})
+        flow.async_abort = MagicMock(return_value={"type": "abort"})
+        await flow.async_step_user()
+        flow.async_abort.assert_not_called()
+        flow.async_show_form.assert_called_once()
+        call_kwargs = flow.async_show_form.call_args[1]
+        assert call_kwargs["step_id"] == "manual_entry"
+        assert call_kwargs["errors"] == {"base": "cannot_connect"}
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_reshows_manual_form_with_unknown_error(self):
+        """A last-resort catch-all must also re-show the form, not abort the flow."""
         flow = LuxtronikFlowHandler()
         flow.hass = MagicMock()
         flow.hass.async_add_executor_job = AsyncMock(side_effect=Exception("boom"))
         flow._async_migrate_data_from_custom_component_luxtronik2 = AsyncMock()
+        flow.async_show_form = MagicMock(return_value={"type": "form"})
         flow.async_abort = MagicMock(return_value={"type": "abort"})
         await flow.async_step_user()
-        flow.async_abort.assert_called_once_with(reason="unknown")
+        flow.async_abort.assert_not_called()
+        flow.async_show_form.assert_called_once()
+        call_kwargs = flow.async_show_form.call_args[1]
+        assert call_kwargs["step_id"] == "manual_entry"
+        assert call_kwargs["errors"] == {"base": "unknown"}
+
+    @pytest.mark.asyncio
+    async def test_selection_form_includes_manual_entry_option(self):
+        """A pump on another subnet must stay reachable while devices are discovered."""
+        flow = LuxtronikFlowHandler()
+        flow.hass = MagicMock()
+        flow.hass.async_add_executor_job = AsyncMock(return_value=[("1.2.3.4", 8889)])
+        flow._async_current_entries = MagicMock(return_value=[])
+        flow._async_migrate_data_from_custom_component_luxtronik2 = AsyncMock()
+        flow.async_show_form = MagicMock(
+            return_value={"type": "form", "step_id": "select_devices"}
+        )
+        await flow.async_step_user()
+        schema = flow.async_show_form.call_args[1]["data_schema"]
+        select_selector = next(iter(schema.schema.values()))
+        options = select_selector.config["options"]
+        values = {opt["value"] if isinstance(opt, dict) else opt for opt in options}
+        assert MANUAL_ENTRY_VALUE in values
 
 
 # ===========================================================================
@@ -257,6 +342,19 @@ class TestAsyncStepSelectDevices:
                 {"select_device_to_configure": "1.2.3.4:8889"}
             )
         flow.async_create_entry.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_manual_entry_option_routes_to_manual_form(self):
+        """Selecting the manual-entry sentinel must reach the manual host form."""
+        flow = LuxtronikFlowHandler()
+        flow.async_step_manual_entry = AsyncMock(
+            return_value={"type": "form", "step_id": "manual_entry"}
+        )
+        result = await flow.async_step_select_devices(
+            {SELECT_DEVICE_LABEL: MANUAL_ENTRY_VALUE}
+        )
+        flow.async_step_manual_entry.assert_awaited_once_with()
+        assert result["step_id"] == "manual_entry"
 
     @pytest.mark.asyncio
     async def test_already_configured_aborts(self):


### PR DESCRIPTION
## Summary
- `_all_devices` / `_available_devices` were class-level mutable list attributes on `LuxtronikFlowHandler`, shared across all config-flow instances. Moved into `__init__` as instance attributes so two concurrent flows (two users, or discovery + manual entry running at the same time) can't see each other's discovered devices.
- `async_step_user` wrapped its whole body in a blanket `except Exception: return self.async_abort(reason="unknown")` — a transient network error during discovery killed the entire flow. Now catches `OSError` specifically (the socket-based discovery in `lux_helper.discover()` is the realistic failure mode) and re-shows the manual-entry form with `errors={"base": "cannot_connect"}`; a last-resort `except Exception` still logs the full traceback (`LOGGER.exception`) but also re-shows the form with `errors={"base": "unknown"}` instead of aborting. Both error keys already existed in `translations/*.json`, reused from the existing reconfigure-flow error handling — no new translation keys needed.
- When discovery finds unconfigured devices, the flow previously forced a selection among only those — manual host entry was unreachable while any device was pending selection, so a pump on another subnet couldn't be added. Added an "Enter host manually" option to the selection dropdown (`MANUAL_ENTRY_VALUE` sentinel); `async_step_select_devices` now routes that sentinel to `async_step_manual_entry()`.

## Test plan
- [x] `TestFlowInstanceIsolation` — construction-time list-identity check (fails against the old class-level attributes) plus a concurrency test that runs `async_step_user` on two flow instances with different discovered devices and asserts no cross-contamination.
- [x] `test_discovery_os_error_reshows_manual_form_with_cannot_connect` / `test_unexpected_error_reshows_manual_form_with_unknown_error` — replace the old blanket-abort test; verify the flow re-shows the form instead of aborting, with the correct error key per exception type.
- [x] `test_selection_form_includes_manual_entry_option` / `test_manual_entry_option_routes_to_manual_form` — cover the new manual-entry escape hatch end-to-end (option present in the dropdown, selecting it routes to the manual form).
- [x] `pytest --cov=custom_components.luxtronik2` — 822 passed, 100% coverage, no regression.
- [x] `ruff check` / `ruff format --check` clean.
- [x] `basedpyright` — 0 errors, 0 warnings, 0 notes.
- [x] Verified via independent code-review subagent, including tracing `lux_helper.discover()`'s actual exception surface to confirm `OSError` is correctly scoped (ordinary per-port discovery timeouts are already caught inside `discover()` and don't propagate).

Resolves task I8 in `docs/superpowers/plans/2026-07-18-code-review-remediation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)