### PR TITLE
feat(const,coordinator,sensor,select): ✨ add ventilation entities on their own device

### DIFF
--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -150,6 +150,7 @@ class DeviceKey(StrEnum):
     heating = "heating"
     domestic_water = "domestic_water"
     cooling = "cooling"
+    ventilation = "ventilation"
 
 
 class FirmwareVersionMinor(Enum):
@@ -493,7 +494,10 @@ class LuxParameter(StrEnum):
     P0881_MODE_SOLAR = "parameters.ID_Einst_Solar_akt"
     P0882_SOLAR_OPERATION_HOURS = "parameters.ID_BSTD_Solar"
     P0883_SOLAR_PUMP_MAX_TEMPERATURE_COLLECTOR = "parameters.ID_Einst_TDC_Koll_Max_akt"
-    # P0894_VENTILATION_MODE: Final = "parameters.ID_Einst_BA_Lueftung_akt" # "Automatic", "Party", "Holidays", "Off"
+    # Codes are 0=Automatic, 1=Party, 2=Holidays, 3=Off - note this differs
+    # from the heating/DHW mode numbering, which also has second_heatsource.
+    # Irrelevant to the select, which works on the library's decoded strings.
+    P0894_VENTILATION_MODE = "parameters.ID_Einst_BA_Lueftung_akt"
     P0966_COOLING_TARGET_TEMPERATURE_MK3 = "parameters.ID_Sollwert_KuCft3_akt"
     P0973_MAX_DHW_TEMPERATURE = "parameters.ID_Einst_BW_max"
     P0979_HEATING_MIN_FLOW_OUT_TEMPERATURE = (
@@ -640,6 +644,15 @@ class LuxCalculation(StrEnum):
     C0157_ANALOG_OUT2 = "calculations.ID_WEB_AnalogOut2"
     C0158_TIMER_HOT_GAS = "calculations.ID_WEB_Time_Heissgas"
     C0173_HEAT_SOURCE_FLOW_RATE = "calculations.ID_WEB_Durchfluss_WQ"
+    C0159_VENTILATION_SUPPLY_AIR_TEMPERATURE = (
+        "calculations.ID_WEB_Temp_Lueftung_Zuluft"
+    )
+    C0160_VENTILATION_EXHAUST_AIR_TEMPERATURE = (
+        "calculations.ID_WEB_Temp_Lueftung_Abluft"
+    )
+    # Analog 0-10 V fan-speed outputs, not on/off signals.
+    C0164_VENTILATION_SUPPLY_FAN = "calculations.ID_WEB_Out_VZU"
+    C0165_VENTILATION_EXHAUST_FAN = "calculations.ID_WEB_Out_VAB"
     C0175_SUCTION_EVAPORATOR_TEMPERATURE = "calculations.ID_WEB_LIN_ANSAUG_VERDAMPFER"
     C0176_SUCTION_COMPRESSOR_TEMPERATURE = "calculations.ID_WEB_LIN_ANSAUG_VERDICHTER"
     C0177_COMPRESSOR_HEATING_TEMPERATURE = "calculations.ID_WEB_LIN_VDH"
@@ -773,6 +786,11 @@ class SensorKey(StrEnum):
     SECOND_HEAT_GENERATOR_AMOUNT_COUNTER = "second_heat_generator_amount_counter"
     ANALOG_OUT1 = "analog_out1"
     ANALOG_OUT2 = "analog_out2"
+    VENTILATION_MODE = "ventilation_mode"
+    VENTILATION_SUPPLY_AIR_TEMPERATURE = "ventilation_supply_air_temperature"
+    VENTILATION_EXHAUST_AIR_TEMPERATURE = "ventilation_exhaust_air_temperature"
+    VENTILATION_SUPPLY_FAN = "ventilation_supply_fan"
+    VENTILATION_EXHAUST_FAN = "ventilation_exhaust_fan"
     CURRENT_HEAT_OUTPUT = "current_heat_output"
     CURRENT_POWER_CONSUMPTION = "current_power_consumption"
     PUMP_FREQUENCY = "pump_frequency"

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -336,6 +336,9 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         self.device_infos[DeviceKey.cooling] = self._build_device_info(
             DeviceKey.cooling, host, via
         )
+        self.device_infos[DeviceKey.ventilation] = self._build_device_info(
+            DeviceKey.ventilation, host, via
+        )
 
     def _build_device_info(
         self,
@@ -626,6 +629,8 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
             return self.has_domestic_water
         if device_key == DeviceKey.cooling:
             return self.has_cooling
+        if device_key == DeviceKey.ventilation:
+            return self.has_ventilation
         raise NotImplementedError
 
     @property
@@ -641,6 +646,35 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         if val is not None and val > 0:
             return True
         return self.detect_cooling_present()
+
+    @property
+    def has_ventilation(self) -> bool:
+        """Is an integrated ventilation module present.
+
+        Detected from the air temperatures, not from the ventilation
+        visibility flags, which are unreliable: issue #729's reporter runs a
+        working ventilation module while ID_Visi_Lueftung reads 0, so those
+        flags cannot be trusted in either direction and are deliberately not
+        consulted anywhere for ventilation. A unit without the module reports
+        a flat 0.0 on both channels instead (measured on an Alpha Innotec
+        MSW4-16), while a real module reports room-temperature exhaust air
+        and tempered supply air.
+
+        Both channels are required, so a single stuck or unwired channel
+        cannot conjure a phantom ventilation device. This is the only gate
+        the ventilation entities have - they carry no visibility of their
+        own - so it has to be the conservative one.
+
+        Same shape as _detect_solar_present()'s sentinel checks (5.0 / 150.0).
+        """
+        supply = self.get_value(LC.C0159_VENTILATION_SUPPLY_AIR_TEMPERATURE)
+        exhaust = self.get_value(LC.C0160_VENTILATION_EXHAUST_AIR_TEMPERATURE)
+        if supply is None or exhaust is None:
+            return False
+        try:
+            return float(supply) != 0.0 and float(exhaust) != 0.0
+        except (TypeError, ValueError):
+            return False
 
     def get_value(self, group_sensor_id: str | LP | LC | LV):
         """Get a sensor value from Luxtronik."""

--- a/custom_components/luxtronik2/select_entities_predefined.py
+++ b/custom_components/luxtronik2/select_entities_predefined.py
@@ -103,6 +103,17 @@ SELECT_ENTITIES: list[LuxtronikSelectEntityDescription] = [
         options=heating_control_mode_options,
     ),
     LuxtronikSelectEntityDescription(
+        key=SK.VENTILATION_MODE,
+        device_key=DeviceKey.ventilation,
+        luxtronik_key=LuxParameter.P0894_VENTILATION_MODE,
+        # VentilationMode has the same four states as the mixing-circuit modes
+        # (no second_heatsource), so the existing option list fits as-is.
+        # No visibility gate: there is no per-parameter flag for the
+        # ventilation mode, and the ventilation device itself is already
+        # gated on has_ventilation.
+        options=mode_mk_options,
+    ),
+    LuxtronikSelectEntityDescription(
         key=SK.PV_MODE_SELECTOR,
         device_key=DeviceKey.heatpump,
         luxtronik_key=LuxParameter.P0119_MODE_PV,

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -350,6 +350,41 @@ SENSORS: list[descr] = [
         factor=0.1,
     ),
     descr(
+        key=SensorKey.VENTILATION_SUPPLY_AIR_TEMPERATURE,
+        device_key=DeviceKey.ventilation,
+        luxtronik_key=LC.C0159_VENTILATION_SUPPLY_AIR_TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    ),
+    descr(
+        key=SensorKey.VENTILATION_EXHAUST_AIR_TEMPERATURE,
+        device_key=DeviceKey.ventilation,
+        luxtronik_key=LC.C0160_VENTILATION_EXHAUST_AIR_TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    ),
+    # VZU/VAB are analog 0-10 V fan-speed outputs, so they carry the
+    # modulation level a binary sensor would discard. The library's Voltage
+    # datatype already scales raw/10, hence no factor here.
+    descr(
+        key=SensorKey.VENTILATION_SUPPLY_FAN,
+        device_key=DeviceKey.ventilation,
+        luxtronik_key=LC.C0164_VENTILATION_SUPPLY_FAN,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+    ),
+    descr(
+        key=SensorKey.VENTILATION_EXHAUST_FAN,
+        device_key=DeviceKey.ventilation,
+        luxtronik_key=LC.C0165_VENTILATION_EXHAUST_FAN,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+    ),
+    descr(
         key=SensorKey.CURRENT_HEAT_OUTPUT,
         luxtronik_key=LC.C0257_CURRENT_HEAT_OUTPUT,
         state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -922,6 +922,18 @@
             },
             "circulation_pump_delta": {
                 "name": "Rozd\u00edl pr\u016ftoku ob\u011bhov\u00e9ho \u010derpadla"
+            },
+            "ventilation_supply_air_temperature": {
+                "name": "Teplota přiváděného vzduchu"
+            },
+            "ventilation_exhaust_air_temperature": {
+                "name": "Teplota odváděného vzduchu"
+            },
+            "ventilation_supply_fan": {
+                "name": "Ventilátor přívodu"
+            },
+            "ventilation_exhaust_fan": {
+                "name": "Ventilátor odvodu"
             }
         },
         "date": {
@@ -1049,6 +1061,15 @@
                     "party": "P\u00e1rty",
                     "holidays": "Dovolen\u00e1"
                 }
+            },
+            "ventilation_mode": {
+                "name": "Režim větrání",
+                "state": {
+                    "off": "Vypnuto",
+                    "automatic": "Automaticky",
+                    "party": "Párty",
+                    "holidays": "Dovolená"
+                }
             }
         },
         "climate": {
@@ -1077,6 +1098,9 @@
         },
         "cooling": {
             "name": "Chlazen\u00ed"
+        },
+        "ventilation": {
+            "name": "Větrání"
         }
     },
     "config": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -922,6 +922,18 @@
             },
             "second_heat_generator_amount_counter": {
                 "name": "Zweiter W\u00e4rmeerzeuger W\u00e4rmemenge"
+            },
+            "ventilation_supply_air_temperature": {
+                "name": "Zulufttemperatur"
+            },
+            "ventilation_exhaust_air_temperature": {
+                "name": "Ablufttemperatur"
+            },
+            "ventilation_supply_fan": {
+                "name": "Zuluftventilator"
+            },
+            "ventilation_exhaust_fan": {
+                "name": "Abluftventilator"
             }
         },
         "date": {
@@ -1049,6 +1061,15 @@
                     "party": "Hochleistung",
                     "holidays": "Ferien"
                 }
