### PR TITLE
fix(coordinator,lux_helper): 🐛 retry write confirmation instead of failing on a slow controller

### DIFF
--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -55,6 +55,24 @@ from .model import LuxtronikCoordinatorData, LuxtronikEntityDescription
 # endregion Imports
 
 
+# Some controllers do not reflect a freshly written parameter in their
+# readable register block immediately, so the confirming read-back still
+# returns the pre-write value (issue #729: LWC407 / firmware V1.88.3). The
+# write itself succeeded, so confirmation is retried for a bounded window
+# before a mismatch is reported as a failed write. Controllers that apply
+# writes instantly (~3 ms measured) confirm on the first read and never wait.
+#
+# The delay doubles per retry, capped: every attempt costs a *full* read of
+# ~1900 values, so probing cheaply at first (0.1 s catches a quick settler
+# without making it wait a fixed quarter second) then backing off keeps a
+# write that will never converge from burning reads. The cap stops the last
+# delay from overshooting the budget. Worst case: 6 reads over ~2.5 s of
+# waiting before a genuine rejection is reported.
+WRITE_CONFIRM_MAX_ATTEMPTS = 6
+WRITE_CONFIRM_INITIAL_DELAY = 0.1
+WRITE_CONFIRM_MAX_DELAY = 1.0
+
+
 def _write_confirmed(written: Any, confirmed: Any) -> bool:
     """Return True if a write's post-refresh read-back matches what was written.
 
@@ -205,40 +223,63 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
                 await self.hass.async_add_executor_job(self.client.write)
                 LOGGER.debug("Done: self.client.write")
 
-            # Refresh after write
-            await self.async_refresh()
-            LOGGER.debug("Coordinator data refreshed!")
-
-            # async_refresh() swallows failures internally (logs, does not
-            # raise) rather than propagating them, so self.data may still be
-            # the stale pre-write snapshot here. Comparing newly-written
-            # values against stale data would almost always look like a
-            # mismatch, misleadingly implying the device rejected the write
-            # when only the confirming read failed. Surface that distinctly
-            # instead of running the confirm comparison against stale data.
-            if not self.last_update_success:
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key="write_confirmation_unavailable",
-                    translation_placeholders={
-                        "parameters": ", ".join(parameter for parameter, _ in pairs)
-                    },
-                )
-
-            # Confirm each value after the read
+            # Refresh after write, retrying the confirming read while the
+            # device still reports pre-write values (see the
+            # WRITE_CONFIRM_* constants). The wait is awaited rather than
+            # slept through: this runs on Home Assistant's event loop, and
+            # the socket lock above is already released here.
             mismatches: list[str] = []
-            for parameter, value in pairs:
-                confirmed_value = self.get_value(f"{CONF_PARAMETERS}.{parameter}")
-                LOGGER.debug(
-                    'LuxtronikDevice.write finished %s value: "%s" (confirmed: "%s")',
-                    parameter,
-                    value,
-                    confirmed_value,
-                )
-                if not _write_confirmed(value, confirmed_value):
-                    mismatches.append(
-                        f"{parameter} (wrote {value!r}, device reports {confirmed_value!r})"
+            delay = WRITE_CONFIRM_INITIAL_DELAY
+            for attempt in range(WRITE_CONFIRM_MAX_ATTEMPTS):
+                if attempt:
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, WRITE_CONFIRM_MAX_DELAY)
+
+                await self.async_refresh()
+                LOGGER.debug("Coordinator data refreshed!")
+
+                # async_refresh() swallows failures internally (logs, does not
+                # raise) rather than propagating them, so self.data may still
+                # be the stale pre-write snapshot here. Comparing
+                # newly-written values against stale data would almost always
+                # look like a mismatch, misleadingly implying the device
+                # rejected the write when only the confirming read failed.
+                # Surface that distinctly instead of running the confirm
+                # comparison against stale data - and do not retry, since a
+                # failed read tells us nothing about the write.
+                if not self.last_update_success:
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="write_confirmation_unavailable",
+                        translation_placeholders={
+                            "parameters": ", ".join(parameter for parameter, _ in pairs)
+                        },
                     )
+
+                # Confirm each value after the read
+                mismatches = []
+                for parameter, value in pairs:
+                    confirmed_value = self.get_value(f"{CONF_PARAMETERS}.{parameter}")
+                    LOGGER.debug(
+                        'LuxtronikDevice.write finished %s value: "%s" (confirmed: "%s")',
+                        parameter,
+                        value,
+                        confirmed_value,
+                    )
+                    if not _write_confirmed(value, confirmed_value):
+                        mismatches.append(
+                            f"{parameter} (wrote {value!r}, device reports {confirmed_value!r})"
+                        )
+
+                if not mismatches:
+                    break
+
+                LOGGER.debug(
+                    "Write not confirmed yet (attempt %d/%d): %s",
+                    attempt + 1,
+                    WRITE_CONFIRM_MAX_ATTEMPTS,
+                    "; ".join(mismatches),
+                )
 
             if mismatches:
                 raise HomeAssistantError(

--- a/custom_components/luxtronik2/lux_helper.py
+++ b/custom_components/luxtronik2/lux_helper.py
@@ -22,8 +22,6 @@ from .const import (
 
 # endregion Imports
 
-WAIT_TIME_WRITE_PARAMETER = 1.0
-
 # List of ports that are known to respond to discovery packets.
 # Note: 47808 is also the IANA-reserved standard port for BACnet. discover()
 # only binds it for the brief duration of a broadcast+listen cycle and closes
@@ -295,9 +293,16 @@ class Luxtronik:
         self.connect()
 
         try:
+            # Write and read are exclusive: the coordinator refreshes right
+            # after a write to confirm it, so reading here too would fetch
+            # ~1900 values that are immediately discarded and overwritten -
+            # doubling the socket traffic of every write against a controller
+            # that is happier with less of it. Upstream splits these the same
+            # way (write() writes, write_and_read() is a separate method).
             if write:
                 self._write()
-            self._read()
+            else:
+                self._read()
         except (OSError, struct.error):
             # Deliberately not logged here: the exception propagates to the
             # coordinator, which re-raises it as UpdateFailed and lets
@@ -338,20 +343,37 @@ class Luxtronik:
                 continue
             data = struct.pack(">iii", LUXTRONIK_PARAMETERS_WRITE, index, value)
             self._socket.sendall(data)
+            # The controller acknowledges a 3002 write with two ints: the
+            # echoed command (3002) and the echoed *parameter index* - NOT the
+            # value it stored. Verified on an Alpha Innotec MSW4-16: writing
+            # index 894 (ID_Einst_BA_Lueftung_akt) the value 0 acks with 894,
+            # which cannot be any of that parameter's codes (0-3). So the ack
+            # says only "I received a write for this parameter", never whether
+            # the value was accepted, clamped or rejected - confirming a write
+            # requires reading the parameter back (see the WRITE_CONFIRM_*
+            # retry loop in coordinator.async_write_many).
             cmd = self._read_int()
-            val = self._read_int()
+            echoed_index = self._read_int()
             LOGGER.debug(
-                "Parameter '%d' set to '%s' (ack cmd=%s value=%s)",
+                "Parameter '%d' set to '%s' (ack cmd=%s echoed_index=%s)",
                 index,
                 value,
                 cmd,
-                val,
+                echoed_index,
             )
+            if echoed_index != index:
+                # An ack for a different parameter means the socket stream is
+                # no longer aligned to message boundaries, so every subsequent
+                # read is misaligned garbage rather than heat pump data.
+                LOGGER.warning(
+                    "Write ack mismatch: wrote parameter '%d' but the heat pump "
+                    "echoed '%s' (cmd=%s). The connection may be out of sync.",
+                    index,
+                    echoed_index,
+                    cmd,
+                )
         # Flush queue after writing all values
         self.parameters.queue = {}
-        # Give the heatpump a short time to handle the value changes/calculations:
-        # Todo: Change methods to async
-        # await asyncio.sleep(WAIT_TIME_WRITE_PARAMETER)
 
     def _read_exact(self, count: int) -> bytes:
         """Receive exactly ``count`` bytes from the socket.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -29,6 +29,9 @@ from custom_components.luxtronik2.const import (
     LuxVisibility as LV,
 )
 from custom_components.luxtronik2.coordinator import (
+    WRITE_CONFIRM_INITIAL_DELAY,
+    WRITE_CONFIRM_MAX_ATTEMPTS,
+    WRITE_CONFIRM_MAX_DELAY,
     LuxtronikConnectionError,
     LuxtronikCoordinator,
     LuxtronikSerialNumberError,
@@ -974,6 +977,164 @@ class TestAsyncWriteMany:
 
         result = await coord.async_write_many([("p1", "06:00")])
         assert result is not None
+
+
+class TestWriteConfirmRetry:
+    """Some controllers (e.g. LWC407 / firmware V1.88.3, issue #729) do not
+    reflect a freshly written parameter in their readable register block for
+    a few hundred ms, so the first confirming read still returns the old
+    value. The write itself succeeded, so confirmation must be retried before
+    the mismatch is reported as a failure."""
+
+    @pytest.mark.asyncio
+    async def test_stale_first_readback_confirms_on_retry(self):
+        """A controller that needs a moment to apply the write must not be
+        reported as having rejected it."""
+        coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock()
+        refreshes = 0
+
+        async def fake_refresh():
+            nonlocal refreshes
+            refreshes += 1
+            # First read-back is still the pre-write value; second has applied.
+            value = "Holidays" if refreshes == 1 else "Automatic"
+            coord.data = LuxtronikCoordinatorData(
+                parameters={"ID_Einst_BA_Lueftung_akt": (0, value)},
+                calculations={},
+                visibilities={},
+            )
+
+        coord.async_refresh = fake_refresh
+
+        with patch(
+            "custom_components.luxtronik2.coordinator.asyncio.sleep", new=AsyncMock()
+        ):
+            result = await coord.async_write("ID_Einst_BA_Lueftung_akt", "Automatic")
+
+        assert result is not None
+        assert refreshes == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_delay_is_awaited_not_blocking(self):
+        """The retry wait must yield to the event loop (await asyncio.sleep),
+        never block it - this runs inside Home Assistant's loop."""
+        coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock()
+        refreshes = 0
+
+        async def fake_refresh():
+            nonlocal refreshes
+            refreshes += 1
+            coord.data = LuxtronikCoordinatorData(
+                parameters={"p1": (0, 40 if refreshes == 1 else 42)},
+                calculations={},
+                visibilities={},
+            )
+
+        coord.async_refresh = fake_refresh
+        sleep_mock = AsyncMock()
+
+        with patch(
+            "custom_components.luxtronik2.coordinator.asyncio.sleep", new=sleep_mock
+        ):
+            await coord.async_write("p1", 42)
+
+        sleep_mock.assert_awaited_once_with(WRITE_CONFIRM_INITIAL_DELAY)
+
+    @pytest.mark.asyncio
+    async def test_immediate_confirmation_never_sleeps(self):
+        """Controllers that apply the write instantly (~3ms measured) must pay
+        no delay penalty: exactly one refresh, no wait."""
+        coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock()
+        refreshes = 0
+
+        async def fake_refresh():
+            nonlocal refreshes
+            refreshes += 1
+            coord.data = LuxtronikCoordinatorData(
+                parameters={"p1": (0, 42)},
+                calculations={},
+                visibilities={},
+            )
+
+        coord.async_refresh = fake_refresh
+        sleep_mock = AsyncMock()
+
+        with patch(
+            "custom_components.luxtronik2.coordinator.asyncio.sleep", new=sleep_mock
+        ):
+            await coord.async_write("p1", 42)
+
+        assert refreshes == 1
+        sleep_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_retry_delays_back_off_and_stay_capped(self):
+        """Each retry is a full read (~1900 values), so repeated probing is
+        expensive: the delay doubles to stop hammering a value that is not
+        converging, but stays capped so the final wait cannot overshoot the
+        retry budget."""
+        coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock()
+
+        async def fake_refresh():
+            # Never converges, so every retry is used.
+            coord.data = LuxtronikCoordinatorData(
+                parameters={"p1": (0, 40)},
+                calculations={},
+                visibilities={},
+            )
+
+        coord.async_refresh = fake_refresh
+        sleep_mock = AsyncMock()
+
+        with (
+            patch(
+                "custom_components.luxtronik2.coordinator.asyncio.sleep",
+                new=sleep_mock,
+            ),
+            pytest.raises(HomeAssistantError),
+        ):
+            await coord.async_write("p1", 42)
+
+        delays = [call.args[0] for call in sleep_mock.await_args_list]
+        assert delays == [0.1, 0.2, 0.4, 0.8, 1.0]
+        assert max(delays) == WRITE_CONFIRM_MAX_DELAY
+        assert delays[0] == WRITE_CONFIRM_INITIAL_DELAY
+
+    @pytest.mark.asyncio
+    async def test_genuinely_rejected_write_still_raises_after_retries(self):
+        """A clamped/rejected write never converges, so it must still surface
+        as write_confirmation_mismatch once the retry budget is spent."""
+        coord = _make_coordinator_direct()
+        coord.hass.async_add_executor_job = AsyncMock()
+        refreshes = 0
+
+        async def fake_refresh():
+            nonlocal refreshes
+            refreshes += 1
+            # Device clamped the write and will never report 42.
+            coord.data = LuxtronikCoordinatorData(
+                parameters={"p1": (0, 40)},
+                calculations={},
+                visibilities={},
+            )
+
+        coord.async_refresh = fake_refresh
+
+        with (
+            patch(
+                "custom_components.luxtronik2.coordinator.asyncio.sleep",
+                new=AsyncMock(),
+            ),
+            pytest.raises(HomeAssistantError) as exc_info,
+        ):
+            await coord.async_write("p1", 42)
+
+        assert exc_info.value.translation_key == "write_confirmation_mismatch"
+        assert refreshes == WRITE_CONFIRM_MAX_ATTEMPTS
 
 
 class TestWriteConfirmed:

--- a/tests/test_lux_helper.py
+++ b/tests/test_lux_helper.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import struct
 from unittest.mock import MagicMock, patch
 
@@ -498,6 +499,37 @@ class TestLuxtronikReadWrite:
         ):
             client._read_write(write=False)
 
