### PR TITLE
chore(lux_overrides,sensor): 🔍 verify energy-input scaling and move it into a datatype

### DIFF
--- a/custom_components/luxtronik2/lux_overrides.py
+++ b/custom_components/luxtronik2/lux_overrides.py
@@ -30,6 +30,23 @@ class MajorMinorVersion(Base):
         return f"{major}.{minor:02d}"
 
 
+class Energy2(Base):
+    """Energy counter stored in 0.01 kWh units, unlike the library's `Energy`.
+
+    Both scales occur on the same controller - see the energy-input parameters
+    in `parameters_to_add_update` for which registers were measured onto this
+    one, and why upstream's unit annotation cannot be used to tell them apart.
+    """
+
+    measurement_type = "energy"
+
+    def from_heatpump(self, value):
+        return value / 100
+
+    def to_heatpump(self, value):
+        return int(value * 100)
+
+
 class SecondsToHours(Base):
     """Seconds to hours datatype, converts from and to hours."""
 
@@ -133,15 +150,19 @@ parameters_to_add_update = {
     1147: SecondsToHours("Extra_DHW_duration", True),
     1148: Celsius("HEATING_TARGET_TEMP_ROOM_THERMOSTAT", True),
     1159: Percent("ELECTRICAL_POWER_LIMIT_VALUE", True),
-    # Read-only energy counters. These three still carry an additional /10 on
-    # top of Energy's own /10, applied via factor=0.1 on their descriptions -
-    # established from plausibility only (see 6df44aa), not from measurement.
-    # Upstream's "kWh/10" unit note is NOT what distinguishes them: 1059 and
-    # calculations 151/152/154 carry the same note and need Energy alone.
-    # Re-measuring these three is tracked in #734.
-    1136: Energy("HEAT_ENERGY_INPUT", False),
-    1137: Energy("DHW_ENERGY_INPUT", False),
-    1139: Energy("COOLING_ENERGY_INPUT", False),
+    # Read-only energy counters in 0.01 kWh units, hence Energy2 and no factor
+    # on their descriptions. Measured in #734 against the heat-quantity
+    # calculations: regressing calc 151/152 on these over 19 snapshots of one
+    # unit gives a marginal COP of 6.4 (heating) and 3.8 (DHW) at /100, but
+    # 0.64 and 0.38 at /10 - below 1, so impossible for a compressor. Lifetime
+    # totals put the same upper bound under 2 at /10 on six further units.
+    # Upstream's "kWh/10" note claims /10 for these and is simply wrong here;
+    # it also sits on 1059 and calculations 151/152/154, which need /10.
+    # 1139 has read 0.0 on every unit seen so far, so it follows its two
+    # siblings by analogy rather than by measurement.
+    1136: Energy2("HEAT_ENERGY_INPUT", False),
+    1137: Energy2("DHW_ENERGY_INPUT", False),
+    1139: Energy2("COOLING_ENERGY_INPUT", False),
     # Auxiliary-heater heat counters, both in 0.1 kWh units, so Energy's own
     # /10 is the whole conversion and their descriptions carry no factor. The
     # scale was measured against the rated element power in #625; the name of

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -593,9 +593,9 @@ SENSORS: list[descr] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         native_precision=2,
-        # Energy.from_heatpump() already divides by 10; this factor supplies
-        # the remaining /10 noted for this parameter ("kWh/10" raw unit).
-        factor=0.1,
+        # 0.01 kWh raw unit, applied by the Energy2 datatype this parameter is
+        # registered with in lux_overrides - hence no factor. Scale measured
+        # against the heat-quantity calculations in #734.
         # min_firmware_version_minor=FirmwareVersionMinor.minor_89,
     ),
     descr(
@@ -667,9 +667,7 @@ SENSORS: list[descr] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         native_precision=2,
-        # Energy.from_heatpump() already divides by 10; this factor supplies
-        # the remaining /10 noted for this parameter ("kWh/10" raw unit).
-        factor=0.1,
+        # 0.01 kWh raw unit, applied by the Energy2 datatype (see 1136 above).
         # min_firmware_version_minor=FirmwareVersionMinor.minor_89,
     ),
     descr(
@@ -722,9 +720,9 @@ SENSORS: list[descr] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         native_precision=2,
-        # Energy.from_heatpump() already divides by 10; this factor supplies
-        # the remaining /10 noted for this parameter ("kWh/10" raw unit).
-        factor=0.1,
+        # 0.01 kWh raw unit, applied by the Energy2 datatype (see 1136 above).
+        # This one reads 0.0 on every unit examined in #734, so its scale
+        # follows its two siblings by analogy and is not itself measured.
         # min_firmware_version_minor=FirmwareVersionMinor.minor_88,
     ),
     # endregion Cooling

