### PR TITLE
docs: document previously-undocumented features across README and new guides

### DIFF
--- a/ADVANCED_FEATURES.md
+++ b/ADVANCED_FEATURES.md
@@ -1,0 +1,131 @@
+# Advanced Features
+
+This page documents integration features that go beyond the basic entity tables in [README.md](README.md) — things that are easy to overlook, easy to misunderstand, or only relevant to specific hardware configurations.
+
+## Integration Options
+
+Beyond the initial setup, this integration has an **Options** flow: go to **Settings → Devices & Services → Luxtronik → Configure** to reach it. It lets you change, after setup and without removing/re-adding the integration:
+
+- **External indoor temperature sensor** — replaces the heat pump's own room-thermostat reading (`Room Thermostat Temperature`) as the *current temperature* shown on the Heating climate entity, if you have a more accurate HA temperature sensor elsewhere in the house.
+- **External power consumption sensor** — see [COP calculation](#cop-calculation-and-the-external-power-sensor) below.
+- **Update interval** — how often the integration polls the heat pump for new data.
+
+## DHW Manual Frequency (Matching Compressor Power to Solar Surplus)
+
+The **DHW Manual Frequency** Number entity (Config category, enabled by default, 0–120 Hz) forces the compressor to run at a fixed frequency while heating DHW, instead of letting the heat pump's own control logic choose it:
+- **`0` = Automatic** — the heat pump picks the frequency itself (the normal/default behavior).
+- **`20`–`120` Hz** — the compressor is forced to run at (approximately) that fixed frequency for the whole DHW heating cycle.
+
+Because a modulating compressor draws roughly proportionally less power at a lower frequency, this can be used for solar self-consumption: setting a **lower** frequency than the heat pump would have chosen on its own draws less instantaneous power, but takes correspondingly **longer** to reach the DHW target temperature. That lets a DHW charge track a modest, steady solar surplus for a longer stretch of time instead of the heat pump defaulting to a short, higher-power burst that could exceed what your panels are producing and pull the difference from the grid.
+
+Two things worth knowing before relying on this:
+- **The actual frequency can land about 1 Hz below whatever you set.** This was confirmed empirically and discussed at length in [GitHub issue #674](https://github.com/BenPru/luxtronik/issues/674) — if you need to verify the real value, compare against the **Pump Frequency** sensor during a DHW run rather than trusting the setpoint alone.
+- **Remember to set it back to `0` (Automatic)** once you no longer have a surplus to chase — leaving a low fixed frequency in place on a cloudy day will make DHW heating take unnecessarily long, or fail to comfortably keep up with demand.
+
+## Heating Circuit Control Mode (Bypassing the Heating Curve)
+
+The **Heating circuit control mode** select entity (`select.<prefix>_heating_control_circuit_mode`, disabled by default, Config category) lets you change *how* the heat pump decides its flow/return target temperature for heating, with three options:
+- **Heating curve control - Controlled by outside temperature** (the normal/default mode): the heat pump calculates its own target from the heating curve parameters and current outdoor temperature — this is what the rest of this README assumes.
+- **Manual set temperature**: ignores the heating curve and outdoor temperature entirely, and instead uses a fixed target you set yourself via the **Manual target flow out temperature** Number entity (also disabled by default, 20–70°C).
+- **Analog in**: the target is driven by an external analog input wired to the controller — not further configurable from Home Assistant.
+
+This exists specifically for setups **without a room thermostat** that want to run the heat pump at a fixed flow/return temperature and build their own control logic on top (e.g. adjusting the manual target based on an indoor sensor and available solar power), instead of relying on the built-in outside-temperature-based curve. See [GitHub issue #482](https://github.com/BenPru/luxtronik/issues/482) for the original request and discussion this was built from.
+
+A few things worth knowing before using it:
+- **The Manual target flow out temperature (Number) and the Flow out target temperature (Sensor) are two different parameters.** The Number entity is what you write; the Sensor is the heat pump's own *calculated* current target, and it only catches up once the heat pump re-evaluates internally on its next poll (default every 60s — see [Integration Options](#integration-options) to poll faster if you need quicker feedback while testing). Seeing the sensor lag behind right after a change, or right after switching modes, is expected, not a sync bug.
+- **The heat pump still enforces its own configured maximum flow temperature** (set on the physical/installer panel) regardless of what you request through the Number entity — so this cannot push the system past whatever ceiling was configured during commissioning.
+- Because this fully replaces the built-in heating-curve regulation, treat it like the heating-curve parameters elsewhere in this README: avoid changing it frequently or aggressively via automations, since heat pumps are slow-reacting systems.
+
+## Room Thermostat (RBE) Type and What "Target Temperature" Means
+
+The Heating and Cooling climate entities' **Target Temperature** field does not always mean "desired room temperature" — what it actually controls depends on which room control unit (if any) is connected, detected from firmware parameter `P0033` (and, for RBE units specifically, the RBE's own firmware version):
+
+| Detected type | Heating Target Temperature | Cooling Target Temperature |
+| :--- | :--- | :--- |
+| None / RFV / RFV-K / RFV-DK / RBE older than firmware 2.0 | A **correction offset**, −5…+5 °C, added to the heating curve — the same value as the **Target Temperature Correction** Number entity. Not an absolute room temperature. | The **Minimal Outdoor Temperature** threshold that must be exceeded before cooling is allowed to run at all — an outdoor-air value, not a room or water temperature. |
+| RBE firmware 2.0+ ("RBE Plus"), or a directly reported "Smart" room unit | An actual **absolute desired room temperature**, read from and written to the room control unit itself. | Same absolute room-temperature parameter as Heating above — heating and cooling share one target, since both are driven by the same physical room unit. |
+
+In other words: with an older/no room control unit, moving the Heating climate card's target temperature is really nudging the *heating curve* up or down by a few degrees (exactly like the **Target Temperature Correction** Number entity, because it's the same parameter), and the Cooling card's target temperature is really setting the *outdoor temperature* cooling waits for, not a room or flow temperature. Only a newer RBE ("RBE Plus", firmware ≥ 2.0) or a "Smart" room unit turns these into genuine room-temperature setpoints.
+
+There is currently no dedicated entity showing which type your system has been detected as. To check it yourself, look at parameter `P0033` (`room_thermostat_type`) in a [diagnostics download](#diagnostics-download) — `0`/`1`/`2`/`3` are None/RFV/RFV-K/RFV-DK, `4` is RBE (check the RBE firmware version reported alongside it to tell old RBE from RBE Plus), and `5` is "Smart". The **Room Thermostat Temperature** and **Room Thermostat Target** sensors (if visible on your Heating device at all) confirm *some* room unit is connected, but not which behavior applies.
+
+## COP Calculation and the External Power Sensor
+
+The **Heating COP** and **DHW COP** sensors show an instantaneous coefficient of performance: current heat output divided by current power consumption. They only report a value while the heat pump is actively serving that circuit — otherwise they go `unavailable`, rather than show a stale or misleading ratio.
+
+By default the power consumption figure (the denominator) comes from the heat pump's own reading, which is not always accurate. In **Integration Options** you can point the *external power consumption sensor* setting at a separate Home Assistant power sensor (e.g. a smart plug or clamp meter monitoring the outdoor unit) instead. Two things this does **not** do:
+- It does not change what the regular "Current Power Consumption" sensor displays — only the COP calculation's denominator.
+- It does not affect the heat output (numerator) side of the calculation, which always comes from the heat pump itself.
+
+## EVU / Grid-Lock Status
+
+Many installations (mainly in Germany/Austria) let the electricity utility (EVU, *Energieversorgungsunternehmen*) force the compressor into a lockout for a period, in exchange for a cheaper tariff. When this happens, the **Status** sensor's text briefly shows a cryptic-looking suffix, e.g. `EVU until 42 min` while a lockout is active, or `EVU in 15 min` when one is about to start within the next 30 minutes. This is expected behavior, not a fault.
+
+The integration learns these lockout windows by observing the heat pump's own operating-mode transitions over time (it does not read a pre-configured EVU schedule from the controller) — so right after a Home Assistant restart, no EVU timing is known yet until at least one lockout has been observed. Once learned, the Status sensor also exposes extra attributes: first/second daily start and end time, which days of the week a lockout has been observed on, and minutes until the next event.
+
+**Smart Grid Status** is a related but separate sensor: it only reports a value while the *Smart Grid* switch (see [Smart Grid & Power Limitation](#smart-grid--power-limitation) below) is enabled, and shows one of four SG-ready states (`EVU locked` / `Reduced operation` / `Normal operation` / `Increased operation`) derived from the heat pump's two EVU input signals.
+
+## Firmware Update Entity
+
+The **Firmware** update entity checks Alpha Innotec's public download portal (once per hour) for a newer firmware build than the one currently installed, comparing versions semantically. If a newer version exists, its release notes panel shows: a link to the manufacturer's firmware page for your specific model, a direct download link, localized (German/English) update instructions, and the raw change log fetched from the portal.
+
+This entity is informational only — applying a firmware update is a manual, out-of-band process on the physical controller (typically via USB); the integration does not push or install firmware itself.
+
+Because many entities in this integration are only created when the connected hardware reports the corresponding feature as present, *or* when the firmware version meets that entity's minimum requirement, a firmware update can unlock previously-missing sensors and controls without any changes on the Home Assistant side. If an entity documented in README or here doesn't show up on your system, check whether a newer firmware version is available before assuming it isn't supported.
+
+## Diagnostics Download
+
+Home Assistant's built-in **Download diagnostics** action (from the integration's device page, or Settings → Devices & Services → Luxtronik → the "..." menu) produces a redacted dump containing:
+- every currently-known `parameter`, `calculation`, and `visibility` value read from the heat pump (name + raw value),
+- device info,
+- a partially-masked MAC address (only the vendor prefix is kept),
+- the integration's own **recent log records** (see below).
+
+This is the most useful thing to attach to a bug report or support request, since it captures the exact raw values the integration saw at that moment, without needing you to manually list them.
+
+### Log records in diagnostics
+
+The diagnostics dump also embeds the last ~1000 log lines this integration itself has logged (`log_records`), so you don't need to separately enable debug logging, reproduce, and download a system log file just to attach it to a bug report — one diagnostics download covers both.
+
+This works by keeping an in-memory ring buffer attached directly to the integration's logger (see [log_capture.py](custom_components/luxtronik2/log_capture.py)), populated from the moment Home Assistant loads the integration. A few things worth knowing:
+- It only ever contains what your logging configuration already let through. If you haven't enabled debug logging for this integration, the buffer mostly contains warnings/errors, not the detailed `LOGGER.debug(...)` trace most bug reports actually need — **enable debug logging, reproduce the issue, then download diagnostics**, in that order.
+- Because a restart re-loads the integration (and the buffer) from scratch, this also captures **startup-time** problems, as long as debug logging was already enabled *before* the restart that reproduces them.
+- The configured host/IP is scrubbed from log lines before being included (replaced with `**REDACTED_HOST**`), the same way the rest of the diagnostics payload is redacted. This is a best-effort, targeted substitution — not full log redaction — so still skim the download before posting it publicly if you're unsure.
+
+## Away / Holiday Scheduling
+
+Heating and DHW each have a pair of **Date** entities (Away/Holiday Start Date and End Date), settable independently for each circuit. The underlying firmware parameter names are symmetric — `Fstd` (*Ferien-Start-Datum*, holiday start date) and `Frkd` (*Ferien-Rückkehr-Datum*, holiday return date) — which means this isn't just an end-date safety net: you can set a **future** start date and the heat pump will switch itself into Holiday mode on that date and automatically switch back to Automatic on the return date, with no manual mode change needed on either end. This lets you pre-schedule an entire vacation period in advance.
+
+This is in addition to the *Mode* select/water heater entities documented in README, which switch straight to Holiday mode immediately. Because heating and DHW have separate date pairs, you can schedule DHW's holiday period (e.g. while away) without also disabling space heating, or vice versa.
+
+> **ℹ️ Note:** The exact interaction between an in-progress manual mode change and a still-pending scheduled date hasn't been verified against a physical unit; if you rely on this for unattended scheduling, check the *Mode* entity's actual state once the start date arrives.
+
+## Second Heat Generator (Backup Electric Heater)
+
+Two config entities (disabled by default, category *Configuration*) control when the secondary/backup heat generator — typically an electric immersion heater — is allowed to assist the heat pump:
+- **Release Second Heat Generator**: the outdoor temperature (range −20…20 °C) below which the backup heater is allowed to engage.
+- **Release Time Second Heat Generator**: how long (20–120 minutes) the heat pump must be unable to keep up before the backup heater is allowed to kick in.
+
+Both entities — and the **Additional Heat Generator** running-state binary sensor — only appear if your unit reports having a second heat generator installed. Setting the temperature threshold too high, or the delay too short, causes the backup heater to engage more often than necessary, increasing electricity cost; setting them too conservatively risks insufficient heat output during cold snaps.
+
+## Defrost (De-icing)
+
+Air-source heat pumps periodically defrost their outdoor unit by briefly reversing the refrigerant cycle. Two binary sensors reflect this: **Defrost Valve** (the reversing valve is open) and **Defrost End / Flow OK** (the defrost cycle completed with acceptable flow). Seeing these toggle, or the heat pump's Status sensor briefly showing "Defrost", is normal periodic behavior on air/water systems — not a fault — and typically lasts a few minutes.
+
+## Solar Thermal Collector
+
+If your system has an integrated **solar thermal collector** feeding the DHW tank (not to be confused with solar PV / electricity generation, which this integration doesn't monitor directly), several entities appear under the DHW device once the heat pump reports a collector is present:
+- **Solar Collector** / **Solar Buffer** temperature sensors,
+- **Solar Pump** running-state binary sensor and its operating-hours counter,
+- Configuration numbers for the solar pump's on/off temperature-difference thresholds (collector vs. tank) and the maximum collector temperature.
+
+## PV Mode Selector
+
+The **PV Mode** select entity (disabled by default) controls how the heat pump reacts to a PV (solar electricity) surplus signal, with options `Automatic`, `PV Off`, `Pool Off`, `Pool Party`, and `Pool Holidays`. This is separate from the Heating/DHW *Mode* selects already documented in README, and separate from the Solar Thermal Collector entities above — it specifically governs pool behavior tied to a PV surplus input, not the heat pump's general operating mode.
+
+## Smart Grid & Power Limitation
+
+- **Smart Grid** (switch, config category): enables/disables the heat pump's SG-ready integration as a whole. When on, the **Smart Grid Status** sensor (see [EVU / Grid-Lock Status](#evu--grid-lock-status)) becomes available.
+- **Power limitation** / **Max. thermal power** (switches, disabled by default): turn on enforcement of the numeric power-limit entities below them (electrical power limit value; thermal power limits for heating/water/cooling) — the switches gate whether the limits are enforced at all, the number entities set the actual limit values.
+
+Like the heating-curve parameters mentioned in README §3.2, these are typically set once during commissioning; avoid toggling them frequently via automations.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you like this project, give it a ⭐, or sponsor the developers:
 * Project creator: [BenPru](https://github.com/sponsors/BenPru).
 * Current developer: [rhammen](https://github.com/sponsors/rhammen).
 
-It takes a lot of time and effort to keep up with changes (Home Assistant and Luxtronik Firmware). BenPru has handed over the project to the community fos us to maintain. This means the project depends on you to submit issues and work with the community's developers to improve the integration. 
+It takes a lot of time and effort to keep up with changes (Home Assistant and Luxtronik Firmware). BenPru has handed over the project to the community fos us to maintain. This means the project depends on you to submit issues and work with the community's developers to improve the integration. See [REPORTING_ISSUES.md](REPORTING_ISSUES.md) for how to file a bug report that's actionable on the first pass.
 
 Big thanks to [all community members](https://github.com/BenPru/luxtronik/graphs/contributors) who have contributed to this project. 
 
@@ -63,27 +63,40 @@ Click the button below to automatically add the custom repository to HACS:
 1. **Auto-discovery:** Home Assistant should automatically discover your heat pump. Check the **Settings -> Devices & Services** page and click **Configure**.
 2. **Manual Addition:** If auto-discovery fails, click **Add Integration** in the bottom right corner, search for **Luxtronik**, and enter the IP address of your heat pump manually. *(Tip: Ensure the heat pump has a static IP in your router).*
 
+### Step 4 (optional): Configure Integration Options
+
+After setup, **Settings → Devices & Services → Luxtronik → Configure** lets you set an external indoor temperature sensor, an external power sensor for more accurate COP readings, and the polling interval. See [Advanced Features: Integration Options](ADVANCED_FEATURES.md#integration-options).
+
 ---
 
 ## 2 Using Luxtronik
 
 Entities and actions are organized into four logical devices in Home Assistant to keep things structured. Here is an overview of what each device does and how to use the most common entities.
 
+> **ℹ️ Note:** Not every entity documented below will exist on every installation. Each one is only created if your specific heat pump reports the corresponding feature as present (e.g. a solar collector, a second heat generator, cooling capability) or its firmware version meets that entity's minimum requirement. This means **updating your heat pump's firmware can make additional sensors and controls appear** in Home Assistant that weren't there before — if you're missing an entity mentioned here, check whether a firmware update is available (see [Advanced Features: Firmware Update Entity](ADVANCED_FEATURES.md#firmware-update-entity)) before assuming it's unsupported.
+
 ### 2.1 Heatpump
 This device represents the physical heat pump unit. It contains sensors and diagnostic entities such as electrical power consumption, thermal power output, operating hours, and current status.
 
 **Most important entities:**
-- **Status:** Shows whether the heat pump is heating, cooling, making hot water, or idle.
+- **Status:** Shows whether the heat pump is heating, cooling, making hot water, or idle. If your utility provider can force the compressor into a lockout period (EVU), the status text also briefly shows a countdown like "EVU until 42 min" — see [Advanced Features: EVU / Grid-Lock Status](ADVANCED_FEATURES.md#evu--grid-lock-status).
 - **Power Consumption Sensors:** Ideal for tracking energy usage if your model supports it.
 - **Errors/Lockouts:** Alerts if your heat pump is in an error state.
+- **Firmware:** An Update entity that checks for newer firmware; see [Advanced Features: Firmware Update Entity](ADVANCED_FEATURES.md#firmware-update-entity).
+
+> **ℹ️ Tip:** If you need to report a bug, use Home Assistant's built-in **Download diagnostics** action on this integration first — see [Advanced Features: Diagnostics Download](ADVANCED_FEATURES.md#diagnostics-download).
+
+Depending on your hardware, you may also see PV-linked pool control, Smart Grid / power-limitation switches, or a second (backup) heat generator's settings on this device — see [Advanced Features](ADVANCED_FEATURES.md) for those.
 
 ### 2.2 Heating
 This device controls the space heating functionality (e.g., underfloor heating or radiators).
 
 **Most important entities & actions:**
-- **Heating Climate Entity (`climate.heating`):** The primary thermostat to view the current operation mode and adjust the target temperature.
+- **Heating Climate Entity (`climate.heating`):** The primary thermostat to view the current operation mode and adjust the target temperature. **What "Target Temperature" actually means depends on your room control unit** — with an older/no room unit it's a −5…+5°C correction offset on the heating curve (same value as *Target Temperature Correction* below); with a newer RBE ("RBE Plus") or "Smart" room unit it's a real desired room temperature. See [Advanced Features: Room Thermostat (RBE) Type](ADVANCED_FEATURES.md#room-thermostat-rbe-type-and-what-target-temperature-means).
 - **Heating Operation Mode:** Choose between Automatic, Second Heatsource, Party (boost), Holidays (reduced), or Off.
 - **Target Temperature Correction:** Quickly bump the heating target up or down by a few degrees without altering the main heating curve.
+- **Away/Holiday Start & End Date:** Pre-schedule a future Holiday period — the heat pump switches into Holiday mode on the start date and back to Automatic on the end date automatically — see [Advanced Features: Away / Holiday Scheduling](ADVANCED_FEATURES.md#away--holiday-scheduling).
+- **Heating Circuit Control Mode** *(disabled by default)*: switches the heat pump between its normal outside-temperature heating curve and a fixed manual flow/return target temperature — useful if you don't have a room thermostat and want to build your own control logic. See [Advanced Features: Heating Circuit Control Mode](ADVANCED_FEATURES.md#heating-circuit-control-mode-bypassing-the-heating-curve).
 
 ### 2.3 Cooling
 If your heat pump supports active or passive cooling, this device manages it.
@@ -91,18 +104,19 @@ If your heat pump supports active or passive cooling, this device manages it.
 Basic entities:
 | Name | Entity Type | Units | Description |
 | :--- | :--- | :--- | :--- |
-| **Cooling** | Climate | &deg;C | The climate entity combines several of the entities below into a combined climate entity. It shows the current temperature and controls the *Cooling Mode* and *Cooling Target Temperature* (in case no thermostat is present) or *Room Thermostat Target* (in case a thermostat is present). Note: Cooling does not aim for the target temperature in the same way heating does. |
-| **Cooling** | Select / Switch | on/off | Controls the state. "Off" disables cooling, while "On" allows cooling depending on the *Approval*, *Minimal Outdoor Temperture* and *Room Thermostat Target Temperature* entities. |
-| **Cooling Target Temperature** | Number | &deg;C | The target water temperature sent into the house. This value is ignored if cooling is based on outdoor temperature. |
+| **Cooling** | Climate | &deg;C | The climate entity combines several of the entities below into a combined climate entity. It shows the current temperature and controls the *Cooling Mode*. **Its Target Temperature field is not a room/water setpoint unless a newer RBE Plus or Smart room unit is connected** — with an older/no room unit it's actually the same value as the *Minimal Outdoor Temperature* entity below (an outdoor-air threshold). See [Advanced Features: Room Thermostat (RBE) Type](ADVANCED_FEATURES.md#room-thermostat-rbe-type-and-what-target-temperature-means) for the full breakdown. Note: Cooling does not aim for the target temperature the way heating does even in the room-temperature case. |
+| **Cooling** | Select / Switch | on/off | Controls the state. "Off" disables cooling, while "On" allows cooling depending on the *Approval*, *Minimal Outdoor Temperature* and *Room Thermostat Target Temperature* entities. |
 | **Approval** | Binary Sensor | - | Indicates if cooling is unlocked by the heat pump based on various factors such as outdoor temperature and room temperature. Consult the manual for more details |
 
 Advanced entities:
 | Name | Entity Type | Units | Description |
 | :--- | :--- | :--- | :--- |
 | **Cooling Minimal Flow Temperature** | Number | &deg;C | The minimal water temperature used for activating cooling. Default 18&deg;C. |
-| **Minimal Outdoor Temperature** | Number | &deg;C | The minimal outdoor temperature which needs to be exceeded for a) the duration of the *start delay* or b) by 5&deg;C. |
-| **Start Delay** | Number | h | Duration the minimal outdoor temperature must be exceeded before cooling starts. |
-| **Stop Delay** | Number | h | Duration the minimal outdoor temperature must no longer be met before cooling stops. |
+| **Minimal Outdoor Temperature** | Number | &deg;C | The outdoor temperature threshold that must be exceeded before cooling is allowed to start. |
+| **Start Delay** | Number | h | How long the outdoor temperature must stay above *Minimal Outdoor Temperature* before cooling actually starts (0–12h) — a debounce so a brief warm spell doesn't trigger cooling. **Bypassed entirely if the outdoor temperature exceeds the threshold by more than 5°C at once** — in that case cooling starts immediately regardless of this delay. |
+| **Stop Delay** | Number | h | How long the outdoor temperature must stay back below *Minimal Outdoor Temperature* before cooling actually stops (0–12h) — prevents rapid on/off cycling right at the threshold. |
+
+> **ℹ️ Note:** Cooling is always the lowest-priority demand on the heat pump — e.g. an active DHW heating demand will interrupt or block cooling regardless of how *Start Delay*/*Stop Delay*/*Minimal Outdoor Temperature* are set. If *Approval* never turns on despite the outdoor temperature clearly qualifying, check for a competing demand first.
 
 > **⚠️ Important:** If the cooling target temperature is set too low, condensation can form on floor tiles, pipes, and inside the heat pump. A brine heat pump should generally not use a target temperature below 18°C to avoid damage. Consult your manual for details.
 
@@ -141,7 +155,7 @@ action:
 ```
 </details>
 
-The amount of cooling can be controlled with *Cooling Target Temperature* when the heatpump is configured to cool based on fixed temperature ([page 17](https://mw.ait-group.net/files/docs/EN/A0220/83055400.pdf)).
+The amount of cooling can be controlled with the Cooling climate entity's *Target Temperature* when the heatpump is configured to cool based on fixed temperature ([page 17](https://mw.ait-group.net/files/docs/EN/A0220/83055400.pdf)) — remember its meaning depends on your room control unit, per the note above.
 
 ### 2.4 DHW (Domestic Hot Water)
 This device controls the boiler/tank for your tap water.
@@ -160,9 +174,17 @@ Advanced entities:
 | :--- | :--- | :--- | :--- |
 | **Hysteresis** | Number | °C | The difference between the *DHW Current Temperature* and *DHW Target Temperature* before the water is heated up gain to the *DHW Target Temperature*. |
 | **Thermal Desinfection Target Temperature** | Number | °C | Target temperature for Thermal Disinfection cycle. |
-| **Thermal Desinfection Day** | Select | Day | The day on which the thermal disinfection cycle is performed. |
+| **Thermal Desinfection Day** | Select | Day | The day on which the thermal disinfection cycle is performed, or `continuous` to make every DHW heating cycle eligible (see the on-demand trick below). The heat pump runs the cycle at its own fixed nightly time on that day — this integration cannot change *when* it runs, only *which day(s)*. |
+| **DHW Manual Frequency** | Number | Hz | Forces the compressor to a fixed frequency during DHW heating instead of the heat pump's own automatic choice (`0` = Automatic). Useful for solar self-consumption — see [Advanced Features: DHW Manual Frequency](ADVANCED_FEATURES.md#dhw-manual-frequency-matching-compressor-power-to-solar-surplus). |
+| **Away/Holiday Start & End Date** | Date | - | Pre-schedule a future DHW Holiday period (auto start and return), independent of the Heating device's own dates — see [Advanced Features: Away / Holiday Scheduling](ADVANCED_FEATURES.md#away--holiday-scheduling). |
 
-> **ℹ️ Note:** It is not possible to trigger a thermal disinfection cycle on demand. It can be emulated by raising the *DHW Target Temperature*. 
+> **ℹ️ Note:** It is not possible to trigger a thermal disinfection cycle on demand, or move it off its fixed nightly time, using the *Thermal Desinfection Day* select alone. It can be emulated at a time of your choosing by temporarily setting *Thermal Desinfection Day* to `continuous` and raising the *DHW Target Temperature* to the *Thermal Desinfection Target Temperature* value — this makes the heat pump's normal (immediate) heating logic reach disinfection temperature right away, instead of waiting for its own nightly schedule. See the *Legionella prevention using solar power* example below. The **Thermal Desinfection Target Temperature** entity also exposes a `last_thermal_desinfection` timestamp attribute (last time the DHW temperature rose above that target), handy for gating an automation like the example to "at most once a week".
+
+If your system has an integrated **solar thermal collector** feeding the DHW tank, extra temperature/pump entities appear automatically — see [Advanced Features: Solar Thermal Collector](ADVANCED_FEATURES.md#solar-thermal-collector).
+
+#### DHW Timer Schedule (Blocking Times)
+
+DHW also supports an editable weekly schedule of **blocking times** — windows during which automatic DHW heating is switched off, exposed as a set of Text entities. See **[TIMER_SCHEDULES.md](TIMER_SCHEDULES.md)** for the entity list, the `HH:MM-HH:MM/...` format, and an important note on how DHW's blocking-time semantics differ from the heating schedule.
 
 #### 3.1.2 Automating DHW
 Automations for DHW typically use the water heater entity or the Party/Boost mode. Common scenarios include pre-heating before showers, using excess solar energy to heat the tank.
@@ -177,7 +199,7 @@ trigger:
     above: 2000
     for: "00:05:00"
     id: "solar_high"
-    - platform: numeric_state
+  - platform: numeric_state
     entity_id: sensor.solar_power
     below: 2000
     for: "00:10:00"
@@ -198,6 +220,67 @@ action:
         data:
           temperature: 54
 ```
+</details>
+
+<details>
+<summary>⚙️ Example: Legionella prevention (thermal disinfection) using solar power instead of midnight</summary>
+
+The heat pump's built-in thermal disinfection cycle always runs at a fixed nightly time on whichever *Thermal Desinfection Day* is configured — there's no entity to change *when* it runs. This automation instead triggers a disinfection-grade heating cycle around midday, when solar production is typically highest, by temporarily switching *Thermal Desinfection Day* to `continuous` and raising the *DHW Target Temperature* to the disinfection target — which makes the heat pump's normal, immediate heating logic do the work instead of waiting for the nightly schedule. It uses the `last_thermal_desinfection` attribute (on the *Thermal Desinfection Target Temperature* entity) to only run once a week, and reverts both settings afterwards so normal DHW operation resumes.
+
+> **ℹ️ Note:** The weekly-gate condition treats a never-yet-recorded `last_thermal_desinfection` (i.e. its value is empty/unknown) as "overdue," not "skip." If you built this before ever running it once, `last_thermal_desinfection` starts out empty and stays that way until the very first successful run — an `and`-style condition that *requires* a real timestamp before proceeding would never let that first run happen at all.
+
+```yaml
+alias: "Legionella prevention using solar power"
+description: "Run thermal disinfection around midday to use solar power, instead of the heat pump's fixed nightly schedule"
+trigger:
+  - platform: time
+    at: "11:45:00"
+condition:
+  - condition: state
+    entity_id: select.luxtronik2_dhw_mode
+    state: "automatic"
+  - condition: template
+    value_template: >
+      {% set last = state_attr('number.luxtronik2_dhw_thermal_desinfection_target', 'last_thermal_desinfection') %}
+      {{ last in [None, 'unknown', 'unavailable', ''] or
+         (as_timestamp(now()) - as_timestamp(last)) > (7 * 24 * 3600) }}
+action:
+  - action: select.select_option
+    target:
+      entity_id: select.luxtronik2_thermal_desinfection_day
+    data:
+      option: "continuous"
+  - delay:
+      seconds: 10
+  - action: number.set_value
+    target:
+      entity_id: number.luxtronik2_dhw_target_temperature
+    data:
+      value: 57  # match your Thermal Desinfection Target Temperature
+  - wait_for_trigger:
+      - platform: numeric_state
+        entity_id: sensor.luxtronik2_dhw_temperature
+        above: number.luxtronik2_dhw_thermal_desinfection_target
+        for:
+          minutes: 1
+    timeout:
+      hours: 5
+  - action: select.select_option
+    target:
+      entity_id: select.luxtronik2_thermal_desinfection_day
+    data:
+      option: "none"
+  - delay:
+      seconds: 10
+  - action: number.set_value
+    target:
+      entity_id: number.luxtronik2_dhw_target_temperature
+    data:
+      value: 50  # restore your normal DHW target temperature
+```
+
+> **ℹ️ Note:** The `57`/`50` values above must match your own *Thermal Desinfection Target Temperature* and normal *DHW Target Temperature* settings. The `wait_for_trigger` has a 5-hour timeout so the automation still reverts the temporary settings even if the target is never reached (e.g. insufficient solar that day).
+
 </details>
 
 ---
@@ -237,10 +320,11 @@ data:
 To protect your system from accidental misconfiguration, several advanced configuration parameters are **disabled by default**. They can be enabled manually from the Home Assistant entity registry if you need them.
 
 **These advanced entities include:**
-- **Thermal & Electrical Power Limits:** Used to throttle the heat pump's maximum power output.
-- **Heating Curve Parameters:** (End temperature, Parallel shift, Night offset) These define how the heat pump reacts to outdoor temperatures. They are typically configured once during commissioning by your installer.
+- **Thermal & Electrical Power Limits:** Switches gate whether power limiting is enforced at all; separate Number entities set the actual limit values. Used to throttle the heat pump's maximum power output. See [Advanced Features: Smart Grid & Power Limitation](ADVANCED_FEATURES.md#smart-grid--power-limitation).
+- **Heating Curve Parameters:** (End temperature, Parallel shift, Night offset) These define how the heat pump reacts to outdoor temperatures. They are typically configured once during commissioning by your installer. Use [mnemotron.de's heating curve visualizer](https://mnemotron.de/lux/heatcurve.html) to plot the exact resulting curve for your parameter values before changing them.
 - **Heating Threshold Temperature:** The outdoor temperature above which the heating completely stops.
-- **Second Heat Generator Settings:** Rules for when the backup electric heater is allowed to engage.
+- **Second Heat Generator Settings:** The outdoor temperature and delay that determine when the backup electric heater is allowed to engage. See [Advanced Features: Second Heat Generator](ADVANCED_FEATURES.md#second-heat-generator-backup-electric-heater).
+- **Smart Grid / PV Mode:** Controls tied to SG-ready and PV-surplus signals — see [Advanced Features](ADVANCED_FEATURES.md#smart-grid--power-limitation).
 
 > **Tip:** Do not modify the heating curve or power limits frequently via automations. Heat pumps are slow-reacting systems and perform best when left running with stable parameters.
 
@@ -248,6 +332,8 @@ To protect your system from accidental misconfiguration, several advanced config
 
 Not all heat pumps have built-in electrical energy metering. Some only show the thermal energy produced but not the electricity consumed. 
 If you want to accurately measure the SCOP (Seasonal Coefficient of Performance) of your device, consider adding an external energy meter. Devices like Shelly offer a [16A power plug](https://www.shelly.com/en-nl/products/product-overview/1xplug) or [in-line/clamp energy meters](https://www.shelly.com/en-nl/products/energy-metering-energy-efficiency) that integrate perfectly with Home Assistant.
+
+The **Heating COP** and **DHW COP** sensors report an instantaneous efficiency ratio, and can use such an external meter directly as their power-consumption input instead of the heat pump's own reading — see [Advanced Features: COP Calculation and the External Power Sensor](ADVANCED_FEATURES.md#cop-calculation-and-the-external-power-sensor).
 
 ---
 
@@ -258,5 +344,9 @@ In case of connectivity or data issues, please perform the following steps first
 2. Ensure the heat pump has a **Static IP address** configured in your router.
 3. Update to the **latest (beta) version** of this integration in HACS.
 4. If issues persist, enable debug logging for this integration and check the Home Assistant logs.
+
+**Missing an entity mentioned in this README?** It may simply not be created for your unit — see the note at the top of [§2 Using Luxtronik](#2-using-luxtronik) about hardware- and firmware-gated entities, and consider checking for a firmware update.
+
+**Still stuck?** See **[REPORTING_ISSUES.md](REPORTING_ISSUES.md)** for how to file a bug report that includes everything needed to diagnose it (diagnostics download + debug logs) in one pass.
 
 *For detailed parameter reference, see the [Loxwiki Luxtronik Java Web Interface](https://loxwiki.atlassian.net/wiki/spaces/LOX/pages/1533935933/Java+Webinterface) or the [Bouni/python-luxtronik](https://github.com/Bouni/python-luxtronik/blob/master/luxtronik/parameters.py) repository.*

--- a/REPORTING_ISSUES.md
+++ b/REPORTING_ISSUES.md
@@ -1,0 +1,34 @@
+# Reporting Issues
+
+Found a bug, or something behaving unexpectedly? Please file it as a [GitHub Issue](https://github.com/BenPru/luxtronik/issues) on this repository. This page explains what to include so it can be diagnosed without a back-and-forth.
+
+## Before opening an issue
+
+1. Check the [Troubleshooting section](README.md#4-troubleshooting) in README first — connectivity issues are usually a heat pump restart or a missing static IP.
+2. Search [existing issues](https://github.com/BenPru/luxtronik/issues?q=is%3Aissue) for your symptom; your heat pump model or firmware version may already be a known case.
+3. Make sure you're on the **latest (beta) version** of the integration in HACS — the bug may already be fixed.
+
+## What to include
+
+A useful bug report needs one file plus a bit of context — no need to separately dig up system logs.
+
+### 1. Diagnostics download (covers both state and logs)
+
+1. Go to **Settings → Devices & Services → Luxtronik**, open the ⋮ menu, and choose **Enable debug logging**.
+2. Reproduce the issue (trigger the automation, change the setting, restart Home Assistant if the issue happens at startup, etc.).
+3. Go to **Settings → Devices & Services → Luxtronik**, open the device, and use **Download diagnostics** (⋮ menu).
+
+This produces a single redacted JSON file containing every parameter/calculation/visibility value the integration currently has for your heat pump, device info, **and** the integration's own recent log records — so it captures both the exact raw state the integration saw *and* what happened while the bug occurred. See [Advanced Features: Diagnostics Download](ADVANCED_FEATURES.md#diagnostics-download) for exactly what it contains and what's redacted.
+
+Step 1 (enabling debug logging) matters — without it, the embedded log records are mostly warnings/errors, not the detailed trace most bug reports need. If the bug only happens at startup, enable debug logging *before* the restart that reproduces it.
+
+### 2. Context
+
+Beyond that one file, please describe:
+- **Heat pump model/manufacturer** (e.g. Alpha Innotec, Nibe, Novelan) and firmware version — both visible on the **Firmware** update entity, see [Advanced Features](ADVANCED_FEATURES.md#firmware-update-entity).
+- **What you expected** vs. **what happened**, and the exact steps to reproduce.
+- Whether the behavior is new (regression after an update) or has always been present.
+
+## Privacy note
+
+The diagnostics download redacts your host/IP, credentials, and unique identifiers, and only keeps the MAC address's vendor prefix (see `TO_REDACT` in [diagnostics.py](custom_components/luxtronik2/diagnostics.py)). The embedded log records have the same host/IP scrubbed out, but that's a targeted substitution, not full redaction — skim them before attaching if you're concerned about anything else sensitive appearing (this integration doesn't log credentials, but always worth a quick check).

--- a/TIMER_SCHEDULES.md
+++ b/TIMER_SCHEDULES.md
@@ -1,0 +1,45 @@
+# Timer Schedules
+
+Several circuits on the heat pump controller can be programmed with a weekly schedule directly on the controller (or its firmware's built-in web interface). This integration exposes those schedules as editable Home Assistant entities so they can be read and changed without touching the physical controller.
+
+Only the **DHW (Bw)** circuit is wired up so far. The other five timer-program circuits — heating (Hkr), mixing circuits 1/2 (Mk1/Mk2), circulation pump (ZIP), and pool (Swb) — are intentionally deferred until the DHW implementation has been validated in the field; see [Extending to other circuits](#extending-to-other-circuits) below.
+
+## DHW Timer Schedule (Blocking Times)
+
+The heat pump controller can be programmed with a weekly schedule of **blocking times** for DHW. Unlike a heating schedule (which defines when heating is *raised*), a DHW schedule window is a **"do not heat" window**: during a configured time span, automatic DHW heating is switched off; outside those spans it runs normally according to the *Mode* setting (see [README § 2.4 DHW](README.md#24-dhw-domestic-hot-water)). If you need hot water during an active blocking window, switch *Mode* to *Party* to override it temporarily (see the README's [Automating DHW](README.md#312-automating-dhw) section, *Boost hot water* example).
+
+The controller supports three mutually-exclusive schedule shapes for DHW, up to 5 blocking windows per day each:
+- **Week** – one schedule applies to every day.
+- **Weekday / Weekend** ("5+2") – one schedule for Monday-Friday, a separate one for Saturday-Sunday.
+- **Per day** – an independent schedule for each individual day of the week.
+
+Only one shape is active at a time. Which shape is active is selected on the physical controller (or its web interface) — this integration does not yet expose a control for that selector, only for editing the time windows themselves.
+
+| Name | Entity Type | Description |
+| :--- | :--- | :--- |
+| **DHW Timer Schedule (Week)** | Text | Editable only while the *Week* shape is active. |
+| **DHW Timer Schedule (Weekdays)** | Text | Editable only while *Weekday/Weekend* is active; covers Monday-Friday. |
+| **DHW Timer Schedule (Weekend)** | Text | Editable only while *Weekday/Weekend* is active; covers Saturday-Sunday. |
+| **DHW Timer Schedule (Monday)** … **(Sunday)** | Text | One entity per day of the week, editable only while *Per day* is active. |
+
+Each entity holds up to 5 blocking windows as a single string of `HH:MM-HH:MM` pairs separated by `/`, for example:
+```
+12:00-13:00/22:00-23:30
+```
+This blocks DHW heating over lunch (12:00-13:00) and in the evening (22:00-23:30). Set the value to an empty string to clear all blocking windows for that entity. Entities belonging to a schedule shape other than the one currently active on the controller show as `unavailable` — this is expected, not an error.
+
+## Extending to other circuits
+
+The remaining five timer-program circuits share the same underlying shape (mode selector + Week/5+2/Per-day time blocks), just with different parameter-name prefixes and row counts:
+
+| Circuit | Mode selector | Rows/day |
+| :--- | :--- | :--- |
+| Heating (Hkr) | `ID_Einst_SuHkr_akt` | 3 |
+| Mixing circuit 1 (Mk1) | `ID_Einst_SuMk1_akt` | 3 |
+| Mixing circuit 2 (Mk2) | `ID_Einst_SuMk2_akt` | 3 |
+| Circulation pump (ZIP) | `ID_Einst_SuZIP_akt` | 5 |
+| Pool (Swb) | `ID_Einst_SuSwb_akt` | 3 |
+
+Adding one is additive: define a `_TimerCircuit` in `timer_schedule_entities_predefined.py` (mirroring `_DHW_CIRCUIT`) with that circuit's selector name, row count, and `WO`/`25`/`TG` parameter prefixes, then call `_build_circuit_entities` with a matching set of `SensorKey` entries and translations. No changes to `text.py` itself should be needed — its logic is already generic per `LuxtronikTimerScheduleTextDescription`.
+
+Unlike DHW, the heating/mixing/pool circuit schedules define when the circuit is *raised* (comfort setback), not blocking times — the semantics are the opposite of DHW's "Sperrzeiten". Confirm the correct direction for each circuit against the controller manual before writing its documentation, rather than assuming DHW's polarity applies uniformly.


### PR DESCRIPTION
## Summary
- Add **TIMER_SCHEDULES.md**: DHW timer-program schedule (blocking-time semantics, week/weekday-weekend/per-day shapes, `HH:MM-HH:MM/...` format).
- Add **ADVANCED_FEATURES.md**: Integration Options, COP calculation and the external power sensor, EVU/grid-lock status, firmware update entity and diagnostics download (including embedded log records), away/holiday scheduling, second heat generator, defrost, solar thermal collector, PV mode selector, Smart Grid/power limitation, room thermostat (RBE) type and what "Target Temperature" means, heating circuit control mode, and DHW manual frequency for solar self-consumption.
- Add **REPORTING_ISSUES.md**: how to file an actionable bug report using a single diagnostics download instead of separately hunting logs.
- Update **README.md**: cross-link the above from the relevant device sections, correct the Cooling entity table's framing of Target Temperature/Minimal Outdoor Temperature, add Start/Stop Delay and the 5°C bypass-rule mechanics, add a Legionella-prevention-via-solar DHW automation example (verified against a real automation, including a fix for a never-recorded-timestamp catch-22 in its condition), and fix a pre-existing YAML indentation bug in the "Preheat DHW using solar power" example.

## Test plan
- [x] All new/edited Markdown reviewed for accuracy against current code (`const.py`, `coordinator.py`, `number.py`, `evu_helper.py`, `config_flow.py`, etc.)
- [x] `codespell` clean on all touched/added files
- [x] All `yaml` code fences parse (`yaml.safe_load`)
- [x] Internal anchor links verified against GitHub's heading-slug algorithm
- [x] The Legionella-prevention automation example verified live against a real Home Assistant instance (including the empty-attribute condition fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)