+            },
+            "ventilation_mode": {
+                "name": "Lüftungsmodus",
+                "state": {
+                    "off": "Aus",
+                    "automatic": "Automatisch",
+                    "party": "Hochleistung",
+                    "holidays": "Ferien"
+                }
             }
         },
         "climate": {
@@ -1077,6 +1098,9 @@
         },
         "cooling": {
             "name": "K\u00fchl"
+        },
+        "ventilation": {
+            "name": "Lüft"
         }
     },
     "config": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -922,6 +922,18 @@
             },
             "circulation_pump_delta": {
                 "name": "Circulation pump delta"
+            },
+            "ventilation_supply_air_temperature": {
+                "name": "Supply air temperature"
+            },
+            "ventilation_exhaust_air_temperature": {
+                "name": "Exhaust air temperature"
+            },
+            "ventilation_supply_fan": {
+                "name": "Supply fan"
+            },
+            "ventilation_exhaust_fan": {
+                "name": "Exhaust fan"
             }
         },
         "date": {
@@ -1049,6 +1061,15 @@
                     "party": "Party",
                     "holidays": "Holidays"
                 }
+            },
+            "ventilation_mode": {
+                "name": "Ventilation mode",
+                "state": {
+                    "off": "Off",
+                    "automatic": "Automatic",
+                    "party": "Party",
+                    "holidays": "Holidays"
+                }
             }
         },
         "climate": {
@@ -1077,6 +1098,9 @@
         },
         "cooling": {
             "name": "Cool"
+        },
+        "ventilation": {
+            "name": "Vent"
         }
     },
     "config": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -922,6 +922,18 @@
             },
             "second_heat_generator_amount_counter": {
                 "name": "Tweede warmtebron warmtemenge"
+            },
+            "ventilation_supply_air_temperature": {
+                "name": "Toevoerluchttemperatuur"
+            },
+            "ventilation_exhaust_air_temperature": {
+                "name": "Afvoerluchttemperatuur"
+            },
+            "ventilation_supply_fan": {
+                "name": "Toevoerventilator"
+            },
+            "ventilation_exhaust_fan": {
+                "name": "Afvoerventilator"
             }
         },
         "date": {
@@ -1049,6 +1061,15 @@
                     "party": "Party",
                     "holidays": "Vakantie"
                 }