+    def test_write_does_not_read_back(self):
+        """A write must not drag a full read (~1900 values) along with it: the
+        coordinator refreshes straight afterwards to confirm the write, so the
+        client-side read is discarded work and doubles the socket traffic of
+        every write. Upstream's write() reads nothing either."""
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+
+        with (
+            patch.object(client, "connect"),
+            patch.object(client, "_write") as mock_write,
+            patch.object(client, "_read") as mock_read,
+        ):
+            client._read_write(write=True)
+
+        mock_write.assert_called_once()
+        mock_read.assert_not_called()
+
+    def test_read_still_reads(self):
+        """The read path must be unaffected: it reads and never writes."""
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+
+        with (
+            patch.object(client, "connect"),
+            patch.object(client, "_write") as mock_write,
+            patch.object(client, "_read") as mock_read,
+        ):
+            client._read_write(write=False)
+
+        mock_read.assert_called_once()
+        mock_write.assert_not_called()
+
     def test_write_no_socket_raises(self):
         client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
         client._socket = None
@@ -509,8 +541,11 @@ class TestLuxtronikReadWrite:
         mock_sock = MagicMock()
         mock_sock.fileno.return_value = -1
         mock_socket_class.return_value = mock_sock
-        # recv returns packed ints for cmd and val responses
-        mock_sock.recv.return_value = struct.pack(">i", 0)
+        # The ack is the echoed command followed by the echoed parameter index.
+        mock_sock.recv.side_effect = [
+            struct.pack(">i", 3002),
+            struct.pack(">i", 1),
+        ]
 
         client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
         client._socket = mock_sock
