### PR TITLE
fix(translations): 🐛 move device names to top-level device key

### DIFF
--- a/.github/scripts/check_translation_coverage.py
+++ b/.github/scripts/check_translation_coverage.py
@@ -46,6 +46,25 @@ def load_const_mapping() -> dict[str, str]:
     return mapping
 
 
+def load_device_keys() -> list[str]:
+    """Load DeviceKey enum values from const.py without importing homeassistant."""
+    with open(CONST_FILE, encoding="utf-8") as f:
+        source = f.read()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "DeviceKey":
+            values: list[str] = []
+            for stmt in node.body:
+                if (
+                    isinstance(stmt, ast.Assign)
+                    and isinstance(stmt.value, ast.Constant)
+                    and isinstance(stmt.value.value, str)
+                ):
+                    values.append(stmt.value.value)
+            return values
+    raise RuntimeError("DeviceKey class not found in const.py")
+
+
 def get_entity_keys(filename: str) -> list[str]:
     """Extract SensorKey translation keys used in a predefined entities file."""
     filepath = ENTITY_DIR / filename
@@ -78,6 +97,24 @@ def load_all_languages() -> dict[str, dict]:
         with open(TRANS_DIR / lang_file, encoding="utf-8") as f:
             data_by_lang[lang_file.removesuffix(".json")] = json.load(f)
     return data_by_lang
+
+
+def find_invalid_json_files() -> list[str]:
+    """Check that every translations/<lang>.json file parses as valid JSON.
+
+    All other checks call load_all_languages()/json.load() and would raise
+    an unhandled JSONDecodeError on a syntax error rather than a clean,
+    isolated problem report - this gives a dedicated, easy-to-read failure
+    pointing at the exact file and line/column instead.
+    """
+    problems: list[str] = []
+    for lang_file in LANG_FILES:
+        with open(TRANS_DIR / lang_file, encoding="utf-8") as f:
+            try:
+                json.load(f)
+            except json.JSONDecodeError as e:
+                problems.append(f"[{lang_file}] invalid JSON: {e}")
+    return problems
 
 
 def find_missing_entity_keys() -> list[str]:
@@ -171,8 +208,52 @@ def find_state_key_mismatches() -> list[str]:
     return problems
 
 
+def find_device_translation_problems() -> list[str]:
+    """Check that every DeviceKey has a translated name at the top-level
+    `device.<key>.name` path in every language file, and that no locale has
+    regressed back to nesting the block under `entity.device` instead.
+
+    HA's device_registry resolves DeviceInfo(translation_key=...) from
+    `component.{domain}.device.{key}.name` - a top-level `device` section,
+    not `entity.device`. A file that nests it under `entity` builds and
+    loads fine but silently fails to resolve any device name at runtime,
+    which `find_missing_entity_keys` cannot catch since it only inspects
+    the `entity` section.
+    """
+    problems: list[str] = []
+    device_keys = load_device_keys()
+    data_by_lang = load_all_languages()
+
+    for lang, data in data_by_lang.items():
+        if "device" in data.get("entity", {}):
+            problems.append(
+                f"[{lang}] device block is nested under entity.device; "
+                "it must be a top-level `device` key so HA's "
+                "translation_key resolution can find it"
+            )
+
+        device_section = data.get("device", {})
+        for key in device_keys:
+            name = device_section.get(key, {}).get("name")
+            if not name:
+                problems.append(f"[{lang}] device.{key}.name missing")
+
+    return problems
+
+
 if __name__ == "__main__":
-    all_problems = find_missing_entity_keys() + find_state_key_mismatches()
+    json_problems = find_invalid_json_files()
+    if json_problems:
+        LOG.info("Translation coverage problems found:")
+        for problem in json_problems:
+            LOG.info("  - %s", problem)
+        sys.exit(1)
+
+    all_problems = (
+        find_missing_entity_keys()
+        + find_state_key_mismatches()
+        + find_device_translation_problems()
+    )
     if not all_problems:
         LOG.info("All translation files have complete coverage!")
         sys.exit(0)

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -59,20 +59,6 @@
                 "name": "Ochrana motoru"
             }
         },
