### PR TITLE
fix(number): fix dead TIMESTAMP_LAST_OVER comparison for last_thermal_desinfection

### DIFF
--- a/custom_components/luxtronik2/number.py
+++ b/custom_components/luxtronik2/number.py
@@ -221,17 +221,22 @@ class LuxtronikNumberEntity(LuxtronikEntity[LuxtronikNumberDescription], NumberE
         return attributes
 
     def formatted_data(self, attr: LuxtronikEntityAttributeDescription) -> str:
-        """Calculate the attribute value."""
+        """Calculate the attribute value.
+
+        Compares the raw attribute reading (e.g. DHW temperature) against
+        this entity's own already-scaled `_attr_native_value` (e.g. the DHW
+        thermal desinfection target) - not `_attr_state * factor`, which is
+        never populated for entities (the only real one,
+        DHW_THERMAL_DESINFECTION_TARGET) that don't declare a `factor`.
+        """
         if attr.format != SensorAttrFormat.TIMESTAMP_LAST_OVER:
             return super().formatted_data(attr)
         value = self._get_value(attr.luxtronik_key)
         if value is None:
             return ""
         if (
-            self._attr_state is not None
-            and self.entity_description.factor is not None
-            and float(value)
-            >= float(self._attr_state) * float(self.entity_description.factor)
+            self._attr_native_value is not None
+            and float(value) >= float(self._attr_native_value)
             and (
                 attr.key not in self._attr_cache
                 or self._is_past(self._attr_cache[attr.key])

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -215,7 +215,6 @@ class TestNumberFormattedData:
             key=SensorKey.HEATING_TARGET_CORRECTION,
             luxtronik_key=LP.P0001_HEATING_TARGET_CORRECTION,
             device_key=DeviceKey.heating,
-            factor=0.1,
         )
         entity = _make_number_entity(data, desc)
         attr = LuxtronikEntityAttributeDescription(
@@ -227,15 +226,18 @@ class TestNumberFormattedData:
         assert result == ""
 
     def test_timestamp_last_over_with_value_above_threshold(self):
+        """Regression: DHW_THERMAL_DESINFECTION_TARGET (the only real entity
+        using TIMESTAMP_LAST_OVER) declares no `factor` - the comparison
+        must work against `_attr_native_value` directly, not silently no-op
+        because `entity_description.factor` is None."""
         data = make_coordinator_data(parameters={"ID_Einst_WK_akt": 100})
         desc = LuxtronikNumberDescription(
             key=SensorKey.HEATING_TARGET_CORRECTION,
             luxtronik_key=LP.P0001_HEATING_TARGET_CORRECTION,
             device_key=DeviceKey.heating,
-            factor=0.1,
         )
         entity = _make_number_entity(data, desc)
-        entity._attr_state = 5.0  # 5.0 * 0.1 = 0.5, value=100 >= 0.5
+        entity._attr_native_value = 50.0  # value=100 >= 50.0
         attr = LuxtronikEntityAttributeDescription(
             key=SA.TIMER_HEATPUMP_ON,
             luxtronik_key=LP.P0001_HEATING_TARGET_CORRECTION,
@@ -245,16 +247,32 @@ class TestNumberFormattedData:
         # Should set cache and return today's date
         assert result != ""
 
+    def test_timestamp_last_over_below_threshold_stays_empty(self):
+        data = make_coordinator_data(parameters={"ID_Einst_WK_akt": 40})
+        desc = LuxtronikNumberDescription(
+            key=SensorKey.HEATING_TARGET_CORRECTION,
+            luxtronik_key=LP.P0001_HEATING_TARGET_CORRECTION,
+            device_key=DeviceKey.heating,
+        )
+        entity = _make_number_entity(data, desc)
+        entity._attr_native_value = 50.0  # value=40 < 50.0
+        attr = LuxtronikEntityAttributeDescription(
+            key=SA.TIMER_HEATPUMP_ON,
+            luxtronik_key=LP.P0001_HEATING_TARGET_CORRECTION,
+            format=SensorAttrFormat.TIMESTAMP_LAST_OVER,
+        )
+        result = entity.formatted_data(attr)
+        assert result == ""
+
     def test_timestamp_last_over_cached_result(self):
         data = make_coordinator_data(parameters={"ID_Einst_WK_akt": 100})
         desc = LuxtronikNumberDescription(
             key=SensorKey.HEATING_TARGET_CORRECTION,
             luxtronik_key=LP.P0001_HEATING_TARGET_CORRECTION,
             device_key=DeviceKey.heating,
-            factor=0.1,
         )
         entity = _make_number_entity(data, desc)
-        entity._attr_state = 5.0
+        entity._attr_native_value = 50.0
         entity._attr_cache[SA.TIMER_HEATPUMP_ON] = date(2099, 12, 31)
         attr = LuxtronikEntityAttributeDescription(
             key=SA.TIMER_HEATPUMP_ON,


### PR DESCRIPTION
## Summary
- `formatted_data()`'s `TIMESTAMP_LAST_OVER` branch required `entity_description.factor` to be set before comparing values — but `DHW_THERMAL_DESINFECTION_TARGET` (the only entity actually using `TIMESTAMP_LAST_OVER`) declares no `factor`, so the branch could never execute and `last_thermal_desinfection` stayed permanently `""`.
- Both the DHW temperature reading and the entity's own target are already real-unit Celsius (confirmed via a live diagnostics dump: raw `ID_Einst_LGST_akt` = `"60.0"`), so no factor-scaling belongs in the comparison at all. Now compares against the already-scaled `_attr_native_value` instead of `_attr_state * factor`.
- Follow-up to #718: after that merge/replace fix landed, the attribute became *present* on the live entity but stuck empty — found by fetching a user's live diagnostics dump and entity state.

## Test plan
- [x] `pytest --cov=custom_components.luxtronik2` — 857 passed, 100% coverage maintained
- [x] Rewrote `TestNumberFormattedData` tests to reflect real (factor-free) semantics; added a below-threshold case
- [x] `ruff check` / `ruff format --check` clean
- [x] `basedpyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)