+            },
+            "ventilation_mode": {
+                "name": "Ventilatiemodus",
+                "state": {
+                    "off": "Uit",
+                    "automatic": "Automatisch",
+                    "party": "Party",
+                    "holidays": "Vakantie"
+                }
             }
         },
         "climate": {
@@ -1077,6 +1098,9 @@
         },
         "cooling": {
             "name": "Koel"
+        },
+        "ventilation": {
+            "name": "Vent"
         }
     },
     "config": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -922,6 +922,18 @@
             },
             "pump_flow_delta_target": {
                 "name": "Delta docelowa przep\u0142ywu pompy"
+            },
+            "ventilation_supply_air_temperature": {
+                "name": "Temperatura powietrza nawiewanego"
+            },
+            "ventilation_exhaust_air_temperature": {
+                "name": "Temperatura powietrza wywiewanego"
+            },
+            "ventilation_supply_fan": {
+                "name": "Wentylator nawiewu"
+            },
+            "ventilation_exhaust_fan": {
+                "name": "Wentylator wywiewu"
             }
         },
         "date": {
@@ -1049,6 +1061,15 @@
                     "party": "Tryb imprezowy",
                     "holidays": "Tryb wakacyjny"
                 }
+            },
+            "ventilation_mode": {
+                "name": "Tryb wentylacji",
+                "state": {
+                    "off": "Wyłączony",
+                    "automatic": "Automatyczny",
+                    "party": "Tryb imprezowy",
+                    "holidays": "Tryb wakacyjny"
+                }
             }
         },
         "climate": {
@@ -1077,6 +1098,9 @@
         },
         "cooling": {
             "name": "Ch\u0142odzenie"
+        },
+        "ventilation": {
+            "name": "Wentylacja"
         }
     },
     "config": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -311,6 +311,56 @@ class TestDeviceKeyActive:
         )
         assert coord.device_key_active(DeviceKey.cooling) is True
 