-        "device": {
-            "heatpump": {
-                "name": "T\u010c"
-            },
-            "heating": {
-                "name": "Topen\u00ed"
-            },
-            "domestic_water": {
-                "name": "TUV"
-            },
-            "cooling": {
-                "name": "Chlazen\u00ed"
-            }
-        },
         "switch": {
             "remote_maintenance": {
                 "name": "Vzd\u00e1len\u00e1 \u00fadr\u017eba"
@@ -1048,6 +1034,20 @@
             "domestic_water": {
                 "name": "TUV"
             }
+        }
+    },
+    "device": {
+        "heatpump": {
+            "name": "T\u010c"
+        },
+        "heating": {
+            "name": "Topen\u00ed"
+        },
+        "domestic_water": {
+            "name": "TUV"
+        },
+        "cooling": {
+            "name": "Chlazen\u00ed"
         }
     },
     "config": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -65,20 +65,6 @@
                 "name": "Zweiter W\u00e4rmeerzeuger W\u00e4rmemenge"
             }
         },
-        "device": {
-            "heatpump": {
-                "name": "WP"
-            },
-            "heating": {
-                "name": "Heiz"
-            },
-            "domestic_water": {
-                "name": "BW"
-            },
-            "cooling": {
-                "name": "K\u00fchl"
-            }
-        },
         "switch": {
             "remote_maintenance": {
                 "name": "Fernwartung"
@@ -1051,6 +1037,20 @@
             "domestic_water": {
                 "name": "Brauchwasser"
             }
+        }
+    },
+    "device": {
+        "heatpump": {
+            "name": "WP"
+        },
+        "heating": {
+            "name": "Heiz"
+        },
+        "domestic_water": {
+            "name": "BW"
+        },
+        "cooling": {
+            "name": "K\u00fchl"
         }
     },
     "config": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -59,20 +59,6 @@
                 "name": "Motor protection"
             }
         },
-        "device": {
-            "heatpump": {
-                "name": "HP"
-            },
-            "heating": {
-                "name": "Heat"
-            },
-            "domestic_water": {
-                "name": "DHW"
-            },
-            "cooling": {
-                "name": "Cool"
-            }
-        },
         "switch": {
             "remote_maintenance": {
                 "name": "Remote maintenance"
@@ -1079,6 +1065,20 @@
             }
         }
     },
+    "device": {
+        "heatpump": {
+            "name": "HP"
+        },
+        "heating": {
+            "name": "Heat"
+        },
+        "domestic_water": {
+            "name": "DHW"
+        },
+        "cooling": {
+            "name": "Cool"
+        }
+    },
     "config": {
         "abort": {
             "cannot_connect": "Failed to connect to Luxtronik at {host}.\\nError: {connect_error}",
@@ -1182,7 +1182,7 @@
             "message": "Luxtronik heat pump did not confirm the written value(s): {details}"
         },
         "write_confirmation_unavailable": {
-            "message": "Wrote {parameters} to the Luxtronik heat pump, but the confirming refresh failed — the result could not be confirmed"
+            "message": "Wrote {parameters} to the Luxtronik heat pump, but the confirming refresh failed \u2014 the result could not be confirmed"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -68,20 +68,6 @@
                 "name": "Tweede warmtebron warmtemenge"
             }
         },
-        "device": {
-            "heatpump": {
-                "name": "WP"
-            },
-            "heating": {
-                "name": "Verw"
-            },
-            "domestic_water": {
-                "name": "Warmwater"
-            },
-            "cooling": {
-                "name": "Koel"
-            }
-        },
         "switch": {
             "remote_maintenance": {
                 "name": "Dienst op afstand"
@@ -1056,6 +1042,20 @@
             }
         }
     },
+    "device": {
+        "heatpump": {
+            "name": "WP"
+        },
+        "heating": {
+            "name": "Verw"
+        },
+        "domestic_water": {
+            "name": "Warmwater"
+        },
+        "cooling": {
+            "name": "Koel"
+        }
+    },
     "config": {
         "abort": {
             "cannot_connect": "De verbinding met Luxtronik op {host} is mislukt.\nFout: {connect_error}",
@@ -1156,7 +1156,7 @@
             "message": "De Luxtronik-warmtepomp heeft de geschreven waarde(n) niet bevestigd: {details}"
         },
         "write_confirmation_unavailable": {
-            "message": "{parameters} is/zijn naar de Luxtronik-warmtepomp geschreven, maar de bevestigende vernieuwing is mislukt — het resultaat kon niet worden bevestigd"
+            "message": "{parameters} is/zijn naar de Luxtronik-warmtepomp geschreven, maar de bevestigende vernieuwing is mislukt \u2014 het resultaat kon niet worden bevestigd"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -80,20 +80,6 @@
                 "name": "Delta docelowa przep\u0142ywu pompy"
             }
         },
