### PR TITLE
fix(coordinator): 🐛 report domestic water across the thermal disinfection transition

### DIFF
--- a/ADVANCED_FEATURES.md
+++ b/ADVANCED_FEATURES.md
@@ -65,6 +65,14 @@ The integration learns these lockout windows by observing the heat pump's own op
 
 **Smart Grid Status** is a related but separate sensor: it only reports a value while the *Smart Grid* switch (see [Smart Grid & Power Limitation](#smart-grid--power-limitation) below) is enabled, and shows one of four SG-ready states (`EVU locked` / `Reduced operation` / `Normal operation` / `Increased operation`) derived from the heat pump's two EVU input signals.
 
+## Domestic Water Status During Thermal Disinfection
+
+The heat pump controller briefly reports `no_request` while switching from normal domestic-water heating into a thermal disinfection run, even though the DHW recirculation pump keeps running. To keep energy accounting (for example a utility meter split by operating mode) from attributing that gap to idle time, the **Status** sensor keeps reporting `domestic_water` for up to 5 minutes after a genuine domestic-water state, for as long as the DHW recirculation pump is still running.
+
+Two limits are deliberate: the hold never *starts* a `domestic_water` state on its own — the pump running by itself is not enough, a real domestic-water state must have preceded it — and it never overrides a genuine switch to heating or cooling. It also ends as soon as the pump stops, so in practice it lasts only the couple of minutes the transition actually takes; the 5-minute cap is a backstop against an installation whose recirculation pump runs continuously.
+
+A visible side effect: for up to 5 minutes after *any* domestic-water cycle ends, not just before a disinfection run, the Status sensor lingers on `domestic_water` while the pump is still circulating.
+
 ## Firmware Update Entity
 
 The **Firmware** update entity checks Alpha Innotec's public download portal (once per hour) for a newer firmware build than the one currently installed, comparing versions semantically. If a newer version exists, its release notes panel shows: a link to the manufacturer's firmware page for your specific model, a direct download link, localized (German/English) update instructions, and the raw change log fetched from the portal.

--- a/custom_components/luxtronik2/common.py
+++ b/custom_components/luxtronik2/common.py
@@ -232,7 +232,16 @@ def normalize_sensor_value(
     # endregion Workaround Luxtronik Bug: Line 1 shows 'pump forerun' on CompressorHeater!
 
     if sensor_id == LC.C0080_STATUS:
-        return _derive_operation_mode(value, coordinator)
+        mode = _derive_operation_mode(value, coordinator)
+        # Transition hold: the controller briefly reports no_request while
+        # moving from normal DHW heating into thermal disinfection, even though
+        # the DHW recirculation pump keeps running (issue #519). The coordinator
+        # decides once per poll whether we are inside such a window; here we
+        # only honour that decision. Scoped to no_request so a genuine switch to
+        # cooling or heating is never masked.
+        if mode == LuxOperationMode.no_request and coordinator.dhw_transition_hold:
+            return LuxOperationMode.domestic_water
+        return mode
 
     # no changes needed, return sensor value
     return value

--- a/custom_components/luxtronik2/common.py
+++ b/custom_components/luxtronik2/common.py
@@ -103,6 +103,90 @@ def get_sensor_data(
     )
 
 
+def _derive_operation_mode(value: Any, coordinator: LuxtronikCoordinatorData) -> Any:
+    """Derive the effective operation mode for C0080_STATUS.
+
+    The Luxtronik controller's raw status word is unreliable in several
+    documented cases (passive/active cooling reported as no_request, thermal
+    disinfection reported as heating, heating reported while the compressor is
+    off). Each ``if`` below is one such workaround. Returns ``value`` unchanged
+    when no workaround applies.
+    """
+    status_line3_raw = get_sensor_data(
+        coordinator, LC.C0119_STATUS_LINE_3, raw_value=True
+    )
+
+    if status_line3_raw == LuxStatus3Option.thermal_desinfection:
+        return LuxOperationMode.domestic_water
+
+    status_line1 = get_sensor_data(coordinator, LC.C0117_STATUS_LINE_1)
+    status_line3 = get_sensor_data(coordinator, LC.C0119_STATUS_LINE_3)
+    add_circ_pump = get_sensor_data(coordinator, LC.C0047_ADDITIONAL_CIRCULATION_PUMP)
+    s1_workaround: list[str] = [
+        LuxStatus1Option.heatpump_idle,
+        LuxStatus1Option.pump_forerun,
+        LuxStatus1Option.heatpump_coming,
+    ]
+    s3_workaround: list[str | None] = [
+        LuxStatus3Option.no_request,
+        LuxStatus3Option.unknown,
+        LuxStatus3Option.none,
+        LuxStatus3Option.grid_switch_on_delay,
+        None,
+    ]
+    if (
+        status_line1 in s1_workaround
+        and status_line3 in s3_workaround
+        and not add_circ_pump
+    ):
+        return LuxOperationMode.no_request
+
+    if (
+        status_line3
+        in [
+            LuxStatus3Option.no_request,
+            LuxStatus3Option.cycle_lock,
+            LuxStatus3Option.heating,
+        ]
+        and get_sensor_data(coordinator, LC.C0038_DHW_RECIRCULATION_PUMP)
+        and get_sensor_data(coordinator, LC.C0048_ADDITIONAL_HEAT_GENERATOR)
+    ):
+        return LuxOperationMode.domestic_water
+
+    if value == LuxOperationMode.no_request:
+        if (
+            status_line3_raw is not None
+            and status_line3_raw == LuxStatus3Option.cooling
+        ):
+            return LuxOperationMode.cooling
+
+        if (
+            status_line3_raw is not None
+            and status_line3_raw == LuxStatus3Option.heating
+        ):
+            T_in = get_sensor_data(coordinator, LC.C0010_FLOW_IN_TEMPERATURE)
+            T_out = get_sensor_data(coordinator, LC.C0011_FLOW_OUT_TEMPERATURE)
+            T_heat_in = get_sensor_data(
+                coordinator, LC.C0204_HEAT_SOURCE_INPUT_TEMPERATURE
+            )
+            T_heat_out = get_sensor_data(
+                coordinator, LC.C0024_HEAT_SOURCE_OUTPUT_TEMPERATURE
+            )
+            Flow_WQ = get_sensor_data(coordinator, LC.C0173_HEAT_SOURCE_FLOW_RATE)
+            Pump = get_sensor_data(coordinator, LC.C0043_PUMP_FLOW)
+            if (T_out > T_in) and (T_heat_out > T_heat_in) and (Flow_WQ > 0) and Pump:
+                return LuxOperationMode.cooling
+
+    if (
+        value == LuxOperationMode.heating
+        and not get_sensor_data(coordinator, LC.C0044_COMPRESSOR)
+        and not get_sensor_data(coordinator, LC.C0048_ADDITIONAL_HEAT_GENERATOR)
+    ):
+        return LuxOperationMode.no_request
+
+    return value
+
+
 def normalize_sensor_value(
     value: Any,
     coordinator: LuxtronikCoordinatorData | None,
@@ -148,84 +232,7 @@ def normalize_sensor_value(
     # endregion Workaround Luxtronik Bug: Line 1 shows 'pump forerun' on CompressorHeater!
 
     if sensor_id == LC.C0080_STATUS:
-        status_line3_raw = get_sensor_data(
-            coordinator, LC.C0119_STATUS_LINE_3, raw_value=True
-        )
-
-        if status_line3_raw == LuxStatus3Option.thermal_desinfection:
-            return LuxOperationMode.domestic_water
-
-        status_line1 = get_sensor_data(coordinator, LC.C0117_STATUS_LINE_1)
-        status_line3 = get_sensor_data(coordinator, LC.C0119_STATUS_LINE_3)
-        add_circ_pump = get_sensor_data(
-            coordinator, LC.C0047_ADDITIONAL_CIRCULATION_PUMP
-        )
-        s1_workaround: list[str] = [
-            LuxStatus1Option.heatpump_idle,
-            LuxStatus1Option.pump_forerun,
-            LuxStatus1Option.heatpump_coming,
-        ]
-        s3_workaround: list[str | None] = [
-            LuxStatus3Option.no_request,
-            LuxStatus3Option.unknown,
-            LuxStatus3Option.none,
-            LuxStatus3Option.grid_switch_on_delay,
-            None,
-        ]
-        if (
-            status_line1 in s1_workaround
-            and status_line3 in s3_workaround
-            and not add_circ_pump
-        ):
-            return LuxOperationMode.no_request
-
-        if (
-            status_line3
-            in [
-                LuxStatus3Option.no_request,
-                LuxStatus3Option.cycle_lock,
-                LuxStatus3Option.heating,
-            ]
-            and get_sensor_data(coordinator, LC.C0038_DHW_RECIRCULATION_PUMP)
-            and get_sensor_data(coordinator, LC.C0048_ADDITIONAL_HEAT_GENERATOR)
-        ):
-            return LuxOperationMode.domestic_water
-
-        if value == LuxOperationMode.no_request:
-            if (
-                status_line3_raw is not None
-                and status_line3_raw == LuxStatus3Option.cooling
-            ):
-                return LuxOperationMode.cooling
-
-            if (
-                status_line3_raw is not None
-                and status_line3_raw == LuxStatus3Option.heating
-            ):
-                T_in = get_sensor_data(coordinator, LC.C0010_FLOW_IN_TEMPERATURE)
-                T_out = get_sensor_data(coordinator, LC.C0011_FLOW_OUT_TEMPERATURE)
-                T_heat_in = get_sensor_data(
-                    coordinator, LC.C0204_HEAT_SOURCE_INPUT_TEMPERATURE
-                )
-                T_heat_out = get_sensor_data(
-                    coordinator, LC.C0024_HEAT_SOURCE_OUTPUT_TEMPERATURE
-                )
-                Flow_WQ = get_sensor_data(coordinator, LC.C0173_HEAT_SOURCE_FLOW_RATE)
-                Pump = get_sensor_data(coordinator, LC.C0043_PUMP_FLOW)
-                if (
-                    (T_out > T_in)
-                    and (T_heat_out > T_heat_in)
-                    and (Flow_WQ > 0)
-                    and Pump
-                ):
-                    return LuxOperationMode.cooling
-
-        if (
-            value == LuxOperationMode.heating
-            and not get_sensor_data(coordinator, LC.C0044_COMPRESSOR)
-            and not get_sensor_data(coordinator, LC.C0048_ADDITIONAL_HEAT_GENERATOR)
-        ):
-            return LuxOperationMode.no_request
+        return _derive_operation_mode(value, coordinator)
 
     # no changes needed, return sensor value
     return value

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -58,6 +58,14 @@ UPDATE_INTERVAL_NORMAL: Final = timedelta(minutes=1)
 UPDATE_INTERVAL_SLOW: Final = timedelta(minutes=3)
 UPDATE_INTERVAL_VERY_SLOW: Final = timedelta(minutes=5)
 
+# How long the status sensor keeps reporting domestic_water after a genuine DHW
+# state ends, provided the DHW recirculation pump is still running. Covers the
+# gap where the controller reports no_request while transitioning from normal
+# DHW heating into thermal disinfection (issue #519) - observed at ~2 minutes on
+# real hardware. Bounded so a permanently running recirculation pump can never
+# latch the status indefinitely.
+DHW_TRANSITION_HOLD: Final = timedelta(minutes=5)
+
 
 SECOND_TO_HOUR_FACTOR: Final = 1 / 3600
 

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Mapping
-from datetime import timedelta
+from datetime import datetime, timedelta
 import operator
 import re
 from types import MappingProxyType
@@ -17,9 +17,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 from packaging.version import InvalidVersion, Version
 
-from .common import normalize_sensor_value
+from .common import get_sensor_data, normalize_sensor_value
 from .const import (
     CONF_CALCULATIONS,
     CONF_MAX_DATA_LENGTH,
@@ -30,6 +31,7 @@ from .const import (
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
     DEFAULT_UPDATE_INTERVAL,
+    DHW_TRANSITION_HOLD,
     DOMAIN,
     LOGGER,
     LUX_PARAMETER_MK_SENSORS,
@@ -37,6 +39,7 @@ from .const import (
     DeviceKey,
     LuxCalculation as LC,
     LuxMkTypes,
+    LuxOperationMode,
     LuxParameter as LP,
     LuxRoomThermostatType,
     LuxVisibility as LV,
@@ -85,6 +88,8 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         self.client = client
         self._config = config
         self.device_infos = dict[str, DeviceInfo]()
+        # Deadline for the DHW transition hold; see _update_dhw_transition_hold().
+        self._dhw_hold_until: datetime | None = None
 
         update_interval: timedelta = DEFAULT_UPDATE_INTERVAL
         raw = config.get(CONF_UPDATE_INTERVAL)
@@ -117,15 +122,51 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
                     if self.update_interval is not None
                     else None,
                 )
-                self.data = LuxtronikCoordinatorData(
+                data = LuxtronikCoordinatorData(
                     parameters=self.client.parameters,
                     calculations=self.client.calculations,
                     visibilities=self.client.visibilities,
                 )
+                self._update_dhw_transition_hold(data)
+                self.data = data
 
                 return self.data
             except Exception as err:
                 raise UpdateFailed(f"Error fetching data: {err}") from err
+
+    def _update_dhw_transition_hold(self, data: LuxtronikCoordinatorData) -> None:
+        """Decide whether this poll falls inside a DHW transition hold.
+
+        The controller drops to no_request for a minute or two while moving from
+        normal domestic-water heating into thermal disinfection, even though the
+        DHW recirculation pump keeps running (issue #519). Reporting the heat
+        pump as idle there breaks utility meters that split energy by operating
+        mode, so we keep reporting domestic_water for a bounded window.
+
+        Reading the status through get_sensor_data() here is safe and
+        deliberate: `data.dhw_transition_hold` is still False at this point, so
+        the value returned is the un-held mode - exactly the input this decision
+        needs, with no second derivation path to keep in sync.
+
+        The hold can only ever extend a domestic_water state that actually
+        happened. It never starts one from the pump alone, and it is capped at
+        DHW_TRANSITION_HOLD so a permanently running pump cannot latch it.
+        """
+        now = dt_util.utcnow()
+
+        if get_sensor_data(data, LC.C0080_STATUS) == LuxOperationMode.domestic_water:
+            self._dhw_hold_until = now + DHW_TRANSITION_HOLD
+            return
+
+        if (
+            self._dhw_hold_until is not None
+            and now < self._dhw_hold_until
+            and get_sensor_data(data, LC.C0038_DHW_RECIRCULATION_PUMP)
+        ):
+            data.dhw_transition_hold = True
+            return
+
+        self._dhw_hold_until = None
 
     async def async_write(self, parameter: str, value: Any) -> LuxtronikCoordinatorData:
         """Write a single parameter to the heat pump and confirm it stuck.

--- a/custom_components/luxtronik2/model.py
+++ b/custom_components/luxtronik2/model.py
@@ -52,6 +52,10 @@ class LuxtronikCoordinatorData:
     calculations: Calculations
     visibilities: Visibilities
 
+    # Derived once per poll by LuxtronikCoordinator._update_dhw_transition_hold().
+    # Defaulted so every other construction site (tests, diagnostics) is unaffected.
+    dhw_transition_hold: bool = False
+
 
 @dataclass
 class LuxtronikEntityAttributeDescription:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -309,6 +309,57 @@ class TestNormalizeSensorValue:
         result = normalize_sensor_value(LuxOperationMode.heating, data, LC.C0080_STATUS)
         assert result == LuxOperationMode.no_request
 
+    def test_dhw_hold_converts_no_request_to_domestic_water(self):
+        """During the DHW->TDI transition the status must stay domestic_water."""
+        data = make_coordinator_data(
+            calculations={
+                "ID_WEB_HauptMenuStatus_Zeile3": LuxStatus3Option.no_request,
+                "ID_WEB_BUPout": True,
+                "ID_WEB_ZW1out": False,
+            }
+        )
+        data.dhw_transition_hold = True
+        result = normalize_sensor_value(
+            LuxOperationMode.no_request, data, LC.C0080_STATUS
+        )
+        assert result == LuxOperationMode.domestic_water
+
+    def test_no_dhw_hold_leaves_no_request_alone(self):
+        """Without an active hold the existing no_request behaviour is unchanged."""
+        data = make_coordinator_data(
+            calculations={
+                "ID_WEB_HauptMenuStatus_Zeile3": LuxStatus3Option.no_request,
+                "ID_WEB_BUPout": True,
+                "ID_WEB_ZW1out": False,
+            }
+        )
+        result = normalize_sensor_value(
+            LuxOperationMode.no_request, data, LC.C0080_STATUS
+        )
+        assert result == LuxOperationMode.no_request
+
+    def test_dhw_hold_does_not_mask_cooling(self):
+        """A hold must never override a mode the heat pump genuinely moved into."""
+        data = make_coordinator_data(
+            calculations={
+                "ID_WEB_HauptMenuStatus_Zeile3": LuxStatus3Option.cooling,
+            }
+        )
+        data.dhw_transition_hold = True
+        result = normalize_sensor_value(
+            LuxOperationMode.no_request, data, LC.C0080_STATUS
+        )
+        assert result == LuxOperationMode.cooling
+
+    def test_dhw_hold_does_not_affect_other_sensors(self):
+        """The hold is scoped to C0080_STATUS only."""
+        data = make_coordinator_data(
+            calculations={"ID_WEB_HauptMenuStatus_Zeile1": "Heatpump Idle"}
+        )
+        data.dhw_transition_hold = True
+        result = normalize_sensor_value("Heatpump Idle", data, LC.C0117_STATUS_LINE_1)
+        assert result == LuxStatus1Option.heatpump_idle
+
 
 # ===========================================================================
 # state_as_number_or_none

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -22,8 +22,10 @@ from custom_components.luxtronik2.const import (
     DeviceKey,
     LuxCalculation as LC,
     LuxMkTypes,
+    LuxOperationMode,
     LuxParameter as LP,
     LuxRoomThermostatType,
+    LuxStatus3Option,
     LuxVisibility as LV,
 )
 from custom_components.luxtronik2.coordinator import (
@@ -84,6 +86,7 @@ def _make_coordinator_direct(data=None):
     coord.client = MagicMock()
     coord._config = {"host": "1.2.3.4", "port": 8889}
     coord.device_infos = {}
+    coord._dhw_hold_until = None
     coord.async_request_refresh = AsyncMock()
     coord.async_refresh = AsyncMock()
     coord.update_interval = DEFAULT_UPDATE_INTERVAL
@@ -1476,3 +1479,92 @@ class TestConnectAndGetCoordinator:
             pytest.raises(LuxtronikConnectionError),
         ):
             await connect_and_get_coordinator(MagicMock(), config_entry)
+
+
+# ===========================================================================
+# DHW transition hold (issue #519)
+# ===========================================================================
+
+
+class TestDhwTransitionHold:
+    """Cross-poll lifecycle of the DHW transition hold (issue #519)."""
+
+    def _coord(self) -> LuxtronikCoordinator:
+        return _make_coordinator()
+
+    def _data(self, status: str, recirculation: bool) -> LuxtronikCoordinatorData:
+        return make_coordinator_data(
+            calculations={
+                "ID_WEB_WP_BZ_akt": status,
+                "ID_WEB_HauptMenuStatus_Zeile3": LuxStatus3Option.no_request,
+                "ID_WEB_BUPout": recirculation,
+                "ID_WEB_ZW1out": False,
+            }
+        )
+
+    def test_dhw_poll_arms_the_hold_but_does_not_flag_it(self):
+        """While DHW is genuinely reported there is nothing to hold."""
+        coord = self._coord()
+        data = self._data(LuxOperationMode.domestic_water, recirculation=True)
+        coord._update_dhw_transition_hold(data)
+        assert data.dhw_transition_hold is False
+        assert coord._dhw_hold_until is not None
+
+    def test_next_poll_holds_when_pump_still_running(self, freezer):
+        """The transition poll right after DHW must be flagged as held."""
+        coord = self._coord()
+        freezer.move_to("2026-08-08 12:00:00+00:00")
+        coord._update_dhw_transition_hold(
+            self._data(LuxOperationMode.domestic_water, recirculation=True)
+        )
+        freezer.move_to("2026-08-08 12:01:00+00:00")
+        data = self._data(LuxOperationMode.no_request, recirculation=True)
+        coord._update_dhw_transition_hold(data)
+        assert data.dhw_transition_hold is True
+
+    def test_no_hold_when_pump_stopped(self, freezer):
+        """Pump off means the DHW cycle really ended - report no_request."""
+        coord = self._coord()
+        freezer.move_to("2026-08-08 12:00:00+00:00")
+        coord._update_dhw_transition_hold(
+            self._data(LuxOperationMode.domestic_water, recirculation=True)
+        )
+        freezer.move_to("2026-08-08 12:01:00+00:00")
+        data = self._data(LuxOperationMode.no_request, recirculation=False)
+        coord._update_dhw_transition_hold(data)
+        assert data.dhw_transition_hold is False
+        assert coord._dhw_hold_until is None
+
+    def test_hold_expires_after_the_configured_window(self, freezer):
+        """A permanently running recirculation pump must not latch DHW forever."""
+        coord = self._coord()
+        freezer.move_to("2026-08-08 12:00:00+00:00")
+        coord._update_dhw_transition_hold(
+            self._data(LuxOperationMode.domestic_water, recirculation=True)
+        )
+        freezer.move_to("2026-08-08 12:06:00+00:00")  # > DHW_TRANSITION_HOLD
+        data = self._data(LuxOperationMode.no_request, recirculation=True)
+        coord._update_dhw_transition_hold(data)
+        assert data.dhw_transition_hold is False
+        assert coord._dhw_hold_until is None
+
+    def test_hold_does_not_start_from_pump_alone(self):
+        """Without a preceding genuine DHW state the pump alone proves nothing."""
+        coord = self._coord()
+        data = self._data(LuxOperationMode.no_request, recirculation=True)
+        coord._update_dhw_transition_hold(data)
+        assert data.dhw_transition_hold is False
+
+    def test_hold_does_not_extend_itself(self, freezer):
+        """The deadline is anchored to the last genuine DHW poll, not refreshed."""
+        coord = self._coord()
+        freezer.move_to("2026-08-08 12:00:00+00:00")
+        coord._update_dhw_transition_hold(
+            self._data(LuxOperationMode.domestic_water, recirculation=True)
+        )
+        deadline = coord._dhw_hold_until
+        freezer.move_to("2026-08-08 12:02:00+00:00")
+        coord._update_dhw_transition_hold(
+            self._data(LuxOperationMode.no_request, recirculation=True)
+        )
+        assert coord._dhw_hold_until == deadline

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -35,6 +35,17 @@ class TestLuxtronikCoordinatorData:
         assert data.calculations.get("key2") is not None
         assert data.visibilities.get("key3") is not None
 
+    def test_dhw_transition_hold_defaults_to_false(self):
+        """A freshly built bundle must not hold - callers may omit the field."""
+        data = make_coordinator_data()
+        assert data.dhw_transition_hold is False
+
+    def test_dhw_transition_hold_is_settable(self):
+        """The coordinator sets this once per poll after building the bundle."""
+        data = make_coordinator_data()
+        data.dhw_transition_hold = True
+        assert data.dhw_transition_hold is True
+
 
 class TestLuxtronikEntityDescription:
     def test_defaults(self):


### PR DESCRIPTION
## 🐛 Problem

The controller drops to `no_request` for a minute or two while switching from normal domestic-water heating into a thermal disinfection run, even though the DHW recirculation pump keeps running. The **Status** sensor reports the heat pump as idle in that window, which breaks utility meters that split energy by operating mode.

The TDI run *itself* was already fixed — `status_line_3 == thermal_desinfection` maps to `domestic_water`. What remained was only the transition *into* it. In @ChrisMisker's history one such gap lasted 117 seconds.

## ✨ Approach

A time-bounded **hold**. The coordinator owns the cross-poll state (a deadline) and derives a single boolean onto the per-poll data bundle. `normalize_sensor_value()` stays a pure function of that bundle: when its existing rules produce `no_request` **and** the bundle says a hold is active, it returns `domestic_water`.

Three guards keep this from becoming a false-positive machine:

- The hold can only be **armed** by a genuine `domestic_water` poll. It never starts one from the recirculation pump alone — which is what made the simpler "pump ON ⇒ DHW" rule unattractive.
- It requires the recirculation pump to be running **now**, and ends the moment it stops.
- It expires after `DHW_TRANSITION_HOLD` (5 minutes), so a permanently running pump can never latch the status.

It also only ever converts `no_request`. A genuine switch to `heating` or `cooling` is never masked.

## 🏗️ Why the state lives where it does

`LuxtronikCoordinatorData` is rebuilt every poll, so it cannot hold cross-poll state. `normalize_sensor_value()` is called ~10× per poll (status sensor, 4 climate `hvac_action`, 2 water-heater `current_action`, the `SWITCH_GAP` formatter, the COP sensors), so a memo inside it would feed on its own output and latch indefinitely.

Hence the split: **time-dependent facts are computed once per poll on the bundle; pure functions of the bundle stay pure.** A pleasant consequence — when the coordinator reads the status to make its decision, the fresh bundle's flag is still `False`, so it naturally sees the un-held mode. No recursion, no second derivation path to keep in sync.

The first commit is a behaviour-neutral refactor extracting the six C0080 workarounds out of `normalize_sensor_value()` into `_derive_operation_mode()` — that branch was already 80 lines before this change.

## ⚠️ Behaviour change worth noting in the release notes

The hold fires after **any** DHW cycle ends, not only before a disinfection run. For up to 5 minutes after normal domestic-water heating, `status` lingers on `domestic_water` while the pump is still circulating, where it previously flipped to `no_request`. This is documented in `ADVANCED_FEATURES.md`.

## ✅ Verification

- 883 tests pass; coverage **100%** (3188 statements, 0 missed) — unchanged
- `ruff check` / `ruff format --check` clean, `basedpyright` 0 errors, `codespell` clean
- 10 new tests: 4 on the hold rule (pure), 6 on the cross-poll lifecycle (arming, pump stopping, expiry, no self-extension, no start-from-pump-alone)

**Not yet verified against real hardware.** The evidence above is tests only. This should sit on a live heat pump through an actual disinfection run before the issue is closed.

Resolves #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)
