### PR TITLE
fix(base): 🐛 return default instead of raising on non-numeric external sensor state

### DIFF
--- a/custom_components/luxtronik2/common.py
+++ b/custom_components/luxtronik2/common.py
@@ -232,15 +232,15 @@ def normalize_sensor_value(
 
 
 def state_as_number_or_none(state: State, default: float | None = None) -> float | None:
-    """Try to coerce our state to a number.
-
-    Raises ValueError if this is not possible.
-    """
+    """Try to coerce our state to a number, returning default if not possible."""
     if state is None:
         return default
     if state.state == STATE_UNAVAILABLE:
         return default  # state.state
-    result = state_as_number(state)
+    try:
+        result = state_as_number(state)
+    except ValueError:
+        return default
     return default if not isinstance(result, float) or result is None else result
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -338,6 +338,16 @@ class TestStateAsNumberOrNone:
         result = state_as_number_or_none(state)
         assert result == 42.5
 
+    def test_non_numeric_garbage_state(self):
+        state = MagicMock()
+        state.state = "N/A"
+        assert state_as_number_or_none(state) is None
+
+    def test_non_numeric_garbage_state_with_default(self):
+        state = MagicMock()
+        state.state = "N/A"
+        assert state_as_number_or_none(state, default=10.0) == 10.0
+
 
 # ===========================================================================
 # convert_to_int_if_possible


### PR DESCRIPTION
## 🐛 Bug

`state_as_number_or_none()` handled an external Home Assistant sensor being `unavailable` or `unknown`, but propagated an uncaught `ValueError` for any other non-numeric state text (e.g. `"N/A"`). That crash leaves the consuming entity's value stale until the next successful update instead of degrading gracefully like the other bad-input cases already do.

Affects both existing consumers of this helper:
- `climate.py`'s indoor-temperature external sensor override
- `sensor.py`'s new COP external power sensor override (#[external-power-sensor-for-cop branch])

## ✅ Fix

Catch `ValueError` from `state_as_number()` and return `default`, same as the `unavailable`/`unknown` branches.

## 🧪 Testing

- 2 new tests (`test_non_numeric_garbage_state`, `test_non_numeric_garbage_state_with_default`) added via TDD — confirmed they reproduce the crash before the fix, pass after.
- Full suite: 839 passed, 100% coverage on `custom_components.luxtronik2`, `ruff`/`basedpyright`/`codespell` all clean.

## 📝 Background

Flagged as a Minor, non-blocking follow-up during the final whole-branch review of the external-power-sensor-for-cop feature branch — this shared helper's gap predates that branch (already present in `climate.py`) but is worth hardening once for both call sites.