### PR TITLE
refactor(lux_overrides,sensor): ♻️ scale aux heater counters via the Energy datatype

### DIFF
--- a/custom_components/luxtronik2/lux_overrides.py
+++ b/custom_components/luxtronik2/lux_overrides.py
@@ -14,7 +14,6 @@ from luxtronik.datatypes import (
     Power,
     SelectionBase,
     Timestamp,
-    Unknown,
 )
 from luxtronik.parameters import Parameters
 from luxtronik.visibilities import Visibilities
@@ -134,14 +133,21 @@ parameters_to_add_update = {
     1147: SecondsToHours("Extra_DHW_duration", True),
     1148: Celsius("HEATING_TARGET_TEMP_ROOM_THERMOSTAT", True),
     1159: Percent("ELECTRICAL_POWER_LIMIT_VALUE", True),
-    # Read-only sensors confirmed against Bouni/python-luxtronik's in-progress
-    # parameter definitions (not yet released). Their "kWh/10" unit note means
-    # an additional /10 is needed on top of Energy's own /10 scaling, which is
-    # exactly what the matching sensor descriptions already apply via factor=0.1.
+    # Read-only energy counters. These three still carry an additional /10 on
+    # top of Energy's own /10, applied via factor=0.1 on their descriptions -
+    # established from plausibility only (see 6df44aa), not from measurement.
+    # Upstream's "kWh/10" unit note is NOT what distinguishes them: 1059 and
+    # calculations 151/152/154 carry the same note and need Energy alone.
+    # Re-measuring these three is tracked in #734.
     1136: Energy("HEAT_ENERGY_INPUT", False),
     1137: Energy("DHW_ENERGY_INPUT", False),
     1139: Energy("COOLING_ENERGY_INPUT", False),
-    1140: Unknown("SECOND_HEAT_GENERATOR_AMOUNT_COUNTER", False),
+    # Auxiliary-heater heat counters, both in 0.1 kWh units, so Energy's own
+    # /10 is the whole conversion and their descriptions carry no factor. The
+    # scale was measured against the rated element power in #625; the name of
+    # 1059 must stay ID_Waermemenge_ZWE, which is how const.py resolves it.
+    1059: Energy("ID_Waermemenge_ZWE", False),
+    1140: Energy("SECOND_HEAT_GENERATOR_AMOUNT_COUNTER", False),
     # Bouni/python-luxtronik's in-progress definitions mark these read-only,
     # but our switch/number entities treat them as user-writable by design.
     1158: Bool("POWER_LIMIT_SWITCH", True),

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -314,11 +314,11 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         entity_active_formula="!= 0.0",
         visibility=LV.V0324_ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER,
-        # Raw register unit is 0.1 kWh. #490 changed this to 0.01 based on a
-        # single unverified display comparison; measured against the rated
-        # element power (parameter 1025) on five units, 0.1 is the correct
-        # scale and 0.01 reports a tenth of the real energy. See #625.
-        factor=0.1,
+        # Raw register unit is 0.1 kWh, applied by the Energy datatype this
+        # parameter is registered with in lux_overrides - hence no factor.
+        # #490 scaled it by a further /10 based on a single unverified display
+        # comparison; measured against the rated element power (parameter
+        # 1025) on five units, that reported a tenth of the real energy. #625.
         native_precision=1,
     ),
     descr(
@@ -329,7 +329,7 @@ SENSORS: list[descr] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         entity_active_formula="!= 0.0",
-        factor=0.1,
+        # 0.1 kWh raw unit, applied by the Energy datatype (see 1059 above).
         native_precision=1,
         # min_firmware_version_minor=FirmwareVersionMinor.minor_90,
     ),

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -784,44 +784,44 @@ class TestEnergyInputScaling:
 
 class TestAuxHeaterAmountScaling:
     """Parameters 1059 and 1140 both count auxiliary-heater heat in 0.1 kWh
-    units. They stay `Unknown` in the library, so the description's `factor`
-    is the whole conversion and the raw register reaches the entity untouched.
+    units, so the Energy datatype they are registered with is the whole
+    conversion and neither description carries a `factor`.
 
-    The scale is pinned by physics rather than by a datatype: energy divided
-    by the aux heater's run time must equal its rated power (parameter 1025).
-    The values below are real readings taken from user diagnostics in #625 -
-    37539 counts over 420.03 hours of ZWE1 run time on a unit whose rated
-    element is 9.0 kW, giving 8.94 kW at factor 0.1 and 0.89 kW at 0.01.
+    The scale is pinned by physics rather than by upstream's unit note:
+    energy divided by the aux heater's run time must equal its rated power
+    (parameter 1025). The values below are real readings from user
+    diagnostics in #625 - 37539 counts over 420.03 hours of ZWE1 run time on
+    a unit whose rated element is 9.0 kW, giving 8.94 kW at 0.1 kWh per count
+    and 0.89 kW if a further /10 is applied on top, as #490 did.
     """
 
