### PR TITLE
fix(sensor): 🐛 stop scaling the analog outputs twice

### DIFF
--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -337,7 +337,6 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         visibility=LV.V0248_ANALOG_OUT1,
         entity_registry_enabled_default=False,
-        factor=0.1,
     ),
     descr(
         key=SensorKey.ANALOG_OUT2,
@@ -347,7 +346,6 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         visibility=LV.V0249_ANALOG_OUT2,
         entity_registry_enabled_default=False,
-        factor=0.1,
     ),
     descr(
         key=SensorKey.CURRENT_HEAT_OUTPUT,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
+from luxtronik.calculations import Calculations
 
 from conftest import make_coordinator_data
 from custom_components.luxtronik2.binary_sensor import LuxtronikBinarySensorEntity
@@ -730,6 +731,33 @@ def _energy_input_case(
         dt for dt in parameters_to_add_update.values() if dt.name == raw_name
     )
     return description, datatype
+
+
+class TestAnalogOutScaling:
+    """The library's Voltage datatype already applies its own scaling_factor
+    of 0.1, and the coordinator surfaces that decoded value. An additional
+    `factor` in the description would scale a second time and report a tenth
+    of the real voltage. Unlike the energy inputs below, the raw analog-out
+    registers carry no extra /10, so no factor belongs here."""
+
+    def _assert_raw_converts_to(
+        self, sensor_key: SensorKey, raw_value: int, expected_volt: float
+    ) -> None:
+        description = next(d for d in SENSORS if d.key == sensor_key)
+        raw_name = description.luxtronik_key.rsplit(".", 1)[1]
+        datatype = Calculations().get(raw_name)
+        converted = datatype.from_heatpump(raw_value)
+        group, sensor_id = description.luxtronik_key.split(".", 1)
+        data = make_coordinator_data(**{group: {sensor_id: converted}})
+        entity = _make_sensor(description, data)
+        entity._handle_coordinator_update(data)
+        assert entity._attr_native_value == expected_volt
+
+    def test_analog_out1_scaling(self):
+        self._assert_raw_converts_to(SensorKey.ANALOG_OUT1, 105, 10.5)
+
+    def test_analog_out2_scaling(self):
+        self._assert_raw_converts_to(SensorKey.ANALOG_OUT2, 55, 5.5)
 
 
 class TestEnergyInputScaling:


### PR DESCRIPTION
## 🐛 Problem

`ANALOG_OUT1` / `ANALOG_OUT2` apply `factor=0.1` on top of the luxtronik library's `Voltage` datatype, which already scales the raw value by its own `scaling_factor = 0.1`. The coordinator surfaces that **decoded** value (`.value`), so the description's factor scales a second time.

Raw `105` is reported as **1.05 V** instead of **10.5 V** — a tenth of the real voltage.

## ✅ Fix

Remove `factor=0.1` from both descriptions. Nothing else changes; the datatype's own scaling is left to do the work.

## 🧪 Testing

Added `TestAnalogOutScaling`, mirroring the existing `TestEnergyInputScaling` guard. It fails on `main` with `assert 1.05 == 10.5` and passes after the fix.

```
885 passed — coverage 100% (3188/3188)
ruff check / ruff format --check / codespell — clean
basedpyright — 0 errors, 0 warnings, 0 notes
```

## ⚠️ Please sanity-check against real hardware before merging

This deserves scrutiny, because a stacked factor is **not** automatically a bug in this codebase. `TestEnergyInputScaling` documents the opposite case: the energy inputs legitimately need `factor=0.1` on top of `Energy`'s own `/10`, because those raw registers are in `kWh/10` units — `/100` total is intended there.

What supports this change:
- The library declares `Voltage(ScalingBase)` with `scaling_factor = 0.1` and unit `V`, with no documented second offset (unlike the energy case).
- `.value` demonstrably returns the decoded number (raw 105 → 10.5).

What is **not** established: what the controller's analog-out register means physically. If those registers are in units of 0.01 V (0–1000 spanning 0–10 V), then the old `factor=0.1` was compensating correctly and this change makes readings 10× too high — the mirror image of the bug the energy test guards.

It could not be settled empirically here: both entities are `entity_registry_enabled_default=False`, so they have no state on the test system. **Enabling `analog_out1` on a heat pump with a configured analog output and comparing one reading against the controller display would decide it outright.**

**Coupled to #731.** The ventilation fan sensors (VZU/VAB) added there use the same `Voltage` datatype and are deliberately factor-free, consistent with this change. If this resolves the other way, those need a factor too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
