### PR TITLE
fix(translations): 🐛 fill missing timer-schedule and exception translations

### DIFF
--- a/.github/scripts/check_translation_coverage.py
+++ b/.github/scripts/check_translation_coverage.py
@@ -21,6 +21,7 @@ ENTITY_CHECKS = [
     ("date_entities_predefined.py", "date"),
     ("select_entities_predefined.py", "select"),
     ("switch_entities_predefined.py", "switch"),
+    ("timer_schedule_entities_predefined.py", "text"),
 ]
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -164,7 +165,9 @@ def find_state_key_mismatches() -> list[str]:
     for platform, entity_key in sorted(entity_paths):
         per_lang_state: dict[str, set[str]] = {}
         for lang, data in data_by_lang.items():
-            state = data["entity"].get(platform, {}).get(entity_key, {}).get("state", {})
+            state = (
+                data["entity"].get(platform, {}).get(entity_key, {}).get("state", {})
+            )
             per_lang_state[lang] = set(state.keys())
         union = set().union(*per_lang_state.values())
         for lang, keys in per_lang_state.items():
@@ -177,9 +180,10 @@ def find_state_key_mismatches() -> list[str]:
         attr_names: set[str] = set()
         for data in data_by_lang.values():
             attrs = (
-                data["entity"].get(platform, {}).get(entity_key, {}).get(
-                    "state_attributes", {}
-                )
+                data["entity"]
+                .get(platform, {})
+                .get(entity_key, {})
+                .get("state_attributes", {})
             )
             attr_names |= set(attrs.keys())
 
@@ -241,6 +245,31 @@ def find_device_translation_problems() -> list[str]:
     return problems
 
 
+def find_exceptions_translation_problems() -> list[str]:
+    """Check that every top-level `exceptions.<key>.message` in en.json also
+    exists (non-empty) in every other language file.
+
+    `find_missing_entity_keys` only inspects the `entity` section, so a
+    ServiceValidationError/HomeAssistantError translation_key added under the
+    top-level `exceptions` block (see text.py's invalid_timer_schedule) can go
+    untranslated in de/nl/cs/pl without CI ever catching it.
+    """
+    problems: list[str] = []
+    data_by_lang = load_all_languages()
+    en_keys = set(data_by_lang["en"].get("exceptions", {}).keys())
+
+    for lang, data in data_by_lang.items():
+        if lang == "en":
+            continue
+        exceptions_section = data.get("exceptions", {})
+        for key in sorted(en_keys):
+            message = exceptions_section.get(key, {}).get("message")
+            if not message:
+                problems.append(f"[{lang}] exceptions.{key}.message missing")
+
+    return problems
+
+
 if __name__ == "__main__":
     json_problems = find_invalid_json_files()
     if json_problems:
@@ -253,6 +282,7 @@ if __name__ == "__main__":
         find_missing_entity_keys()
         + find_state_key_mismatches()
         + find_device_translation_problems()
+        + find_exceptions_translation_problems()
     )
     if not all_problems:
         LOG.info("All translation files have complete coverage!")

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -196,9 +196,6 @@
             "dhw_hysteresis": {
                 "name": "Hystereze TUV"
             },
-            "dhw_frequency_control": {
-                "name": "Inverter Frekvence TUV (Hz, 0 = Automaticky)"
-            },
             "heating_room_temperature_impact_factor": {
                 "name": "Faktor vlivu teploty m\u00edstnosti na vyt\u00e1p\u011bn\u00ed"
             },
@@ -941,6 +938,38 @@
                 "name": "Datum konce re\u017eimu mimo domov - vyt\u00e1p\u011bn\u00ed"
             }
         },