@@ -536,11 +571,65 @@ class TestLuxtronikReadWrite:
         mock_sock.sendall.assert_not_called()
 
     @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_write_warns_when_ack_echoes_unexpected_index(
+        self, mock_socket_class, caplog
+    ):
+        """The controller acks a 3002 write by echoing the parameter index. An
+        echo for a different index means the socket stream has desynced, so
+        every following read is misaligned garbage - that must not pass
+        silently."""
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+        mock_sock.recv.side_effect = [
+            struct.pack(">i", 3002),
+            struct.pack(">i", 999),  # echo for a parameter we did not write
+        ]
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        client.parameters.queue = {1: 42}
+
+        with caplog.at_level(logging.WARNING):
+            client._write()
+
+        assert any(
+            record.levelno == logging.WARNING and "999" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_write_does_not_warn_when_ack_echoes_written_index(
+        self, mock_socket_class, caplog
+    ):
+        """A correct ack echoes back the index just written - the normal case,
+        which must stay quiet."""
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+        mock_sock.recv.side_effect = [
+            struct.pack(">i", 3002),
+            struct.pack(">i", 1),  # echo matches the written index
+        ]
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        client.parameters.queue = {1: 42}
+
+        with caplog.at_level(logging.WARNING):
+            client._write()
+
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
     def test_write_converts_float_to_int(self, mock_socket_class):
         mock_sock = MagicMock()
         mock_sock.fileno.return_value = -1
         mock_socket_class.return_value = mock_sock
-        mock_sock.recv.return_value = struct.pack(">i", 0)
+        mock_sock.recv.side_effect = [
+            struct.pack(">i", 3002),
+            struct.pack(">i", 5),
+        ]
 
         client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
         client._socket = mock_sock


### PR DESCRIPTION
## 🐛 Problem

Reported as a side observation in #729: every `luxtronik2.write` that actually changes a value raises

```
HomeAssistantError: Luxtronik heat pump did not confirm the written value(s):
ID_Einst_BA_Lueftung_akt (wrote 'Automatic', device reports 'Holidays')
```

The write **succeeds** — the controller shows the new mode. Only the verification read is wrong: some controllers (reporter's LWC407 / firmware V1.88.3) do not reflect a freshly written parameter in their readable register block for a few hundred ms, so the confirming read still returns the pre-write value. Writing an already-set value never errors, which is what points at timing.

Consequence for users: any script or automation calling the service needs `continue_on_error: true`, or the raised exception aborts every following step.

The race has always existed; it only became user-visible when 670d57a promoted a mismatch from a debug log to a raised `HomeAssistantError`.

## 🔍 Root cause

`async_write_many` judged the write by a **single** read taken immediately after it. That is fine on a fast controller and wrong on a slow one. It is a property of the device, not of the write.

Two things ruled out along the way:

- **The write ack cannot confirm anything.** The 3002 ack's second int echoes the written parameter's **index**, not the stored value — verified by writing `0` to index 894 (`ID_Einst_BA_Lueftung_akt`), which acked `894`, a number that cannot be any of that parameter's codes (0–3). So the ack says only "I received a write for this parameter", never whether the value was accepted, clamped or rejected.
- **A fixed settle sleep is the wrong shape.** It taxes every write on controllers that confirm in ~3 ms, and 1 s is a guess that may still be short elsewhere. It also cannot live in `lux_helper._write()`, which is sync and runs in an executor — which is precisely why the 2023 `WAIT_TIME_WRITE_PARAMETER` attempt was left commented out.

## ✅ Changes

- **`coordinator.py`** — the confirming read is retried with capped exponential backoff (`0.1 → 0.2 → 0.4 → 0.8 → 1.0` s, 6 attempts) before a mismatch is reported. Awaited on the event loop, after the socket lock is released. Controllers that apply writes instantly confirm on the first read and pay **no** delay; a genuinely rejected or clamped write still raises `write_confirmation_mismatch` once the budget is spent. A failed *read* still raises `write_confirmation_unavailable` immediately without retrying, since it says nothing about the write.
- **`lux_helper.py`** — a write no longer drags a full read behind it. The coordinator refreshes right afterwards to confirm, so the client-side read fetched ~1900 values that were immediately discarded, doubling the socket traffic of every write. Upstream splits these the same way (`write()` writes; `write_and_read()` is a separate method).
- **`lux_helper.py`** — the ack debug log said `value=`, inviting the reading that it confirms the write. Renamed to `echoed_index=` with the protocol and its evidence documented, plus a `LOGGER.warning` when the echo does not match the index written — that means the socket stream has desynced and every following read is misaligned garbage.
- **`lux_helper.py`** — removed the dead `WAIT_TIME_WRITE_PARAMETER` constant and its commented-out sleep. Never active since it was added in 2023, and sitting exactly where a settle wait cannot work — inviting the wrong fix for this bug.

## 🧪 Testing

Test-driven; every test was watched failing first.

- `TestWriteConfirmRetry` — stale-then-good read-back confirms on retry; the delay is awaited (not blocking); the backoff sequence and its cap are pinned; immediate confirmation takes exactly one refresh and **zero** sleeps; a rejected write still raises after the full budget.
- `TestLuxtronikReadWrite` — a write performs no read, the read path is unaffected, and the ack-mismatch warning fires only on mismatch. Two pre-existing tests fed unrealistic acks (writing index 1 while the mock returned `0` for both ints); they now return `(3002, <index>)` as real hardware does, asserting exactly what they asserted before.

```
892 passed — coverage 100% (3201/3201)
ruff check / ruff format --check / codespell — clean
basedpyright — 0 errors, 0 warnings, 0 notes
```

Protocol behaviour was verified live against an Alpha Innotec MSW4-16 (fw V3.92.1) over ~6 writes.

## ⚠️ Note for reviewers

This **cannot be reproduced on fast hardware.** The controller I have access to confirms in ~3 ms; the reporter's does not within ~270 ms. The retry loop is therefore correct by construction and covered by unit tests, but unexercised against a genuinely slow controller. The 6-attempt / ~2.5 s budget is a safety margin, not a measurement — if #729's reporter finds their LWC407 needs longer, it is a one-constant change.

Refs #729 — fixes only the write-verification race reported there. The issue's main request (ventilation entities) is untouched, so this does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