+    def test_ventilation_active_when_both_air_temperatures_report(self):
+        """A ventilation module reports real supply and exhaust air
+        temperatures; units without one report 0.0 for both (issue #729)."""
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_Temp_Lueftung_Zuluft": 17.4,
+                "ID_WEB_Temp_Lueftung_Abluft": 21.2,
+            }
+        )
+        assert coord.device_key_active(DeviceKey.ventilation) is True
+
+    def test_ventilation_inactive_when_both_air_temperatures_are_zero(self):
+        """The no-module signal: both channels flat at 0.0 (measured on an
+        Alpha Innotec MSW4-16, which has no ventilation module)."""
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_Temp_Lueftung_Zuluft": 0.0,
+                "ID_WEB_Temp_Lueftung_Abluft": 0.0,
+            }
+        )
+        assert coord.device_key_active(DeviceKey.ventilation) is False
+
+    def test_ventilation_inactive_when_only_one_air_temperature_reports(self):
+        """Both channels are required. Gating fails open elsewhere in
+        entity_visible, so a half-signal must not create the device."""
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_Temp_Lueftung_Zuluft": 0.0,
+                "ID_WEB_Temp_Lueftung_Abluft": 21.2,
+            }
+        )
+        assert coord.device_key_active(DeviceKey.ventilation) is False
+
+    def test_ventilation_inactive_when_air_temperatures_are_not_numeric(self):
+        """A non-numeric reading is not evidence of a ventilation module, and
+        must not raise out of a device-gating check either."""
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_Temp_Lueftung_Zuluft": "n/a",
+                "ID_WEB_Temp_Lueftung_Abluft": "n/a",
+            }
+        )
+        assert coord.device_key_active(DeviceKey.ventilation) is False
+
+    def test_ventilation_inactive_when_air_temperatures_missing(self):
+        """Firmware that does not expose these calculations at all must not
+        produce a ventilation device."""
+        coord = _make_coordinator(calculations={})
+        assert coord.device_key_active(DeviceKey.ventilation) is False
+
     def test_unknown_device_key_raises(self):
         coord = _make_coordinator()
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
## ✨ What

