### PR TITLE
fix(sensor): 🐛 restore 0.1 factor on additional heat generator amount counter

### DIFF
--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -314,7 +314,11 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         entity_active_formula="!= 0.0",
         visibility=LV.V0324_ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER,
-        factor=0.01,
+        # Raw register unit is 0.1 kWh. #490 changed this to 0.01 based on a
+        # single unverified display comparison; measured against the rated
+        # element power (parameter 1025) on five units, 0.1 is the correct
+        # scale and 0.01 reports a tenth of the real energy. See #625.
+        factor=0.1,
         native_precision=1,
     ),
     descr(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -780,3 +780,48 @@ class TestEnergyInputScaling:
 
     def test_cooling_energy_input_scaling(self):
         self._assert_raw_converts_to(SensorKey.COOLING_ENERGY_INPUT, 12345, 123.45)
+
+
+class TestAuxHeaterAmountScaling:
+    """Parameters 1059 and 1140 both count auxiliary-heater heat in 0.1 kWh
+    units. They stay `Unknown` in the library, so the description's `factor`
+    is the whole conversion and the raw register reaches the entity untouched.
+
+    The scale is pinned by physics rather than by a datatype: energy divided
+    by the aux heater's run time must equal its rated power (parameter 1025).
+    The values below are real readings taken from user diagnostics in #625 -
+    37539 counts over 420.03 hours of ZWE1 run time on a unit whose rated
+    element is 9.0 kW, giving 8.94 kW at factor 0.1 and 0.89 kW at 0.01.
+    """
+
+    def _assert_raw_converts_to(
+        self, sensor_key: SensorKey, raw_value: int, expected_kwh: float
+    ) -> None:
+        description = next(d for d in SENSORS if d.key == sensor_key)
+        group, sensor_id = description.luxtronik_key.split(".", 1)
+        data = make_coordinator_data(**{group: {sensor_id: raw_value}})
+        entity = _make_sensor(description, data)
+        entity._handle_coordinator_update(data)
+        assert entity._attr_native_value == expected_kwh
+
+    def test_additional_heat_generator_amount_counter_scaling(self):
+        self._assert_raw_converts_to(
+            SensorKey.ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER, 37539, 3753.9
+        )
+
+    def test_second_heat_generator_amount_counter_scaling(self):
+        self._assert_raw_converts_to(
+            SensorKey.SECOND_HEAT_GENERATOR_AMOUNT_COUNTER, 841, 84.1
+        )
+
+    def test_implied_power_matches_rated_element(self):
+        """Guards the scale itself: 37539 counts over 420.03 ZWE1 hours must
+        come out near the unit's rated 9.0 kW, which only holds at 0.1."""
+        description = next(
+            d
+            for d in SENSORS
+            if d.key == SensorKey.ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER
+        )
+        assert description.factor is not None
+        implied_kw = 37539 * description.factor / 420.03
+        assert 8.0 <= implied_kw <= 9.5


### PR DESCRIPTION
## 🐛 Problem

Since #490 changed the factor of parameter 1059 `ID_Waermemenge_ZWE` from `0.1` to `0.01`, `sensor.<prefix>_additional_heat_generator_amount_counter` reports a tenth of the real energy. Reported in #625, where four users split evenly on which factor was right, with no correlation to firmware version.

## 🔍 How the scale was settled

By measurement rather than by comparing displays. Accumulated energy divided by the aux heater's run time (parameter 671 `ID_Zaehler_BetrZeitZWE1`) must equal its rated power (parameter 1025 `ID_Einst_Leistung_ZWE`).

Ten distinct units from diagnostics dumps collected across issues; five carry both a non-zero 1059 and run time:

```
model     fw          p1059   p1140   ZWE1 h  kW@0.1  kW@0.01  rated(1025)
MSW4-16   V3.79       37539       -    420.0    8.94     0.89      9.0 kW
MSW4-16   V3.92.1     37604     841    430.5    8.73     0.87      9.0 kW
MSW2-6S   V3.92.3     63105    5165    788.4    8.00     0.80      9.0 kW
MSW2-9S   V3.92.3       178       -      2.0    8.83     0.88      9.0 kW
LW SEC 2  V3.89.5      1843       -     20.6    8.95     0.89      9.0 kW
```

Every unit lands at 8.0–8.95 kW under `0.1` against a rated 9.0 kW. Under `0.01` they would all have to be 0.87 kW elements, which parameter 1025 contradicts on every machine.

The error direction is one-sided: a unit whose hour counter predates its kWh counter reads too *low*, never too high, so the highest observation is the best estimate of the true scale — 8.95 kW at `0.1` versus 0.89 kW at `0.01`.

## ✅ Changes

- `sensor_entities_predefined.py` — factor back to `0.1`, with the reasoning recorded at the description.
- `tests/test_sensor.py` — new `TestAuxHeaterAmountScaling`:
  - raw → kWh conversion for both aux-heater energy registers (1059 and 1140),
  - `test_implied_power_matches_rated_element`, asserting 37539 counts over 420.03 ZWE1 hours lands within 8.0–9.5 kW. This fails at `0.01`, so a future change to this factor has to argue with the measurement rather than a magic number.

## 🧪 Verification

- `pytest --cov=custom_components.luxtronik2` — 902 passed, coverage 100%
- `ruff check` / `ruff format --check` — clean
- `basedpyright` — 0 errors, 0 warnings
- `codespell` — clean

## ⚠️ Upgrade note

Anyone running `0.01` since January will see a 10× step in long-term statistics when the corrected value appears. It can be fixed under **Developer tools → Statistics**.

## 🔗 Related

- Resolves #625
- #733 — 1059 stops updating on firmware ≥ V3.92, superseded by 1140 (uncovered here, tracked separately)
- #734 — verify the energy-input scaling of 1136/1137/1139 by the same method

🤖 Generated with [Claude Code](https://claude.com/claude-code)