-        "device": {
-            "heatpump": {
-                "name": "Pompa ciep\u0142a"
-            },
-            "heating": {
-                "name": "Ogrzewanie"
-            },
-            "domestic_water": {
-                "name": "Ciep\u0142a woda"
-            },
-            "cooling": {
-                "name": "Ch\u0142odzenie"
-            }
-        },
         "switch": {
             "remote_maintenance": {
                 "name": "Zdalna konserwacja"
@@ -1069,6 +1055,20 @@
             "domestic_water": {
                 "name": "Ciep\u0142a woda"
             }
+        }
+    },
+    "device": {
+        "heatpump": {
+            "name": "Pompa ciep\u0142a"
+        },
+        "heating": {
+            "name": "Ogrzewanie"
+        },
+        "domestic_water": {
+            "name": "Ciep\u0142a woda"
+        },
+        "cooling": {
+            "name": "Ch\u0142odzenie"
         }
     },
     "config": {

--- a/tests/test_translation_coverage.py
+++ b/tests/test_translation_coverage.py
@@ -32,6 +32,17 @@ sys.modules[_spec.name] = check_translation_coverage
 _spec.loader.exec_module(check_translation_coverage)
 
 
+def test_translation_files_are_valid_json() -> None:
+    """Every translations/<lang>.json file must parse as valid JSON.
+
+    Without this, a syntax error in one file surfaces as an unhandled
+    JSONDecodeError from whichever other check happens to load it first,
+    instead of a clean, isolated failure naming the file and location.
+    """
+    problems = check_translation_coverage.find_invalid_json_files()
+    assert not problems, "\n" + "\n".join(problems)
+
+
 def test_all_referenced_entity_keys_have_translations() -> None:
     """Every SensorKey referenced in a *_entities_predefined.py file must exist as
     an entity in every language file."""
@@ -44,4 +55,17 @@ def test_state_and_state_attribute_codes_match_across_locales() -> None:
     must have the same set of keys in every language file - no locale may be missing
     codes (or have stray/unreachable ones) that others don't."""
     problems = check_translation_coverage.find_state_key_mismatches()
+    assert not problems, "\n" + "\n".join(problems)
+
+
+def test_device_names_are_translated_at_top_level() -> None:
+    """Every DeviceKey must have a `device.<key>.name` translation at the top level
+    of every language file, not nested under `entity.device`.
+
+    Regression guard: HA's device_registry resolves DeviceInfo(translation_key=...)
+    from the top-level `component.{domain}.device.{key}.name` path. A `device` block
+    nested under `entity` loads without error but silently fails to resolve any
+    device name at runtime, falling back to the raw key (e.g. "domestic_water").
+    """
+    problems = check_translation_coverage.find_device_translation_problems()
     assert not problems, "\n" + "\n".join(problems)


### PR DESCRIPTION
## 🐛 Bug

Device names (Heat pump / Heating / Domestic water / Cooling) stopped being translated after #a1f0914, showing raw keys like `heating` / `domestic_water` instead.

## 🔍 Root cause

All 5 translation files nested the device-name block under `entity.device.<key>.name`, but Home Assistant's `device_registry.async_get_or_create` resolves `DeviceInfo(translation_key=...)` from the **top-level** `component.{domain}.device.{key}.name` path (see `homeassistant/helpers/device_registry.py`).

This mismatch predates today but was invisible while `coordinator.py` manually read `entity.device...` translations itself. A recent refactor (removing private `platform_translations` API usage) switched to HA's public `translation_key` resolution, which only checks the top-level `device` key — so device names silently fell back to the raw key.

## ✅ Fix

Move the `device` block to be a top-level sibling of `entity` in `en.json`, `de.json`, `nl.json`, `cs.json`, `pl.json`. Pure relocation — no content changes (verified via minimal diffs).

## 🧪 Test coverage added

The existing translation coverage tooling (`check_translation_coverage.py`) only inspected the `entity` section, so it couldn't have caught this. Added:
- `find_device_translation_problems()` — asserts every `DeviceKey` has a `device.<key>.name` translation at the top level of every locale, and flags a regression back to nesting under `entity.device`.
- `find_invalid_json_files()` — parses each translation file and reports JSON syntax errors with file/line/column, instead of an unhandled `JSONDecodeError` surfacing from whichever other check happens to load the file first.

Both are wired into the CLI entrypoint and have matching `pytest` wrappers in `test_translation_coverage.py`.

## Test plan

- [x] `pytest` — 825 passed, no coverage regression
- [x] `ruff check` / `ruff format --check` clean
- [x] `basedpyright` — 0 errors
- [x] Verified the new device-translation test fails against the pre-fix file structure and passes after the fix
- [x] Verified the new JSON-validity test fails against a deliberately corrupted file and passes on the real ones
- [x] Manual verification in a running HA instance that device names show translated text after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)