+        "text": {
+            "timer_dhw_schedule_week": {
+                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (t\u00fdden)"
+            },
+            "timer_dhw_schedule_weekday": {
+                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (pracovn\u00ed dny)"
+            },
+            "timer_dhw_schedule_weekend": {
+                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (v\u00edkend)"
+            },
+            "timer_dhw_schedule_monday": {
+                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (pond\u011bl\u00ed)"
+            },
+            "timer_dhw_schedule_tuesday": {
+                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (\u00fater\u00fd)"
+            },
+            "timer_dhw_schedule_wednesday": {
+                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (st\u0159eda)"
+            },
+            "timer_dhw_schedule_thursday": {
+                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (\u010dtvrtek)"
+            },
+            "timer_dhw_schedule_friday": {
+                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (p\u00e1tek)"
+            },
+            "timer_dhw_schedule_saturday": {
+                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (sobota)"
+            },
+            "timer_dhw_schedule_sunday": {
+                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (ned\u011ble)"
+            }
+        },
         "select": {
             "thermal_desinfection_day": {
                 "name": "Den termick\u00e9 dezinfekce",
@@ -1147,6 +1176,9 @@
         },
         "invalid_write_target": {
             "message": "Nepoda\u0159ilo se naj\u00edt na\u010dten\u00e9 tepeln\u00e9 \u010derpadlo Luxtronik pro c\u00edl {target}"
+        },
+        "invalid_timer_schedule": {
+            "message": "Neplatn\u00fd \u010dasov\u00fd pl\u00e1n \"{value}\": o\u010dek\u00e1vaj\u00ed se polo\u017eky \"HH:MM-HH:MM\" odd\u011blen\u00e9 znakem \"/\", maxim\u00e1ln\u011b {max_rows} polo\u017eek"
         },
         "write_confirmation_mismatch": {
             "message": "Tepeln\u00e9 \u010derpadlo Luxtronik nepotvrdilo zapsan\u00e9 hodnoty: {details}"

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -57,12 +57,6 @@
             },
             "motor_protection": {
                 "name": "Motorschutz"
-            },
-            "cooling_energy_input": {
-                "name": "Eingesetzte Energie K\u00fchlung"
-            },
-            "second_heat_generator_amount_counter": {
-                "name": "Zweiter W\u00e4rmeerzeuger W\u00e4rmemenge"
             }
         },
         "switch": {
@@ -944,6 +938,38 @@
                 "name": "Abwesenheitsmodus Heizung Enddatum"
             }
         },
+        "text": {
+            "timer_dhw_schedule_week": {
+                "name": "Warmwasser-Zeitschaltplan (Woche)"
+            },
+            "timer_dhw_schedule_weekday": {
+                "name": "Warmwasser-Zeitschaltplan (Werktage)"
+            },
+            "timer_dhw_schedule_weekend": {
+                "name": "Warmwasser-Zeitschaltplan (Wochenende)"
+            },
+            "timer_dhw_schedule_monday": {
+                "name": "Warmwasser-Zeitschaltplan (Montag)"
+            },
+            "timer_dhw_schedule_tuesday": {
+                "name": "Warmwasser-Zeitschaltplan (Dienstag)"
+            },
+            "timer_dhw_schedule_wednesday": {
+                "name": "Warmwasser-Zeitschaltplan (Mittwoch)"
+            },
+            "timer_dhw_schedule_thursday": {
+                "name": "Warmwasser-Zeitschaltplan (Donnerstag)"
+            },
+            "timer_dhw_schedule_friday": {
+                "name": "Warmwasser-Zeitschaltplan (Freitag)"
+            },
+            "timer_dhw_schedule_saturday": {
+                "name": "Warmwasser-Zeitschaltplan (Samstag)"
+            },
+            "timer_dhw_schedule_sunday": {
+                "name": "Warmwasser-Zeitschaltplan (Sonntag)"
+            }
+        },
         "select": {
             "thermal_desinfection_day": {
                 "name": "Tag der thermischen Desinfektion",
@@ -1150,6 +1176,9 @@
         },
         "invalid_write_target": {
             "message": "Es konnte keine geladene Luxtronik-W\u00e4rmepumpe f\u00fcr das Ziel {target} ermittelt werden"
+        },
+        "invalid_timer_schedule": {
+            "message": "Ung\u00fcltiger Zeitschaltplan \"{value}\": erwartet werden \"HH:MM-HH:MM\"-Eintr\u00e4ge, getrennt durch \"/\", mit maximal {max_rows} Eintr\u00e4gen"
         },
         "write_confirmation_mismatch": {
             "message": "Die Luxtronik-W\u00e4rmepumpe hat die geschriebenen Werte nicht best\u00e4tigt: {details}"

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -57,15 +57,6 @@
             },
             "motor_protection": {
                 "name": "Motorbeveiliging"
-            },
-            "cooling_energy_input": {
-                "name": "Gebruikte energie koeling"
-            },
-            "current_power_consumption": {
-                "name": "Stroomverbruik"
-            },
-            "second_heat_generator_amount_counter": {
-                "name": "Tweede warmtebron warmtemenge"
             }
         },
         "switch": {
@@ -947,6 +938,38 @@
                 "name": "Einddatum Verwarming vakantie modus"
             }
         },