Adds support for an integrated ventilation module, requested in #729. The data was already reachable over the socket — visibility flags set, parameter writable via `luxtronik2.write` — but no entity ever surfaced it.

New **Ventilation** device (`DeviceKey.ventilation`), a sibling of heating / domestic water / cooling under the same physical unit, carrying:

| Entity | Source | Type |
|---|---|---|
| Ventilation mode | parameter **894** `ID_Einst_BA_Lueftung_akt` | `select` — Automatic / Party / Holidays / Off |
| Supply air temperature (Zuluft) | calculation **159** | `sensor`, °C |
| Exhaust air temperature (Abluft) | calculation **160** | `sensor`, °C |
| Supply fan (VZU) | calculation **164** | `sensor`, **V** |
| Exhaust fan (VAB) | calculation **165** | `sensor`, **V** |

## 🔍 Two deviations from the issue as filed

**1. Gating is not based on the ventilation visibility flags.** The issue suggests gating on them, but the reporter's own diagnostics show `ID_Visi_Lueftung` (6) = **0** on a system that demonstrably *has* a working ventilation module. Those flags cannot be trusted in either direction, so they are deliberately not consulted anywhere for ventilation.

Instead `has_ventilation` detects the module from the air temperatures: a unit without one reports a flat `0.0` on **both** channels (measured on an Alpha Innotec MSW4-16), while a real module reports room-temperature exhaust air and tempered supply air. Same shape as the existing `_detect_solar_present()` sentinel checks (`!= 5.0` / `!= 150.0`).

Both channels are required. This device gate is the *only* thing keeping ventilation entities off unrelated heat pumps, so it is deliberately the conservative form — a single stuck or unwired channel cannot conjure a phantom device.

**2. VZU/VAB are voltage sensors, not binary sensors.** The issue asks for `binary_sensor`, but the library types both as `Voltage` — they are analog 0–10 V fan-speed outputs, so an on/off sensor would discard the modulation level. `VSK` (calculation 166) genuinely *is* boolean but its visibility reads 0 on the reporter's system, so it is excluded.

## 📝 Notes

- The mode select reuses the existing `mode_mk_options` list: `VentilationMode` has exactly the same four states as the mixing-circuit modes. Its raw codes differ from heating/DHW (0–3, no `second_heatsource`) but selects operate on the library's decoded strings, so that stays invisible.
- No `factor` on the fan sensors — the library's `Voltage` datatype already scales raw/10.
- Device name, select + its four states, and all four sensor names added to **en/de/nl/cs/pl**.

## 🧪 Testing

```
888 passed — coverage 100% (3212/3212)
translation coverage check — complete across all five locales
ruff check / ruff format --check / codespell — clean
basedpyright — 0 errors, 0 warnings, 0 notes
```

`has_ventilation` is covered for: both channels reporting, both flat at 0.0, only one reporting, keys absent, and non-numeric readings.

## ⚠️ For reviewers

**Detection is verified only against the negative case.** An MSW4-16 with no ventilation module reads 0.0/0.0 and correctly gets no device. The positive path is covered with synthetic values — nobody has confirmed that a *real* ventilation module reports non-zero on both channels. #729's reporter (LWC407 / V1.88.3) is the one who can prove that, and it is worth waiting for their confirmation before release.

**Coupled to #732.** The fan sensors use the same `Voltage` datatype as `analog_out1`/`analog_out2`. If the analog-out scaling question resolves the other way, these two need a `factor=0.1` as well.

Refs #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