-    def _assert_raw_converts_to(
-        self, sensor_key: SensorKey, raw_value: int, expected_kwh: float
-    ) -> None:
-        description = next(d for d in SENSORS if d.key == sensor_key)
+    def _converted_value(self, sensor_key: SensorKey, raw_value: int) -> float:
+        description, datatype = _energy_input_case(sensor_key)
+        converted = datatype.from_heatpump(raw_value)
         group, sensor_id = description.luxtronik_key.split(".", 1)
-        data = make_coordinator_data(**{group: {sensor_id: raw_value}})
+        data = make_coordinator_data(**{group: {sensor_id: converted}})
         entity = _make_sensor(description, data)
         entity._handle_coordinator_update(data)
-        assert entity._attr_native_value == expected_kwh
+        return entity._attr_native_value
 
     def test_additional_heat_generator_amount_counter_scaling(self):
-        self._assert_raw_converts_to(
-            SensorKey.ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER, 37539, 3753.9
+        value = self._converted_value(
+            SensorKey.ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER, 37539
         )
+        assert value == 3753.9
 
     def test_second_heat_generator_amount_counter_scaling(self):
-        self._assert_raw_converts_to(
-            SensorKey.SECOND_HEAT_GENERATOR_AMOUNT_COUNTER, 841, 84.1
+        value = self._converted_value(
+            SensorKey.SECOND_HEAT_GENERATOR_AMOUNT_COUNTER, 841
         )
+        assert value == 84.1
 
     def test_implied_power_matches_rated_element(self):
-        """Guards the scale itself: 37539 counts over 420.03 ZWE1 hours must
-        come out near the unit's rated 9.0 kW, which only holds at 0.1."""
-        description = next(
-            d
-            for d in SENSORS
-            if d.key == SensorKey.ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER
+        """Guards the whole chain - datatype plus description - rather than a
+        magic number: 37539 counts over 420.03 ZWE1 hours must come out near
+        the unit's rated 9.0 kW, which fails if either scaling step changes.
+        """
+        kwh = self._converted_value(
+            SensorKey.ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER, 37539
         )
-        assert description.factor is not None
-        implied_kw = 37539 * description.factor / 420.03
-        assert 8.0 <= implied_kw <= 9.5
+        assert 8.0 <= kwh / 420.03 <= 9.5


### PR DESCRIPTION
## ♻️ What

Follow-up to #735, which fixed the *value* of the aux-heater energy counters but left the scaling split across two places. This moves it into one.

Parameters **1059** `ID_Waermemenge_ZWE` and **1140** are registered with the library's `Energy` datatype instead of `Unknown`. Their raw unit is 0.1 kWh, which is exactly what `Energy.from_heatpump()` applies, so both sensor descriptions drop `factor` entirely.

This matches how calculations 151/152/154 are already handled, and how upstream python-luxtronik defines 1059 in its in-progress definitions.

## ✅ Changes

- `lux_overrides.py` — 1059 and 1140 registered as `Energy`. The name `ID_Waermemenge_ZWE` is preserved, since `const.py` resolves the parameter by name and `Parameters.parameters.update()` takes the override's name wholesale — renaming it would silently break the lookup.
- `sensor_entities_predefined.py` — `factor` removed from both descriptions.
- `lux_overrides.py` — corrected the comment above 1136/1137/1139. It claimed upstream's `kWh/10` unit note implies an additional /10 on top of `Energy`; #625 disproved that reading, since 1059 and calculations 151/152/154 carry the identical note and need `Energy` alone. Those three keep `factor=0.1` on plausibility grounds, now labelled as unverified, with re-measurement tracked in #734.
- `tests/test_sensor.py` — `TestAuxHeaterAmountScaling` now drives raw registers through the real datatype, so the implied-power guard covers the datatype choice as well as the description.

## 🧪 Verification

- `pytest --cov=custom_components.luxtronik2` — 902 passed, coverage 100%
- `ruff check` / `ruff format --check` — clean
- `basedpyright` — 0 errors, 0 warnings
- `codespell` — clean

No behaviour change: the reported value is identical to #735 as merged. Only the place the /10 is applied moves.

## 📋 Side effect

Diagnostics dumps now show these two registers decoded (`3753.9`) rather than raw (`37539`) — a deterministic ×10, worth knowing when reading dumps for scaling forensics.

## 🔗 Related

- Follows #735 / #625
- #734 — re-measure the energy-input scaling of 1136/1137/1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