--- a/tests/test_lux_overrides.py
+++ b/tests/test_lux_overrides.py
@@ -154,6 +154,27 @@ class TestSecondsToHours:
         assert converter.to_heatpump(1.5) == 5400
 
 
+class TestEnergy2:
+    """0.01 kWh per count, a hundredth of a kilowatt-hour, against the
+    library's own Energy which is a tenth. Which registers belong on which is
+    measured, not documented - see TestEnergyInputScaling in test_sensor.py.
+    """
+
+    def test_from_heatpump_divides_by_hundred(self):
+        from custom_components.luxtronik2.lux_overrides import Energy2
+
+        converter = Energy2("HEAT_ENERGY_INPUT", False)
+        assert converter.from_heatpump(0) == 0.0
+        assert converter.from_heatpump(269938) == 2699.38
+
+    def test_to_heatpump_round_trips(self):
+        from custom_components.luxtronik2.lux_overrides import Energy2
+
+        converter = Energy2("HEAT_ENERGY_INPUT", False)
+        assert converter.to_heatpump(2699.38) == 269938
+        assert converter.to_heatpump(0.0) == 0
+
+
 class TestTimeOfDay:
     from custom_components.luxtronik2.lux_overrides import TimeOfDay
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -737,8 +737,8 @@ class TestAnalogOutScaling:
     """The library's Voltage datatype already applies its own scaling_factor
     of 0.1, and the coordinator surfaces that decoded value. An additional
     `factor` in the description would scale a second time and report a tenth
-    of the real voltage. Unlike the energy inputs below, the raw analog-out
-    registers carry no extra /10, so no factor belongs here."""
+    of the real voltage, so no factor belongs here - as with the energy
+    counters below, the datatype is the whole conversion."""
 
     def _assert_raw_converts_to(
         self, sensor_key: SensorKey, raw_value: int, expected_volt: float
@@ -761,6 +761,19 @@ class TestAnalogOutScaling:
 
 
 class TestEnergyInputScaling:
+    """Parameters 1136/1137/1139 count energy input in 0.01 kWh units, so the
+    Energy2 datatype they are registered with is the whole conversion and none
+    of the three descriptions carries a `factor`.
+
+    The scale was measured in #734, not read off upstream's "kWh/10" note
+    (which claims /10 for these registers and is wrong): regressing the
+    heat-quantity calculations on these counters across 19 diagnostics
+    snapshots of one MSW4-16 gives a marginal COP of 6.4 for heating and 3.8
+    for DHW at 0.01 kWh per count - and 0.64 / 0.38 at 0.1 kWh per count,
+    which no compressor can achieve. The raw values below are from that same
+    series.
+    """
+
     def _assert_raw_converts_to(
         self, sensor_key: SensorKey, raw_value: int, expected_kwh: float
     ) -> None:
@@ -780,6 +793,29 @@ class TestEnergyInputScaling:
 
     def test_cooling_energy_input_scaling(self):
         self._assert_raw_converts_to(SensorKey.COOLING_ENERGY_INPUT, 12345, 123.45)
+
+    def _converted_value(self, sensor_key: SensorKey, raw_value: int) -> float:
+        description, datatype = _energy_input_case(sensor_key)
+        converted = datatype.from_heatpump(raw_value)
+        group, sensor_id = description.luxtronik_key.split(".", 1)
+        data = make_coordinator_data(**{group: {sensor_id: converted}})
+        entity = _make_sensor(description, data)
+        entity._handle_coordinator_update(data)
+        return entity._attr_native_value
+
+    def test_implied_cop_is_physical(self):
+        """Guards the whole chain - datatype plus description - against a
+        factor-of-ten change: over the window covered by the #734 series the
+        unit put out 17345.0 kWh of heating heat for 269232 counts of input
+        and 2680.7 kWh of DHW heat for 69627 counts, which has to come out as
+        a COP above 1 and below the ~8 no air-source unit exceeds seasonally.
+        """
+        for sensor_key, counts, heat_kwh in (
+            (SensorKey.HEAT_ENERGY_INPUT, 269232, 17345.0),
+            (SensorKey.DHW_ENERGY_INPUT, 69627, 2680.7),
+        ):
+            cop = heat_kwh / self._converted_value(sensor_key, counts)
+            assert 1.0 < cop < 8.0
 
 
 class TestAuxHeaterAmountScaling:


### PR DESCRIPTION
Resolves #734. Follow-up to #625 / #735 / #736.

## 🔍 What was measured

#625 established that a Luxtronik energy register's scale can be settled empirically instead of read off upstream's unit annotation. #734 applied that to the energy-input parameters, whose effective `/100` rested on plausibility only.

Two independent statistics over the diagnostics corpus, both immune to the offset problem (the heat counters have run since install, the input counters only appear on newer firmware):

**1. Least-squares slope over a time series** — one MSW4-16 (V3.92.1, 19 snapshots). The slope is the marginal COP and is unaffected by either counter's starting offset:

| pair | slope (kWh/count) | COP at /10 | COP at /100 |
|---|---|---|---|
| calc 151 heating / param 1136 | 0.0644 | **0.64** | 6.44 |
| calc 152 DHW / param 1137 | 0.0383 | **0.38** | 3.83 |

Endpoint deltas over the same window agree to two decimals. A COP below 1 is impossible for a compressor, so `/10` is out.

**2. Lifetime ratios as upper bounds** on the remaining units. Because the input counter always starts later, `heat / input` *over*estimates the COP — so an upper bound under ~2 falsifies that scale:

| model | fw | COP upper bound @ /10 |
|---|---|---|
| LW SEC 2 | V3.89.5 | 0.31 ❌ |
| LW SEC 2 | V3.89.5 | 0.46 ❌ |
| (unnamed) | V3.92.1 | 0.38 ❌ |
| (unnamed) | V3.88.0 | 0.53 ❌ |
| (unnamed) | V3.92.0 | 0.57 ❌ |
| MSW2-6S | V3.92.3 | 1.93 ❌ |

`/1000` would put the marginal COP at 64. `/100` is the only surviving power of ten.

## 🛠️ What changed

- New `Energy2` datatype in `lux_overrides.py` — energy in 0.01 kWh units, against the library's `Energy` which is a tenth. Parameters 1136/1137/1139 are registered with it.
- `factor=0.1` dropped from all three sensor descriptions; scaling now lives entirely in the datatype, matching the shape 1059/1140 got in #736.
- `TestEnergyInputScaling` gains `test_implied_cop_is_physical`, which drives the real measured deltas through datatype *and* description and asserts `1.0 < COP < 8.0` — a factor-of-ten change in either place fails it.
- `TestEnergy2` covers the new datatype's round-trip.

## ⚠️ Limitations, stated rather than papered over

- `/10` is refuted on six unit-observations, but `/100` is **directly confirmed on one unit only** — the sole unit in the corpus with a usable time series. Every other unit yields an upper bound, which can falsify but not confirm.
- **Parameter 1139 (cooling) is unverified.** It reads 0.0 on every unit examined, so it follows its two siblings by analogy — the same kind of argument #625 proved unsafe. The code says so explicitly.
- The heating COP of 6.44 is high for a real season. Most likely calc 151 counts heat the auxiliary heater contributed while 1136 counts compressor electricity only, which inflates the heating pair but not DHW (3.83, entirely ordinary). It does not affect which power of ten is right.

## ✅ No user-visible change

Effective scaling is `raw/100` before and after, so entity values are identical and no long-term statistics need correcting.

## 🧪 Verification

905 passed, 100% coverage, `ruff check` + `ruff format --check` clean, basedpyright 0 errors, codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
