### PR TITLE
fix(coordinator): 🐛 stop misusing DeviceInfo connections and empty suggested_area

### DIFF
--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -313,15 +313,8 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
             name=str(key.value),
             translation_key=key.value,
             configuration_url=f"http://{host}/",
-            connections={
-                (
-                    DOMAIN,
-                    f"{self.unique_id}_{key.value}".lower(),
-                )
-            },
             sw_version=self.firmware_version,
             model=self.model,
-            suggested_area="",  # was "Utility room",
             hw_version=None,
             manufacturer=self.manufacturer,
             # default_name=f"{text}",

--- a/docs/superpowers/plans/2026-07-18-code-review-remediation.md
+++ b/docs/superpowers/plans/2026-07-18-code-review-remediation.md
@@ -304,6 +304,6 @@ Mark tasks here as they land (edit this file in the same PR as the fix):
 
 - [x] C1  - [x] C2  - [x] C3
 - [ ] I1  - [x] I2  - [x] I3  - [ ] I3b  - [x] I4  - [x] I5  - [x] I6  - [x] I7  - [x] I8  - [ ] I9  - [ ] I10  - [x] I11
-- [x] M1  - [ ] M2  - [x] M3  - [x] M4  - [ ] M5  - [x] M6  - [x] M7  - [ ] M8  - [ ] M9  - [ ] M10  - [x] M11  - [ ] M12
+- [x] M1  - [x] M2  - [x] M3  - [x] M4  - [ ] M5  - [x] M6  - [x] M7  - [ ] M8  - [ ] M9  - [ ] M10  - [x] M11  - [ ] M12
 
 Recovery note (2026-07-18): this file was found deleted mid-session with no git history (it was never committed) and was reconstructed from the content captured earlier in the same conversation. If you're reading this and something looks off versus the actual code state, re-verify line numbers/snippets against the current `main` rather than trusting this doc blindly — several tasks (I11, M3, M4) landed after the original review and their line refs above are stale by design (see the note at the top of this section).


### PR DESCRIPTION
## Summary
- Removes the `connections={(DOMAIN, ...)}` entry from device info construction — `connections` is reserved for real physical connection identifiers (e.g. `CONNECTION_NETWORK_MAC`), not a second unique-id-shaped string; device identity is already established via `identifiers`.
- Omits `suggested_area` instead of passing `""` — an empty string suggests a blank-named area rather than "no suggestion".
- No behavior change: the four devices (`heatpump`/`heating`/`domestic_water`/`cooling`) still nest under the same hub via `identifiers`/`via_device`, untouched by this change.
- Resolves task M2 from `docs/superpowers/plans/2026-07-18-code-review-remediation.md`.

## Test plan
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `basedpyright` 0 errors
- [x] Full test suite passes (825 passed), coverage unchanged at 100%