+        "text": {
+            "timer_dhw_schedule_week": {
+                "name": "Warmwater tijdschema (week)"
+            },
+            "timer_dhw_schedule_weekday": {
+                "name": "Warmwater tijdschema (werkdagen)"
+            },
+            "timer_dhw_schedule_weekend": {
+                "name": "Warmwater tijdschema (weekend)"
+            },
+            "timer_dhw_schedule_monday": {
+                "name": "Warmwater tijdschema (maandag)"
+            },
+            "timer_dhw_schedule_tuesday": {
+                "name": "Warmwater tijdschema (dinsdag)"
+            },
+            "timer_dhw_schedule_wednesday": {
+                "name": "Warmwater tijdschema (woensdag)"
+            },
+            "timer_dhw_schedule_thursday": {
+                "name": "Warmwater tijdschema (donderdag)"
+            },
+            "timer_dhw_schedule_friday": {
+                "name": "Warmwater tijdschema (vrijdag)"
+            },
+            "timer_dhw_schedule_saturday": {
+                "name": "Warmwater tijdschema (zaterdag)"
+            },
+            "timer_dhw_schedule_sunday": {
+                "name": "Warmwater tijdschema (zondag)"
+            }
+        },
         "select": {
             "thermal_desinfection_day": {
                 "name": "Dag waarop de thermische desinfection wordt uitgevoerd",
@@ -1153,6 +1176,9 @@
         },
         "invalid_write_target": {
             "message": "Kon geen geladen Luxtronik-warmtepomp vinden voor doel {target}"
+        },
+        "invalid_timer_schedule": {
+            "message": "Ongeldig tijdschema \"{value}\": verwacht worden \"HH:MM-HH:MM\"-items gescheiden door \"/\", met maximaal {max_rows} items"
         },
         "write_confirmation_mismatch": {
             "message": "De Luxtronik-warmtepomp heeft de geschreven waarde(n) niet bevestigd: {details}"

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -57,27 +57,6 @@
             },
             "compressor2": {
                 "name": "Spr\u0119\u017carka 2"
-            },
-            "cooling_energy_input": {
-                "name": "Energia zu\u017cyta na ch\u0142odzenie"
-            },
-            "current_power_consumption": {
-                "name": "Pob\u00f3r mocy"
-            },
-            "second_heat_generator_amount_counter": {
-                "name": "Ilo\u015b\u0107 ciep\u0142a drugiego generatora"
-            },
-            "circulation_pump_delta": {
-                "name": "Cyrkulacyjna pompdelta"
-            },
-            "circulation_pump_delta_target": {
-                "name": "Cyrkulacyjna pompdelta docelowa"
-            },
-            "pump_flow_delta": {
-                "name": "Delta przep\u0142ywu pompy"
-            },
-            "pump_flow_delta_target": {
-                "name": "Delta docelowa przep\u0142ywu pompy"
             }
         },
         "switch": {
@@ -923,9 +902,6 @@
             "room_thermostat_temperature_target": {
                 "name": "Temperatura docelowa termostatu pokojowego"
             },
-            "compressor2": {
-                "name": "Spr\u0119\u017carka 2"
-            },
             "cooling_energy_input": {
                 "name": "Energia zu\u017cyta na ch\u0142odzenie"
             },
@@ -960,6 +936,38 @@
             },
             "away_heating_enddate": {
                 "name": "Data zako\u0144czenia trybu nieobecno\u015bci - ogrzewanie"
+            }
+        },
+        "text": {
+            "timer_dhw_schedule_week": {
+                "name": "Harmonogram czasowy ciep\u0142ej wody (tydzie\u0144)"
+            },
+            "timer_dhw_schedule_weekday": {
+                "name": "Harmonogram czasowy ciep\u0142ej wody (dni robocze)"
+            },
+            "timer_dhw_schedule_weekend": {
+                "name": "Harmonogram czasowy ciep\u0142ej wody (weekend)"
+            },
+            "timer_dhw_schedule_monday": {
+                "name": "Harmonogram czasowy ciep\u0142ej wody (poniedzia\u0142ek)"
+            },
+            "timer_dhw_schedule_tuesday": {
+                "name": "Harmonogram czasowy ciep\u0142ej wody (wtorek)"
+            },
+            "timer_dhw_schedule_wednesday": {
+                "name": "Harmonogram czasowy ciep\u0142ej wody (\u015broda)"
+            },
+            "timer_dhw_schedule_thursday": {
+                "name": "Harmonogram czasowy ciep\u0142ej wody (czwartek)"
+            },
+            "timer_dhw_schedule_friday": {
+                "name": "Harmonogram czasowy ciep\u0142ej wody (pi\u0105tek)"
+            },
+            "timer_dhw_schedule_saturday": {
+                "name": "Harmonogram czasowy ciep\u0142ej wody (sobota)"
+            },
+            "timer_dhw_schedule_sunday": {
+                "name": "Harmonogram czasowy ciep\u0142ej wody (niedziela)"
             }
         },
         "select": {
@@ -1168,6 +1176,9 @@
         },
         "invalid_write_target": {
             "message": "Nie uda\u0142o si\u0119 znale\u017a\u0107 za\u0142adowanej pompy ciep\u0142a Luxtronik dla celu {target}"
+        },
+        "invalid_timer_schedule": {
+            "message": "Nieprawid\u0142owy harmonogram czasowy \"{value}\": oczekiwane s\u0105 wpisy \"HH:MM-HH:MM\" oddzielone znakiem \"/\", maksymalnie {max_rows} wpis\u00f3w"
         },
         "write_confirmation_mismatch": {
             "message": "Pompa ciep\u0142a Luxtronik nie potwierdzi\u0142a zapisanych warto\u015bci: {details}"

--- a/custom_components/luxtronik2/water_heater.py
+++ b/custom_components/luxtronik2/water_heater.py
@@ -69,6 +69,7 @@ WATER_HEATERS: list[LuxtronikWaterHeaterDescription] = [
         # luxtronik_key_target_temperature_low=LuxParameter,
         temperature_unit=UnitOfTemperature.CELSIUS,
         visibility=LV.V0029_DHW_TEMPERATURE,
+        device_key=DeviceKey.domestic_water,
         max_firmware_version_minor=Version("88.2"),
     ),
     LuxtronikWaterHeaterDescription(
@@ -86,6 +87,7 @@ WATER_HEATERS: list[LuxtronikWaterHeaterDescription] = [
         # luxtronik_key_target_temperature_low=LuxParameter,
         temperature_unit=UnitOfTemperature.CELSIUS,
         visibility=LV.V0029_DHW_TEMPERATURE,
+        device_key=DeviceKey.domestic_water,
         min_firmware_version_minor=Version("88.3"),
     ),
 ]

--- a/tests/test_water_heater.py
+++ b/tests/test_water_heater.py
@@ -53,7 +53,7 @@ class TestWaterHeaterDescriptions:
 
     def test_all_domestic_water(self):
         for wh in WATER_HEATERS:
-            assert wh.device_key == DeviceKey.heatpump  # default
+            assert wh.device_key == DeviceKey.domestic_water
             assert wh.luxtronik_action_heating == LuxOperationMode.domestic_water
 
     def test_firmware_version_split(self):


### PR DESCRIPTION
## 🐛 What

- Adds `entity.text.timer_dhw_schedule_*` (10 keys) to `de/nl/cs/pl.json` — these text entities (DHW timer schedule week/weekday/weekend/per-day) only had a translation in `en.json`.
- Adds `exceptions.invalid_timer_schedule.message` to `de/nl/cs/pl.json` — the `ServiceValidationError` raised by `text.py` on a malformed `HH:MM-HH:MM` schedule string was previously untranslated outside English.
- Removes stale/orphaned translation entries with no matching code reference:
  - duplicate `entity.binary_sensor.*` keys in `de/nl/pl.json` whose real entities live under `entity.sensor.*`
  - a duplicate `entity.sensor.compressor2` in `pl.json` (the real entity is under `binary_sensor`)
  - an orphaned `entity.number.dhw_frequency_control` in `cs.json`
- Fixes both `LuxtronikWaterHeaterDescription` entries in `water_heater.py`, which left `device_key` unset (defaulting to `DeviceKey.heatpump`) instead of `DeviceKey.domestic_water`. This bypassed the `has_domestic_water` presence gate in `coordinator.entity_active()`, so the water heater entity was always created even on units without DHW, unlike every sibling DHW entity across the other platforms.

## 🔧 Why

A full audit of the 5 locale files found translation gaps that weren't caught by CI because `.github/scripts/check_translation_coverage.py` didn't walk the `text` platform (`timer_schedule_entities_predefined.py`) and had no check for the top-level `exceptions` block at all.

A separate audit of entity-description patterns across all 9 platforms turned up the water_heater `device_key` drift described above.

## 🛠️ CI script changes

- Added `timer_schedule_entities_predefined.py` (`text` platform) to `ENTITY_CHECKS`.
- Added `find_exceptions_translation_problems()` to verify every `exceptions.<key>.message` in `en.json` has a non-empty counterpart in every other locale.

## ✅ Test plan

- [x] `check_translation_coverage.py` passes: "All translation files have complete coverage!"
- [x] All 4 edited JSON files parse successfully
- [x] `ruff check` / `ruff format --check` clean
- [x] `basedpyright` — 0 errors on the modified CI script and `water_heater.py`
- [x] Full test suite passes (857 passed) with no coverage regression (100% on `custom_components.luxtronik2`)