### PR TITLE
fix(common,coordinator): 🐛 stop creating entities for registers the controller does not expose

### DIFF
--- a/custom_components/luxtronik2/common.py
+++ b/custom_components/luxtronik2/common.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_PARAMETERS,
     CONF_VISIBILITIES,
     LOGGER,
+    PARSED_COUNT_ATTR,
     LuxCalculation as LC,
     LuxOperationMode,
     LuxParameter as LP,
@@ -23,9 +24,50 @@ from .const import (
     LuxStatus3Option,
     LuxVisibility as LV,
 )
+from .lux_overrides import UPSTREAM_MAX_DEFINED_INDEX
 from .model import LuxtronikCoordinatorData
 
 # endregion Imports
+
+
+def _register_returned(group_data: Any, group: str, index: int) -> bool:
+    """Did the controller actually return this register in its last read?
+
+    The library's definition dict is static, so a definition existing proves
+    nothing about the connected unit.  The recorded block length does: the
+    controller returned indices 0..count-1 and nothing else, the block being
+    positional and always dense.
+
+    The conclusion is drawn only above upstream's own definition range, which
+    is where every register this can affect lives.  Inside that range the
+    pre-existing behaviour is kept, so a controller returning a shorter block
+    than any we have seen - an old 1.x unit, or a read truncated mid-transfer,
+    which the library swallows silently - cannot make entities disappear
+    wholesale.
+
+    Absence is deliberately not inferred from ``.value is None`` - a register
+    that IS present reads ``None`` too when its datatype cannot decode the raw
+    value (``SelectionBase`` returns ``None`` for an unrecognised code).
+    """
+    upstream_max = UPSTREAM_MAX_DEFINED_INDEX.get(group)
+    if upstream_max is None or index <= upstream_max:
+        return True
+    parsed_count = getattr(group_data, PARSED_COUNT_ATTR, None)
+    if not isinstance(parsed_count, int):
+        # No count recorded: the object was built directly rather than through
+        # a patched parse() (tests, diagnostics). Definition presence is all
+        # we have, which is the behaviour this function replaced.
+        return True
+    if index >= parsed_count:
+        LOGGER.debug(
+            "Register %s index %d is beyond the %d values this controller "
+            "returned - not creating its entity",
+            group,
+            index,
+            parsed_count,
+        )
+        return False
+    return True
 
 
 def key_exists(
@@ -47,16 +89,22 @@ def key_exists(
             sensor_id,
         )
 
-        if group == "parameters":
-            items = coordinator.parameters.parameters.items()
-        elif group == "calculations":
-            items = coordinator.calculations.calculations.items()
-        elif group == "visibilities":
-            items = coordinator.visibilities.visibilities.items()
+        if group == CONF_PARAMETERS:
+            group_data = coordinator.parameters
+            items = group_data.parameters.items()
+        elif group == CONF_CALCULATIONS:
+            group_data = coordinator.calculations
+            items = group_data.calculations.items()
+        elif group == CONF_VISIBILITIES:
+            group_data = coordinator.visibilities
+            items = group_data.visibilities.items()
         else:
             return False
 
-        return any(item.name == sensor_id for _, item in items)
+        index = next((i for i, item in items if item.name == sensor_id), None)
+        if index is None:
+            return False
+        return _register_returned(group_data, group, index)
     except Exception as e:
         LOGGER.error("Error checking key existence: %s", e)
         return False

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -81,6 +81,10 @@ CONF_PARAMETERS: Final = "parameters"
 CONF_CALCULATIONS: Final = "calculations"
 CONF_VISIBILITIES: Final = "visibilities"
 
+# Instance attribute set by lux_overrides.record_parsed_block_lengths() on each
+# parse(): how many values the controller returned for that block.
+PARSED_COUNT_ATTR: Final = "luxtronik_parsed_count"
+
 CONF_HA_SENSOR_PREFIX: Final = "ha_sensor_prefix"
 CONF_HA_SENSOR_INDOOR_TEMPERATURE: Final = "ha_sensor_indoor_temperature"
 CONF_HA_SENSOR_CURRENT_POWER_CONSUMPTION: Final = "ha_sensor_current_power_consumption"

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -47,6 +47,7 @@ from .const import (
 from .lux_helper import Luxtronik, get_manufacturer_by_model
 from .lux_overrides import (
     isolate_instance_data,
+    record_parsed_block_lengths,
     update_Luxtronik_HeatpumpCodes,
     update_Luxtronik_Parameters,
 )
@@ -847,6 +848,7 @@ async def connect_and_get_coordinator(
         update_Luxtronik_HeatpumpCodes()
         update_Luxtronik_Parameters()
         isolate_instance_data()
+        record_parsed_block_lengths()
         _OVERRIDES_APPLIED = True
         LOGGER.info(
             "Library overrides applied (HeatpumpCodes, Parameters, instance data isolation)."

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -851,7 +851,8 @@ async def connect_and_get_coordinator(
         record_parsed_block_lengths()
         _OVERRIDES_APPLIED = True
         LOGGER.info(
-            "Library overrides applied (HeatpumpCodes, Parameters, instance data isolation)."
+            "Library overrides applied (HeatpumpCodes, Parameters, instance data "
+            "isolation, parsed block length recording)."
         )
 
     config_data: dict[str, Any] = dict(

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -654,12 +654,16 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
             return False
         if description.entity_active_formula is not None:
             active_value = self.get_value(description.luxtronik_key)
-            if active_value is not None:
-                formula_result = self._evaluate_visibility_formula(
-                    active_value, description.entity_active_formula
-                )
-                if formula_result is not None:
-                    return formula_result
+            if active_value is None:
+                # The controller did not return this register, so the formula
+                # has nothing to decide on. Creating the entity anyway leaves
+                # it permanently unavailable (#738).
+                return False
+            formula_result = self._evaluate_visibility_formula(
+                active_value, description.entity_active_formula
+            )
+            if formula_result is not None:
+                return formula_result
         return True
 
     def device_key_active(self, device_key: DeviceKey) -> bool:

--- a/custom_components/luxtronik2/lux_overrides.py
+++ b/custom_components/luxtronik2/lux_overrides.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import Final
 
 from luxtronik.calculations import Calculations
 from luxtronik.datatypes import (
@@ -17,6 +18,13 @@ from luxtronik.datatypes import (
 )
 from luxtronik.parameters import Parameters
 from luxtronik.visibilities import Visibilities
+
+from .const import (
+    CONF_CALCULATIONS,
+    CONF_PARAMETERS,
+    CONF_VISIBILITIES,
+    PARSED_COUNT_ATTR,
+)
 
 
 class MajorMinorVersion(Base):
@@ -130,6 +138,19 @@ class PoolPVMode(SelectionBase):
         3: "Pool_Holidays",
         4: "Pool_Off",
     }
+
+
+# Highest index the installed luxtronik library defines per block, captured
+# before the overrides below extend those dicts.  Everything at or below this
+# index is part of upstream's own definition set and is returned by every
+# controller observed, so absence is only ever concluded above it - which is
+# exactly where the indices this module adds live.  Measured, not guessed:
+# parameters 0..1125 (dense), calculations max 259, visibilities 0..354.
+UPSTREAM_MAX_DEFINED_INDEX: Final[dict[str, int]] = {
+    CONF_PARAMETERS: max(Parameters.parameters),
+    CONF_CALCULATIONS: max(Calculations.calculations),
+    CONF_VISIBILITIES: max(Visibilities.visibilities),
+}
 
 
 # Define your new/updated custom parameters in a dictionary
@@ -287,6 +308,41 @@ def isolate_instance_data():
     Visibilities.__init__ = _vis_init
 
     _INSTANCE_DATA_ISOLATED = True
+
+
+_PARSE_COUNTS_RECORDED = False
+
+
+def record_parsed_block_lengths():
+    """Patch ``parse()`` to record how many values the controller returned.
+
+    ``parse()`` assigns ``.value`` only for the indices present in the raw
+    block; every other definition keeps whatever it had, which for a register
+    the unit does not have means ``None`` forever.  The definition dict is
+    static, so it cannot answer "does this controller have register N?" - but
+    the block length can: register N is present exactly when ``N < length``.
+
+    This is deliberately not inferred from ``.value is None``, because a
+    register that IS present also reads ``None`` when its datatype cannot
+    decode the raw value (``SelectionBase`` returns ``None`` for a code
+    missing from its table, e.g. an unrecognised heat pump model).
+    """
+    # No lock needed: called only from synchronous code path (no await),
+    # so the event loop cannot preempt between the guard check and flag set.
+    global _PARSE_COUNTS_RECORDED
+    if _PARSE_COUNTS_RECORDED:
+        return
+
+    for cls in (Parameters, Calculations, Visibilities):
+        _orig_parse = cls.parse
+
+        def _parse(self, raw_data, _orig_parse=_orig_parse):
+            setattr(self, PARSED_COUNT_ATTR, len(raw_data))
+            return _orig_parse(self, raw_data)
+
+        cls.parse = _parse
+
+    _PARSE_COUNTS_RECORDED = True
 
 
 def update_Luxtronik_HeatpumpCodes():

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -331,7 +331,6 @@ SENSORS: list[descr] = [
         entity_active_formula="!= 0.0",
         # 0.1 kWh raw unit, applied by the Energy datatype (see 1059 above).
         native_precision=1,
-        # min_firmware_version_minor=FirmwareVersionMinor.minor_90,
     ),
     descr(
         key=SensorKey.ANALOG_OUT1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from custom_components.luxtronik2.const import (
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
     DOMAIN,
+    PARSED_COUNT_ATTR,
 )
 from custom_components.luxtronik2.model import LuxtronikCoordinatorData
 
@@ -36,11 +37,15 @@ class FakeSensorItem:
 class FakeSensorGroup:
     """Fake Parameters / Calculations / Visibilities container."""
 
-    def __init__(self, data: dict[str, Any] | None = None):
+    def __init__(
+        self, data: dict[str, Any] | None = None, parsed_count: int | None = None
+    ):
         self._data: dict[str, FakeSensorItem] = {}
         if data:
             for key, value in data.items():
                 self._data[key] = FakeSensorItem(key, value)
+        if parsed_count is not None:
+            setattr(self, PARSED_COUNT_ATTR, parsed_count)
 
     def get(self, sensor_id: str) -> FakeSensorItem | None:
         return self._data.get(sensor_id)
@@ -76,12 +81,15 @@ def make_coordinator_data(
     parameters: dict[str, Any] | None = None,
     calculations: dict[str, Any] | None = None,
     visibilities: dict[str, Any] | None = None,
+    parameters_parsed_count: int | None = None,
+    calculations_parsed_count: int | None = None,
+    visibilities_parsed_count: int | None = None,
 ) -> LuxtronikCoordinatorData:
     """Build a LuxtronikCoordinatorData with fake sensor groups."""
     return LuxtronikCoordinatorData(
-        parameters=FakeSensorGroup(parameters or {}),
-        calculations=FakeSensorGroup(calculations or {}),
-        visibilities=FakeSensorGroup(visibilities or {}),
+        parameters=FakeSensorGroup(parameters or {}, parameters_parsed_count),
+        calculations=FakeSensorGroup(calculations or {}, calculations_parsed_count),
+        visibilities=FakeSensorGroup(visibilities or {}, visibilities_parsed_count),
     )
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -120,6 +120,24 @@ class TestRegisterPresence:
         )
         assert key_exists(data, "parameters.c") is True
 
+    def test_upstream_max_index_itself_is_inside_the_range(self, monkeypatch):
+        """The confinement is ``index <= upstream_max``, not ``<``.
+
+        The highest index upstream defines is upstream's own, so it must stay on
+        the pre-change behaviour even when the block stops right before it. This
+        is the only case that separates the two operators: everywhere else an
+        index at the boundary also satisfies ``index < parsed_count``.
+        """
+        monkeypatch.setattr(
+            "custom_components.luxtronik2.common.UPSTREAM_MAX_DEFINED_INDEX",
+            {"parameters": 1, "calculations": 1, "visibilities": 1},
+        )
+        data = make_coordinator_data(
+            parameters={"upstream_a": 1, "upstream_b": 2},
+            parameters_parsed_count=1,
+        )
+        assert key_exists(data, "parameters.upstream_b") is True  # index 1 == max
+
     def test_without_recorded_count_falls_back_to_definition(self, tiny_upstream_range):
         """Objects built without a parse() (tests, diagnostics) keep old behaviour."""
         data = make_coordinator_data(parameters={"a": 1, "b": 2})

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -75,6 +75,68 @@ class TestKeyExists:
         assert key_exists(data, "parameters.some_key") is False
 
 
+@pytest.fixture
+def tiny_upstream_range(monkeypatch):
+    """Pretend upstream defines only index 0, so indices 1+ are 'override-added'.
+
+    FakeSensorGroup indexes items by insertion order, so without this every test
+    index would sit inside the real upstream range (0..1125) and never be
+    eligible for the absence rule.
+    """
+    monkeypatch.setattr(
+        "custom_components.luxtronik2.common.UPSTREAM_MAX_DEFINED_INDEX",
+        {"parameters": 0, "calculations": 0, "visibilities": 0},
+    )
+
+
+class TestRegisterPresence:
+    def test_absent_register_returns_false(self, tiny_upstream_range):
+        """A definition exists, but the controller returned a shorter block."""
+        data = make_coordinator_data(
+            parameters={"upstream_a": 1, "added_b": 2, "added_c": None},
+            parameters_parsed_count=2,
+        )
+        assert key_exists(data, "parameters.upstream_a") is True  # index 0
+        assert key_exists(data, "parameters.added_b") is True  # index 1 < 2
+        assert key_exists(data, "parameters.added_c") is False  # index 2 >= 2
+
+    def test_present_register_reading_none_is_still_present(self, tiny_upstream_range):
+        """A SelectionBase register with an unknown code reads None but exists."""
+        data = make_coordinator_data(
+            parameters={"upstream_a": 1, "unknown_code": None},
+            parameters_parsed_count=2,
+        )
+        assert key_exists(data, "parameters.unknown_code") is True
+
+    def test_upstream_range_is_never_suppressed(self):
+        """Even a wildly short block cannot hide a register upstream defines.
+
+        This is what keeps 1.x controllers, which may return fewer values than
+        anything in the diagnostics corpus, on the pre-change behaviour.
+        """
+        data = make_coordinator_data(
+            parameters={"a": 1, "b": 2, "c": 3},
+            parameters_parsed_count=0,
+        )
+        assert key_exists(data, "parameters.c") is True
+
+    def test_without_recorded_count_falls_back_to_definition(self, tiny_upstream_range):
+        """Objects built without a parse() (tests, diagnostics) keep old behaviour."""
+        data = make_coordinator_data(parameters={"a": 1, "b": 2})
+        assert key_exists(data, "parameters.b") is True
+
+    def test_rule_is_generic_across_groups(self, tiny_upstream_range):
+        """The check is not parameters-only, even though only parameters can
+        currently trigger it (lux_overrides adds nothing above the calculations
+        or visibilities range)."""
+        data = make_coordinator_data(
+            calculations={"upstream_a": 1, "added_b": 2},
+            calculations_parsed_count=1,
+        )
+        assert key_exists(data, "calculations.upstream_a") is True
+        assert key_exists(data, "calculations.added_b") is False
+
+
 # ===========================================================================
 # get_sensor_data
 # ===========================================================================

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -699,6 +699,45 @@ class TestEntityActive:
         desc.luxtronik_key = LP.P0001_HEATING_TARGET_CORRECTION
         assert coord.entity_active(desc) is False
 
+    def test_entity_active_formula_absent_register(self):
+        """A register the controller does not expose must not get an entity."""
+        coord = _make_coordinator_direct()
+        coord._is_version_not_compatible = MagicMock(return_value=False)
+        coord.device_key_active = MagicMock(return_value=True)
+        coord.get_value = MagicMock(return_value=None)
+        desc = MagicMock(spec=LuxtronikEntityDescription)
+        desc.visibility = LV.V0024_FLOW_OUT_TEMPERATURE_EXTERNAL
+        desc.device_key = DeviceKey.heatpump
+        desc.entity_active_formula = "!= 0.0"
+        desc.luxtronik_key = LP.P0001_HEATING_TARGET_CORRECTION
+        assert coord.entity_active(desc) is False
+
+    def test_entity_active_formula_zero_is_not_absent(self):
+        """A register reading 0.0 is present - the formula decides, not the None check."""
+        coord = _make_coordinator_direct()
+        coord._is_version_not_compatible = MagicMock(return_value=False)
+        coord.device_key_active = MagicMock(return_value=True)
+        coord.get_value = MagicMock(return_value=0.0)
+        desc = MagicMock(spec=LuxtronikEntityDescription)
+        desc.visibility = LV.V0024_FLOW_OUT_TEMPERATURE_EXTERNAL
+        desc.device_key = DeviceKey.heatpump
+        desc.entity_active_formula = "!= 0.0"
+        desc.luxtronik_key = LP.P0001_HEATING_TARGET_CORRECTION
+        assert coord.entity_active(desc) is False
+
+    def test_entity_active_formula_nonzero_creates_entity(self):
+        """A register with a real reading passes the formula and gets an entity."""
+        coord = _make_coordinator_direct()
+        coord._is_version_not_compatible = MagicMock(return_value=False)
+        coord.device_key_active = MagicMock(return_value=True)
+        coord.get_value = MagicMock(return_value=12.3)
+        desc = MagicMock(spec=LuxtronikEntityDescription)
+        desc.visibility = LV.V0024_FLOW_OUT_TEMPERATURE_EXTERNAL
+        desc.device_key = DeviceKey.heatpump
+        desc.entity_active_formula = "!= 0.0"
+        desc.luxtronik_key = LP.P0001_HEATING_TARGET_CORRECTION
+        assert coord.entity_active(desc) is True
+
 
 # ===========================================================================
 # get_value / get_sensor

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -713,7 +713,12 @@ class TestEntityActive:
         assert coord.entity_active(desc) is False
 
     def test_entity_active_formula_zero_is_not_absent(self):
-        """A register reading 0.0 is present - the formula decides, not the None check."""
+        """A register reading 0.0 is present - the formula decides, not the None check.
+
+        A formula that 0.0 satisfies is the only way to tell the two apart: an
+        active entity here is reachable only if 0.0 reached the evaluator rather
+        than short-circuiting on the absent-register check.
+        """
         coord = _make_coordinator_direct()
         coord._is_version_not_compatible = MagicMock(return_value=False)
         coord.device_key_active = MagicMock(return_value=True)
@@ -721,9 +726,9 @@ class TestEntityActive:
         desc = MagicMock(spec=LuxtronikEntityDescription)
         desc.visibility = LV.V0024_FLOW_OUT_TEMPERATURE_EXTERNAL
         desc.device_key = DeviceKey.heatpump
-        desc.entity_active_formula = "!= 0.0"
+        desc.entity_active_formula = "== 0.0"
         desc.luxtronik_key = LP.P0001_HEATING_TARGET_CORRECTION
-        assert coord.entity_active(desc) is False
+        assert coord.entity_active(desc) is True
 
     def test_entity_active_formula_nonzero_creates_entity(self):
         """A register with a real reading passes the formula and gets an entity."""

--- a/tests/test_lux_overrides.py
+++ b/tests/test_lux_overrides.py
@@ -8,6 +8,14 @@ from luxtronik.parameters import Parameters
 from luxtronik.visibilities import Visibilities
 import pytest
 
+from custom_components.luxtronik2 import lux_overrides
+from custom_components.luxtronik2.const import (
+    CONF_CALCULATIONS,
+    CONF_PARAMETERS,
+    CONF_VISIBILITIES,
+    PARSED_COUNT_ATTR,
+)
+
 
 class TestUpdateLuxtronikHeatpumpCodes:
     def test_codes_updated(self):
@@ -234,3 +242,86 @@ class TestFrequencyAutomatic:
     def test_roundtrip_45hz(self):
         raw = self.converter.to_heatpump(45)
         assert self.converter.from_heatpump(raw) == 45
+
+
+@pytest.fixture
+def restore_parse():
+    """record_parsed_block_lengths patches library classes process-wide."""
+    originals = {cls: cls.parse for cls in (Parameters, Calculations, Visibilities)}
+    flag = lux_overrides._PARSE_COUNTS_RECORDED
+    lux_overrides._PARSE_COUNTS_RECORDED = False
+    yield
+    for cls, parse in originals.items():
+        cls.parse = parse
+    lux_overrides._PARSE_COUNTS_RECORDED = flag
+
+
+class TestRecordParsedBlockLengths:
+    def test_records_block_length_for_each_group(self, restore_parse):
+        lux_overrides.record_parsed_block_lengths()
+
+        params = Parameters()
+        params.parse([0] * 1126)
+        assert getattr(params, PARSED_COUNT_ATTR) == 1126
+
+        calcs = Calculations()
+        calcs.parse([0] * 260)
+        assert getattr(calcs, PARSED_COUNT_ATTR) == 260
+
+        vis = Visibilities()
+        vis.parse([0] * 355)
+        assert getattr(vis, PARSED_COUNT_ATTR) == 355
+
+    def test_values_still_parse(self, restore_parse):
+        """The wrapper must not swallow the original parse behaviour."""
+        lux_overrides.record_parsed_block_lengths()
+        params = Parameters()
+        params.parse([7] * 1126)
+        assert params.parameters[0].value is not None
+
+    def test_is_idempotent(self, restore_parse):
+        """Calling twice must not double-wrap or change the recorded count."""
+        lux_overrides.record_parsed_block_lengths()
+        lux_overrides.record_parsed_block_lengths()
+        params = Parameters()
+        params.parse([0] * 42)
+        assert getattr(params, PARSED_COUNT_ATTR) == 42
+
+    def test_attribute_absent_before_parse(self, restore_parse):
+        """A freshly built instance has no count until it has parsed."""
+        lux_overrides.record_parsed_block_lengths()
+        assert getattr(Parameters(), PARSED_COUNT_ATTR, None) is None
+
+
+class TestUpstreamMaxDefinedIndex:
+    def test_pins_the_installed_library_range(self):
+        """The absence rule only fires above this index, so an upstream bump must
+        be a deliberate, reviewed change - not a silent behaviour shift."""
+        assert lux_overrides.UPSTREAM_MAX_DEFINED_INDEX[CONF_PARAMETERS] == 1125
+        assert lux_overrides.UPSTREAM_MAX_DEFINED_INDEX[CONF_CALCULATIONS] == 259
+        assert lux_overrides.UPSTREAM_MAX_DEFINED_INDEX[CONF_VISIBILITIES] == 354
+
+    def test_every_override_only_parameter_sits_above_the_range(self):
+        """The 13 indices that exist only because of lux_overrides are exactly the
+        ones the absence rule must be able to reach."""
+        upstream_max = lux_overrides.UPSTREAM_MAX_DEFINED_INDEX[CONF_PARAMETERS]
+        override_only = {
+            index
+            for index in lux_overrides.parameters_to_add_update
+            if index > upstream_max
+        }
+        assert override_only == {
+            1136,
+            1137,
+            1139,
+            1140,
+            1146,
+            1147,
+            1148,
+            1158,
+            1159,
+            1175,
+            1176,
+            1177,
+            1179,
+        }

--- a/tests/test_lux_overrides.py
+++ b/tests/test_lux_overrides.py
@@ -9,12 +9,14 @@ from luxtronik.visibilities import Visibilities
 import pytest
 
 from custom_components.luxtronik2 import lux_overrides
+from custom_components.luxtronik2.common import key_exists
 from custom_components.luxtronik2.const import (
     CONF_CALCULATIONS,
     CONF_PARAMETERS,
     CONF_VISIBILITIES,
     PARSED_COUNT_ATTR,
 )
+from custom_components.luxtronik2.model import LuxtronikCoordinatorData
 
 
 class TestUpdateLuxtronikHeatpumpCodes:
@@ -300,6 +302,27 @@ class TestUpstreamMaxDefinedIndex:
         assert lux_overrides.UPSTREAM_MAX_DEFINED_INDEX[CONF_PARAMETERS] == 1125
         assert lux_overrides.UPSTREAM_MAX_DEFINED_INDEX[CONF_CALCULATIONS] == 259
         assert lux_overrides.UPSTREAM_MAX_DEFINED_INDEX[CONF_VISIBILITIES] == 354
+
+    def test_short_block_suppresses_only_override_added_indices(self, restore_parse):
+        """The presence rule against real library objects, not positional fakes.
+
+        Every other presence test runs on conftest's FakeSensorGroup, whose index
+        is positional. A real Parameters carries the sparse override-added keys
+        (1136..1179) and the real 1125 threshold, which is the only place the
+        confinement clause can actually be exercised.
+        """
+        lux_overrides.update_Luxtronik_Parameters()
+        lux_overrides.isolate_instance_data()
+        lux_overrides.record_parsed_block_lengths()
+        short = Parameters()
+        short.parse([0] * 1126)
+        data = LuxtronikCoordinatorData(short, Parameters(), Parameters())
+        assert (
+            key_exists(data, "parameters.SECOND_HEAT_GENERATOR_AMOUNT_COUNTER") is False
+        )
+        assert key_exists(data, "parameters.ELECTRICAL_POWER_LIMIT_VALUE") is False
+        assert key_exists(data, "parameters.ID_Waermemenge_ZWE") is True
+        assert key_exists(data, f"parameters.{short.parameters[1125].name}") is True
 
     def test_every_override_only_parameter_sits_above_the_range(self):
         """The 13 indices that exist only because of lux_overrides are exactly the


### PR DESCRIPTION
## 🐛 The problem

`common.key_exists()` — called from every platform's `async_setup_entry` to decide whether an entity should exist — matches a register name against the upstream library's **static** definition dict. `parse()` assigns `.value` only for the indices the controller actually returned and never removes definitions, so a definition existing proves nothing about the connected unit.

Result: heat pumps that don't expose certain registers get entities that are permanently unavailable.

Confirmed on real hardware — two short units carry an override index with no value:

```
V3.89.5   n=1157 parameters    1159 Unknown_Parameter_1159 = 'None'
V2.89.0   n=1158 parameters    1159 Unknown_Parameter_1159 = 'None'
```

## 🎯 Scope: 12 entities on 13 indices

Upstream's parameter dict is **dense over 0..1125**. `lux_overrides` adds exactly 13 indices above it: `1136, 1137, 1139, 1140, 1146, 1147, 1148, 1158, 1159, 1175, 1176, 1177, 1179`. Across 45 diagnostics dumps (8 distinct unit/firmware shapes, V2.89.0 → V3.92.3) the smallest parameter block is 1126 — exactly upstream's coverage.

So `key_exists` is accurate for every upstream-defined register, and the defined-but-absent condition exists **only** for those 13 override-added indices. Calculations are unaffected: overrides add only index 258, inside the existing range.

| index | entity |
|---|---|
| 1136 / 1137 / 1139 | heat / dhw / cooling energy input |
| 1140 | second heat generator amount counter |
| 1146 / 1147 | extra DHW target temperature, duration |
| 1158 / 1159 / 1175 / 1176 / 1177 / 1179 | electrical + thermal power limit switch & values |

## 🔧 How presence is determined

**Not from `.value is None`.** A register that IS present also reads `None` when its datatype can't decode the raw value — `SelectionBase.from_heatpump` returns `None` for a code missing from its table. Observed live on `ID_WEB_Code_WP_akt` in 5 of 45 dumps.

Instead, from the **block length**. A `parse()` wrapper in `lux_overrides` (alongside the existing `isolate_instance_data()` patching) records how many values the controller returned; a register is present exactly when `index < parsed_count`. This is exact and datatype-agnostic, and stays correct under the `python-luxtronik` `main` rewrite, where 13 of 14 datatypes gain a `None`-returning type guard.

## 🛡️ Why absence is only concluded above upstream's range

`_register_returned` is deliberately two-clause. Inside upstream's definition range it always returns `True`; only above it does the block length decide.

That threshold is **structural, not measured** — `UPSTREAM_MAX_DEFINED_INDEX` is read off the installed library at import time (parameters 1125, calculations 259, visibilities 354) and pinned by a test, so a version bump fails CI rather than silently changing which registers are gateable.

It protects two cases:

- **V1.x controllers.** The diagnostics corpus contains no V1.x unit (oldest is V2.89.0). A 1.x unit returning a shorter block than anything we've seen still behaves exactly as before, because indices inside upstream's range are never suppressed. Guarded by `test_upstream_range_is_never_suppressed`.
- **Truncated reads.** `Luxtronik._read_parameters` swallows `struct.error` on a partial receive and parses the short list anyway, with `last_update_success` still `True`. Confining the rule bounds the damage to these 12 entities, which return on the next reload, instead of hundreds of entities disappearing.

Worth noting: this integration doesn't use upstream's reader. `lux_helper.py`'s `_read_data` loops until each value fully arrives, raises on `len(data) != length`, and returns **without** parsing on exhausted retries — so a truncated block is never parsed here at all. The confinement is belt-and-braces rather than the sole guard.

The wire block is always dense (positional protocol, no index field), so gaps in the *definition* dict are irrelevant to the comparison — `holes_in_block=0` across all 8 corpus shapes.

## ✅ Evidence

End-to-end simulation against the working tree, both controller shapes:

```
V3.79-shaped (short) 1140 present: False | 1159 present: False | 1059 present: True
V3.92.1-shaped (full) 1140 present: True | 1159 present: True | 1059 present: True
```

Pinned in CI by `test_short_block_suppresses_only_override_added_indices`, which runs a real `Parameters` instance (sparse keys, real 1125 threshold) through the patched `parse()` — the earlier tests all used positional fakes, which differ from the real dict in exactly the dimension this fix turns on.

Also verified on a live V3.92.1 unit: it returns 1199 parameters, so every affected entity carries a real value (`number.…electrical_power_limitation_value` = 4.2) and nothing is suppressed. That unit exercises only the "present" path — the suppression path is covered by the simulation and the CI test above.

Gates: `ruff` clean, `basedpyright` 0 errors, `codespell` clean, 921 tests, 100% coverage.

## ⚠️ Note for existing users

There is no entity-registry sweep in this PR. If you already have one of these entities and your controller doesn't expose the register, it will stay in the registry as an unavailable "restored" entity — visually the same as before — until you delete it manually or remove and re-add the config entry. Newly set-up systems are unaffected.

This is not a regression (those entities were already unavailable), but it does mean the fix won't look like it worked without that one-time cleanup.

Resolves #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)
