### PR TITLE
fix(lux_helper): 🐛 read socket values with exact framing to stop sensor corruption

### DIFF
--- a/custom_components/luxtronik2/lux_helper.py
+++ b/custom_components/luxtronik2/lux_helper.py
@@ -172,7 +172,10 @@ def _is_socket_closed(sock: socket.socket) -> bool:
         if sock.fileno() < 0:
             return True
     except Exception as err:  # pylint: disable=broad-except
-        LOGGER.exception(
+        # Debug, not error: this probe runs before every read attempt and the
+        # caller recovers by reconnecting, so a failure here is not itself a
+        # problem worth reporting at default log level.
+        LOGGER.debug(
             "Unexpected exception when checking if a socket is closed", exc_info=err
         )
         return True
@@ -193,12 +196,18 @@ def _is_socket_closed(sock: socket.socket) -> bool:
     except OSError as err:
         if err.errno == 107:  # Socket not connected
             return True
-        LOGGER.exception(
+        # Debug, not error: this probe runs before every read attempt and the
+        # caller recovers by reconnecting, so a failure here is not itself a
+        # problem worth reporting at default log level.
+        LOGGER.debug(
             "Unexpected exception when checking if a socket is closed", exc_info=err
         )
         return False
     except Exception as err:  # pylint: disable=broad-except
-        LOGGER.exception(
+        # Debug, not error: this probe runs before every read attempt and the
+        # caller recovers by reconnecting, so a failure here is not itself a
+        # problem worth reporting at default log level.
+        LOGGER.debug(
             "Unexpected exception when checking if a socket is closed", exc_info=err
         )
         return False
@@ -250,7 +259,7 @@ class Luxtronik:
             if not _is_socket_closed(self._socket):
                 self._socket.close()
             self._socket = None
-            LOGGER.info(
+            LOGGER.debug(
                 "Disconnected from Luxtronik heatpump %s:%s", self._host, self._port
             )
 
@@ -263,7 +272,7 @@ class Luxtronik:
                 self._socket.settimeout(self._socket_timeout)
                 try:
                     self._socket.connect((self._host, self._port))
-                    LOGGER.info(
+                    LOGGER.debug(
                         "Connected to Luxtronik heatpump %s:%s with timeout %.1fs",
                         self._host,
                         self._port,
@@ -289,12 +298,11 @@ class Luxtronik:
             if write:
                 self._write()
             self._read()
-        except OSError:
-            LOGGER.error("Socket error during read/write", exc_info=True)
-            self._disconnect()
-            raise
-        except struct.error:
-            LOGGER.error("Protocol/parse error during read/write", exc_info=True)
+        except (OSError, struct.error):
+            # Deliberately not logged here: the exception propagates to the
+            # coordinator, which re-raises it as UpdateFailed and lets
+            # DataUpdateCoordinator report it. Logging it as well produced two
+            # entries - one with a full traceback - for every transient blip.
             self._disconnect()
             raise
 
@@ -328,14 +336,17 @@ class Luxtronik:
             if not isinstance(index, int) or not isinstance(value, int):
                 LOGGER.warning("Parameter id '%s' or value '%s' invalid!", index, value)
                 continue
-            LOGGER.info("Parameter '%d' set to '%s'", index, value)
             data = struct.pack(">iii", LUXTRONIK_PARAMETERS_WRITE, index, value)
-            LOGGER.debug("Data %s", data)
             self._socket.sendall(data)
             cmd = self._read_int()
-            LOGGER.debug("Command %s", cmd)
             val = self._read_int()
-            LOGGER.debug("Value %s", val)
+            LOGGER.debug(
+                "Parameter '%d' set to '%s' (ack cmd=%s value=%s)",
+                index,
+                value,
+                cmd,
+                val,
+            )
         # Flush queue after writing all values
         self.parameters.queue = {}
         # Give the heatpump a short time to handle the value changes/calculations:
@@ -459,21 +470,29 @@ class Luxtronik:
                 return  # Success, exit after first successful attempt
 
             except (TimeoutError, ConnectionResetError, OSError) as err:
-                LOGGER.warning(
-                    "Error while reading %s (attempt %d/%d): %s",
-                    label,
-                    attempt + 1,
-                    retries + 1,
-                    err,
-                )
                 self._disconnect()
 
                 if attempt < retries:
                     delay = 1  # min(30, 10 * attempt)  # cap delay to avoid long waits
-                    LOGGER.warning("Waiting %s seconds before retrying...", delay)
+                    # Debug, not warning: an attempt that is about to be retried
+                    # is not yet a problem. Only exhausting them all is, and
+                    # that is reported below.
+                    LOGGER.debug(
+                        "Error while reading %s (attempt %d/%d): %s - retrying in %ss",
+                        label,
+                        attempt + 1,
+                        retries + 1,
+                        err,
+                        delay,
+                    )
                     time.sleep(delay)
                 else:
-                    LOGGER.error("All attempts to read %s failed.", label)
+                    LOGGER.error(
+                        "All %d attempts to read %s failed. Last error: %s",
+                        retries + 1,
+                        label,
+                        err,
+                    )
                     return
 
             except Exception as err:

--- a/custom_components/luxtronik2/lux_helper.py
+++ b/custom_components/luxtronik2/lux_helper.py
@@ -225,6 +225,7 @@ class Luxtronik:
         self._port = port
         self._socket_timeout = socket_timeout
         self._max_data_length = max_data_length
+        self._short_reads = 0
         self.calculations = Calculations()
         self.parameters = Parameters(safe=safe)
         self.visibilities = Visibilities()
@@ -331,9 +332,9 @@ class Luxtronik:
             data = struct.pack(">iii", LUXTRONIK_PARAMETERS_WRITE, index, value)
             LOGGER.debug("Data %s", data)
             self._socket.sendall(data)
-            cmd = struct.unpack(">i", self._socket.recv(4))[0]
+            cmd = self._read_int()
             LOGGER.debug("Command %s", cmd)
-            val = struct.unpack(">i", self._socket.recv(4))[0]
+            val = self._read_int()
             LOGGER.debug("Value %s", val)
         # Flush queue after writing all values
         self.parameters.queue = {}
@@ -341,13 +342,56 @@ class Luxtronik:
         # Todo: Change methods to async
         # await asyncio.sleep(WAIT_TIME_WRITE_PARAMETER)
 
+    def _read_exact(self, count: int) -> bytes:
+        """Receive exactly ``count`` bytes from the socket.
+
+        TCP gives no framing guarantee: ``recv(n)`` may return fewer than ``n``
+        bytes whenever a segment boundary falls inside the value being read.
+        Treating such a short read as a failed item (as the upstream library
+        does) both drops that item and leaves its remaining bytes in the
+        stream, so every following value is decoded from misaligned bytes and
+        lands on the wrong sensor. Loop until the full value has arrived
+        instead, and let a dead connection raise rather than spin.
+        """
+        if self._socket is None:
+            raise OSError("Cannot read: socket is not connected")
+        chunks: list[bytes] = []
+        remaining = count
+        while remaining > 0:
+            chunk = self._socket.recv(remaining)
+            if not chunk:
+                raise ConnectionError(
+                    f"Connection to {self._host}:{self._port} closed by peer"
+                )
+            chunks.append(chunk)
+            remaining -= len(chunk)
+            if remaining:
+                # Counted rather than logged: a chatty controller can fragment
+                # every single value, and there are ~1700 of them per poll.
+                # `_read_data` reports the total for the block instead.
+                self._short_reads += 1
+        return b"".join(chunks)
+
+    def _read_int(self) -> int:
+        """Read one big-endian 32 bit integer."""
+        return struct.unpack(
+            ">i", self._read_exact(LUXTRONIK_SOCKET_READ_SIZE_INTEGER)
+        )[0]
+
+    def _read_char(self) -> int:
+        """Read one signed byte."""
+        return struct.unpack(">b", self._read_exact(LUXTRONIK_SOCKET_READ_SIZE_CHAR))[0]
+
     def _read_data(  # pragma: no cover
         self, command: int, item_size: int, parser, label: str, retries: int = 4
     ) -> None:
         """Generic method to read data from the socket with timeout and retry handling."""
-        data = []
-
         for attempt in range(retries + 1):
+            # Must be reset per attempt: items read before a failed attempt
+            # would otherwise be prepended to the retry's data and shift every
+            # index of the reparsed block.
+            data = []
+            self._short_reads = 0
             try:
                 # check if connection still exists before reading
                 if self._socket is None or _is_socket_closed(self._socket):
@@ -360,15 +404,15 @@ class Luxtronik:
                     raise OSError("Socket not connected after connect()")
 
                 self._socket.sendall(struct.pack(">ii", command, 0))
-                cmd = struct.unpack(">i", self._socket.recv(4))[0]
+                cmd = self._read_int()
                 LOGGER.debug("Command %s (%s)", cmd, label)
 
                 # Optional status field for calculations
                 if command == LUXTRONIK_CALCULATIONS_READ:
-                    stat = struct.unpack(">i", self._socket.recv(4))[0]
+                    stat = self._read_int()
                     LOGGER.debug("Stat %s", stat)
 
-                length = struct.unpack(">i", self._socket.recv(4))[0]
+                length = self._read_int()
                 if length > self._max_data_length:
                     LOGGER.warning(
                         "Skip reading %s! Length oversized! %s > %s",
@@ -386,16 +430,31 @@ class Luxtronik:
 
                 LOGGER.debug("Length %s (%s)", length, label)
 
-                fmt = ">i" if item_size == LUXTRONIK_SOCKET_READ_SIZE_INTEGER else ">b"
+                read_item = (
+                    self._read_int
+                    if item_size == LUXTRONIK_SOCKET_READ_SIZE_INTEGER
+                    else self._read_char
+                )
 
+                # Any failure here aborts the whole block: the parsers assign
+                # values by list position, so a single skipped item would
+                # silently relabel every sensor after it (issue #723). The
+                # retry handler below disconnects, which also discards the
+                # desynchronised remainder of the response.
                 for _ in range(length):
-                    try:
-                        raw = self._socket.recv(item_size)
-                        data.append(struct.unpack(fmt, raw)[0])
-                    except (TimeoutError, struct.error) as err:
-                        LOGGER.debug("Error reading %s item: %s", label, err)
+                    data.append(read_item())
 
-                LOGGER.debug("Read %d %s items", length, label)
+                if len(data) != length:
+                    raise OSError(
+                        f"Incomplete {label} block: got {len(data)} of {length} items"
+                    )
+
+                LOGGER.debug(
+                    "Read %d %s items (%d fragmented)",
+                    length,
+                    label,
+                    self._short_reads,
+                )
                 parser.parse(data)
                 return  # Success, exit after first successful attempt
 

--- a/tests/test_lux_helper.py
+++ b/tests/test_lux_helper.py
@@ -551,6 +551,25 @@ class TestLuxtronikReadWrite:
         mock_sock.sendall.assert_called_once()
 
 
+def _fragmented_recv(payload: bytes, chunk_sizes: list[int]):
+    """Build a recv() side effect that serves ``payload`` in short reads.
+
+    Mimics a real stream socket: never returns more than the requested number
+    of bytes, but may return fewer - which is exactly what happens when a TCP
+    segment boundary falls inside a value.
+    """
+    stream = bytearray(payload)
+    sizes = list(chunk_sizes)
+
+    def recv(size):
+        take = min(size, sizes.pop(0) if sizes else size, len(stream))
+        chunk = bytes(stream[:take])
+        del stream[:take]
+        return chunk
+
+    return recv
+
+
 class TestLuxtronikReadData:
     @patch("custom_components.luxtronik2.lux_helper.socket.socket")
     def test_read_data_oversized_length(self, mock_socket_class):
@@ -752,6 +771,226 @@ class TestLuxtronikReadData:
         )
 
         parser.parse.assert_not_called()
+
+    def test_read_exact_without_socket_raises(self):
+        """Reading without a connection is an error, not a silent empty read."""
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = None
+
+        with pytest.raises(OSError, match="not connected"):
+            client._read_exact(4)
+
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_read_data_short_reads_are_reassembled(self, mock_socket_class):
+        """A TCP short read must not drop or misalign items (issue #723)."""
+        from custom_components.luxtronik2.lux_helper import (
+            LUXTRONIK_PARAMETERS_READ,
+            LUXTRONIK_SOCKET_READ_SIZE_INTEGER,
+        )
+
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+
+        # The heatpump answers cmd, length=3 and three ints, but the stream is
+        # fragmented mid-integer the way a real TCP segment boundary does it.
+        payload = struct.pack(">i", LUXTRONIK_PARAMETERS_READ)
+        payload += struct.pack(">i", 3)
+        payload += struct.pack(">iii", 100, 200, 300)
+        # Every value gets split across two recv() returns.
+        mock_sock.recv.side_effect = _fragmented_recv(payload, [3, 1] * 10)
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        parser = MagicMock()
+
+        client._read_data(
+            LUXTRONIK_PARAMETERS_READ,
+            LUXTRONIK_SOCKET_READ_SIZE_INTEGER,
+            parser,
+            "params",
+            retries=0,
+        )
+
+        parser.parse.assert_called_once_with([100, 200, 300])
+
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_read_data_reports_fragmentation_once_per_block(
+        self, mock_socket_class, caplog
+    ):
+        """Fragmentation is summarised per block, not logged per item."""
+        from custom_components.luxtronik2.lux_helper import (
+            LUXTRONIK_PARAMETERS_READ,
+            LUXTRONIK_SOCKET_READ_SIZE_INTEGER,
+        )
+
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+
+        payload = struct.pack(">i", LUXTRONIK_PARAMETERS_READ)
+        payload += struct.pack(">i", 2)
+        payload += struct.pack(">ii", 100, 200)
+        # cmd and length arrive whole; both items are split in two.
+        mock_sock.recv.side_effect = _fragmented_recv(payload, [4, 4, 3, 1, 3, 1])
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        parser = MagicMock()
+
+        with caplog.at_level("DEBUG"):
+            client._read_data(
+                LUXTRONIK_PARAMETERS_READ,
+                LUXTRONIK_SOCKET_READ_SIZE_INTEGER,
+                parser,
+                "params",
+                retries=0,
+            )
+
+        parser.parse.assert_called_once_with([100, 200])
+        assert client._short_reads == 2
+        assert len([r for r in caplog.records if "fragmented" in r.message]) == 1
+
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_read_data_item_timeout_does_not_parse_shifted_data(
+        self, mock_socket_class
+    ):
+        """A timeout mid-block must abort, never parse a short/shifted list."""
+        from custom_components.luxtronik2.lux_helper import (
+            LUXTRONIK_PARAMETERS_READ,
+            LUXTRONIK_SOCKET_READ_SIZE_INTEGER,
+        )
+
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+
+        mock_sock.recv.side_effect = [
+            struct.pack(">i", LUXTRONIK_PARAMETERS_READ),  # cmd
+            struct.pack(">i", 3),  # length
+            struct.pack(">i", 100),  # item 1
+            TimeoutError("timeout"),  # item 2 never arrives
+            struct.pack(">i", 300),  # item 3
+        ]
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        parser = MagicMock()
+
+        client._read_data(
+            LUXTRONIK_PARAMETERS_READ,
+            LUXTRONIK_SOCKET_READ_SIZE_INTEGER,
+            parser,
+            "params",
+            retries=0,
+        )
+
+        parser.parse.assert_not_called()
+
+    @patch("custom_components.luxtronik2.lux_helper.time.sleep")
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_read_data_retry_discards_partial_data(self, mock_socket_class, mock_sleep):
+        """Items read before a failed attempt must not leak into the retry."""
+        from custom_components.luxtronik2.lux_helper import (
+            LUXTRONIK_PARAMETERS_READ,
+            LUXTRONIK_SOCKET_READ_SIZE_INTEGER,
+        )
+
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+
+        mock_sock.recv.side_effect = [
+            # Attempt 1: dies after the first item
+            struct.pack(">i", LUXTRONIK_PARAMETERS_READ),
+            struct.pack(">i", 2),
+            struct.pack(">i", 111),
+            TimeoutError("timeout"),
+            # Attempt 2: full, correct answer
+            struct.pack(">i", LUXTRONIK_PARAMETERS_READ),
+            struct.pack(">i", 2),
+            struct.pack(">i", 100),
+            struct.pack(">i", 200),
+        ]
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        parser = MagicMock()
+
+        client._read_data(
+            LUXTRONIK_PARAMETERS_READ,
+            LUXTRONIK_SOCKET_READ_SIZE_INTEGER,
+            parser,
+            "params",
+            retries=1,
+        )
+
+        parser.parse.assert_called_once_with([100, 200])
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_read_data_peer_close_aborts(self, mock_socket_class):
+        """An empty recv() means the peer closed - abort instead of spinning."""
+        from custom_components.luxtronik2.lux_helper import (
+            LUXTRONIK_PARAMETERS_READ,
+            LUXTRONIK_SOCKET_READ_SIZE_INTEGER,
+        )
+
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+
+        mock_sock.recv.side_effect = [
+            struct.pack(">i", LUXTRONIK_PARAMETERS_READ),
+            struct.pack(">i", 2),
+            struct.pack(">i", 100),
+            b"",  # connection died
+        ]
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        parser = MagicMock()
+
+        client._read_data(
+            LUXTRONIK_PARAMETERS_READ,
+            LUXTRONIK_SOCKET_READ_SIZE_INTEGER,
+            parser,
+            "params",
+            retries=0,
+        )
+
+        parser.parse.assert_not_called()
+
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_read_data_visibilities_short_read(self, mock_socket_class):
+        """Single-byte visibility items also survive a fragmented header."""
+        from custom_components.luxtronik2.lux_helper import (
+            LUXTRONIK_SOCKET_READ_SIZE_CHAR,
+            LUXTRONIK_VISIBILITIES_READ,
+        )
+
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+
+        payload = struct.pack(">i", LUXTRONIK_VISIBILITIES_READ)
+        payload += struct.pack(">i", 3)
+        payload += struct.pack(">bbb", 1, 0, 1)
+        mock_sock.recv.side_effect = _fragmented_recv(payload, [3, 1, 2] * 5)
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        parser = MagicMock()
+
+        client._read_data(
+            LUXTRONIK_VISIBILITIES_READ,
+            LUXTRONIK_SOCKET_READ_SIZE_CHAR,
+            parser,
+            "vis",
+            retries=0,
+        )
+
+        parser.parse.assert_called_once_with([1, 0, 1])
 
     @patch("custom_components.luxtronik2.lux_helper.socket.socket")
     def test_read_calls_all_three_groups(self, mock_socket_class):


### PR DESCRIPTION
## 🐛 Problem

`status_line_1` intermittently reports `defrost` while the compressor is off and the outdoor temperature is ~35 °C, and `error_reason` occasionally shows an implausible code (e.g. `335364`) with a timestamp in 1970. Both are symptoms of one root cause in the socket reader.

`_read_data` requested each value with a bare `self._socket.recv(4)`. TCP gives no framing guarantee: `recv(n)` may return fewer than `n` bytes whenever a segment boundary falls inside the value being read. The resulting `struct.error` was caught and ignored, which:

1. dropped that item, and
2. left its remaining 1-3 bytes in the stream, so every subsequent `recv(4)` was byte-misaligned.

The parsers assign values strictly by list position (`Calculations.parse` enumerates the raw list), so a single dropped or misaligned item silently relabels **every sensor after it**. A shift of two puts `status_line_3`'s code into `status_line_1` - and `lock time` (code 4 on line 3), a perfectly normal state in hot weather, decodes as `defrost` (code 4 on line 1).

Two smaller defects compounded it:

- a per-item `TimeoutError` was swallowed the same way, shifting every later index by one
- `data = []` sat *outside* the retry loop, so a retry appended to the items already read in the failed attempt

## 🔧 Fix

New `_read_exact`/`_read_int`/`_read_char` helpers loop until the full byte count has arrived and raise `ConnectionError` on an empty `recv()`. Every bare `recv` now goes through them - the command/stat/length header reads, the item loop, and the write acknowledgements.

This mirrors the fix already present in upstream python-luxtronik's `main` rewrite (`luxtronik/cfi/interface.py::_read_bytes`), which is **not** part of the pinned `0.3.14` release - and this integration uses its own `lux_helper.py` client rather than the library's socket layer, so it would not have inherited the fix regardless.

Also in this commit:

- no more silently-skipped items: a failure aborts the block and the existing retry handler disconnects, discarding the desynchronised remainder
- refuse to `parse()` a block whose item count doesn't match the announced length
- reset the item buffer per retry attempt
- report fragmentation as a per-block count folded into the existing summary line, rather than per item (which would emit thousands of lines per poll on a chatty controller)

## 🔊 Second commit: log levels on the polling hot path

Separate, reviewable on its own:

- `_read_write` no longer logs-and-raises - the exception already reaches the coordinator, which re-raises it as `UpdateFailed` for `DataUpdateCoordinator` to report, so every transient blip produced two entries, one with a full traceback
- intermediate read retries at debug instead of warning (two warnings per attempt × up to five attempts, for a hiccup that then succeeds); the final failure is still an error and now names the last exception
- connect/disconnect and parameter-write messages moved from info to debug, per HA convention
- the three unlabelled write debug lines collapsed into one carrying parameter, value and acknowledgement
- the socket-state probe's unexpected exceptions at debug rather than errors with tracebacks; it runs before every read attempt and the caller recovers by reconnecting

Steady-state debug output is unchanged at ten lines per poll. A network hiccup drops from roughly twelve lines and two tracebacks at default level to a single error line.

## 🧪 Tests

Seven new tests in `TestLuxtronikReadData`, built on a `_fragmented_recv` stream fake that behaves like a real socket (never returns more than requested, may return less):

- short reads split mid-value are reassembled correctly (int and single-byte/visibility variants)
- a mid-block timeout never parses a short or shifted list
- a retry after a partial read discards the partial data
- an empty `recv()` aborts
- fragmentation is summarised once per block, not per item
- reading with no socket raises

All seven fail against the previous implementation and pass against the new one (verified by stashing just the source file).

## ✅ Verification

```
864 passed
coverage: 100% overall, lux_helper.py 184/184 statements
ruff check: All checks passed!
ruff format --check: clean
basedpyright: 0 errors, 0 warnings, 0 notes
codespell: clean
```

## ⚠️ Note for the reporter

The mechanism is proven and fixed, but as it is timing-dependent I could not reproduce the exact `defrost` reading on demand - the shift-of-two explanation above remains inference. If it recurs, debug logging on `custom_components.luxtronik2` will now show `Read %d %s items (%d fragmented)`; a non-zero fragment count confirms the fragmentation directly.

Resolves #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)
