### PR TITLE
feat(coordinator): ✨ expose the heat pump serial number in device info

### DIFF
--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -323,6 +323,16 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         )
         if via_device is not None:
             device_info["via_device"] = via_device
+        else:
+            # Only the physical unit carries the serial: heating, domestic
+            # water and cooling are logical sub-devices of the same heat pump
+            # (they are the ones passing `via_device`), and repeating the
+            # serial on each would read as several units sharing one serial.
+            #
+            # Rendered as `unique_id` rather than `serial_number` so it matches
+            # the string `config_flow` prints when a second config entry
+            # collides on this serial.
+            device_info["serial_number"] = self.unique_id
         return device_info
 
     def _is_version_not_compatible(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -18,6 +18,7 @@ from custom_components.luxtronik2.const import (
     CONF_UPDATE_INTERVAL,
     DEFAULT_PORT,
     DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
     DeviceKey,
     LuxCalculation as LC,
     LuxMkTypes,
@@ -1261,6 +1262,63 @@ class TestCoordinatorGetDeviceFallback:
         device_info = coord._build_device_info(DeviceKey.heatpump, "192.168.1.1")
         assert device_info["translation_key"] == DeviceKey.heatpump.value
         assert device_info["name"] == DeviceKey.heatpump.value
+
+
+class TestDeviceInfoSerialNumber:
+    """The serial number decides device identity, so it must be discoverable."""
+
+    @staticmethod
+    def _coordinator():
+        return _make_coordinator(
+            calculations={
+                "ID_WEB_SoftStand": "V3.90.1",
+                "ID_WEB_Code_WP_akt": "LWP 10",
+            },
+            parameters={
+                "ID_WP_SerienNummer_DATUM": 230924,
+                "ID_WP_SerienNummer_HEX": 625,
+            },
+        )
+
+    def test_heatpump_device_exposes_serial_number(self):
+        """The physical unit carries the serial in its device info."""
+        coord = self._coordinator()
+
+        device_info = coord._build_device_info(DeviceKey.heatpump, "192.168.1.1")
+
+        assert device_info["serial_number"] == "230924_0271"
+
+    def test_serial_number_matches_unique_id_rendering(self):
+        """Device page and the duplicate-serial abort message must agree.
+
+        `config_flow` reports collisions using the `unique_id` form, so a user
+        comparing that message against the device page has to see the same
+        string.
+        """
+        coord = self._coordinator()
+
+        device_info = coord._build_device_info(DeviceKey.heatpump, "192.168.1.1")
+
+        assert device_info["serial_number"] == coord.unique_id
+
+    @pytest.mark.parametrize(
+        "key",
+        [DeviceKey.heating, DeviceKey.domestic_water, DeviceKey.cooling],
+    )
+    def test_logical_subdevices_omit_serial_number(self, key: DeviceKey):
+        """Only the physical unit owns the serial.
+
+        Heating/DHW/cooling are logical sub-devices of the same heat pump;
+        repeating the serial on each would read as several distinct units
+        sharing one serial - the exact confusion reported in #724.
+        """
+        coord = self._coordinator()
+
+        device_info = coord._build_device_info(
+            key, "192.168.1.1", (DOMAIN, "some_heatpump")
+        )
+
+        assert "serial_number" not in device_info
 
 
 # ===========================================================================


### PR DESCRIPTION
## 💡 Background

Follow-up to the suggestion `2z4gbg7nys-lab` left at the end of #724:

> p.s. Improvement suggestion. If SN has such crucial role, it should be visible e.g. in Device Information. Maybe it already is, I did not find.

They looked in the right place and it genuinely wasn't there. The serial was surfaced in exactly **zero** places in the UI:

- **Device info** - `_build_device_info` set `identifiers`, `name`, `model`, `manufacturer`, `sw_version`, `configuration_url`, but not `serial_number` (a field Home Assistant's `DeviceInfo` has supported for some time)
- **Entities** - nothing in any `*_entities_predefined.py` exposes it
- **Diagnostics** - actively hidden; `TO_REDACT` covers both `unique_id` and `identifiers`, and the serial is embedded in each

Yet the serial *is* the device identity: it feeds `unique_id` and therefore decides whether a config entry is accepted at all. Users had no way to look it up short of the controller's own display.

## 🔧 Change

One branch in `_build_device_info`:

```python
if via_device is not None:
    device_info["via_device"] = via_device
else:
    device_info["serial_number"] = self.unique_id
```

**Only the physical unit gets it.** Heating, domestic water and cooling are logical sub-devices of the same heat pump - they are precisely the ones passing a `via_device` - so keying off that puts the rule in one place. Repeating the serial on all four devices would read as four separate units sharing one serial, which is the exact confusion #724 was about.

**Rendered as `unique_id`, deliberately.** `config_flow` builds its duplicate-serial abort message from `coordinator.unique_id`, so the device page now shows the identical string a user sees in that error (`230924_0271` for the reporter's unit) rather than the hyphenated `serial_number` form. One serial, one spelling.

No new failure mode: `_build_device_info` already calls `self.unique_id` to construct `identifiers`, so it has always required the serial to be readable.

## 🧪 Tests

New `TestDeviceInfoSerialNumber`, 5 cases:

- the heatpump device exposes the serial
- it equals `coordinator.unique_id` - the cross-check that stops the device page and the collision message drifting apart if either rendering is changed later
- parametrized over heating / domestic water / cooling: each omits it

The two presence assertions fail before this change and pass after; the three omission cases were green already and stand as regression guards.

## ✅ Verification

```
871 passed  (was 866)
coverage: 100% overall, coordinator.py 328/328 statements
ruff check: All checks passed!
ruff format --check: clean
basedpyright: 0 errors, 0 warnings, 0 notes
codespell: clean
```

## ⚠️ Scope note

This does **not** address the duplicate-serial collision itself - a rejected second device never gets a device page, so only an already-configured unit's serial becomes visible. The improved abort message shipped in `2026.08.05` remains what covers that case. This is about general discoverability, which is what the suggestion actually asked for.

Linked to #724, which is already closed (its original problem was resolved separately), so this intentionally does not use a closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
