### PR TITLE
feat(text,select): ✨ show only the selected DHW timer program

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Advanced entities:
 | **Thermal Desinfection Day** | Select | Day | The day on which the thermal disinfection cycle is performed, or `continuous` to make every DHW heating cycle eligible (see the on-demand trick below). The heat pump runs the cycle at its own fixed nightly time on that day — this integration cannot change *when* it runs, only *which day(s)*. |
 | **DHW Manual Frequency** | Number | Hz | Forces the compressor to a fixed frequency during DHW heating instead of the heat pump's own automatic choice (`0` = Automatic). Useful for solar self-consumption — see [Advanced Features: DHW Manual Frequency](ADVANCED_FEATURES.md#dhw-manual-frequency-matching-compressor-power-to-solar-surplus). |
 | **Away/Holiday Start & End Date** | Date | - | Pre-schedule a future DHW Holiday period (auto start and return), independent of the Heating device's own dates — see [Advanced Features: Away / Holiday Scheduling](ADVANCED_FEATURES.md#away--holiday-scheduling). |
+| **DHW Timer Program** | Select | - | Which blocking-time schedule shape the controller uses: *Whole week*, *Weekdays + weekend*, or *Per day*. Switching it swaps which schedule entities are present — see [TIMER_SCHEDULES.md](TIMER_SCHEDULES.md). |
 
 > **ℹ️ Note:** It is not possible to trigger a thermal disinfection cycle on demand, or move it off its fixed nightly time, using the *Thermal Desinfection Day* select alone. It can be emulated at a time of your choosing by temporarily setting *Thermal Desinfection Day* to `continuous` and raising the *DHW Target Temperature* to the *Thermal Desinfection Target Temperature* value — this makes the heat pump's normal (immediate) heating logic reach disinfection temperature right away, instead of waiting for its own nightly schedule. See the *Legionella prevention using solar power* example below. The **Thermal Desinfection Target Temperature** entity also exposes a `last_thermal_desinfection` timestamp attribute (last time the DHW temperature rose above that target), handy for gating an automation like the example to "at most once a week".
 
@@ -184,7 +185,7 @@ If your system has an integrated **solar thermal collector** feeding the DHW tan
 
 #### DHW Timer Schedule (Blocking Times)
 
-DHW also supports an editable weekly schedule of **blocking times** — windows during which automatic DHW heating is switched off, exposed as a set of Text entities. See **[TIMER_SCHEDULES.md](TIMER_SCHEDULES.md)** for the entity list, the `HH:MM-HH:MM/...` format, and an important note on how DHW's blocking-time semantics differ from the heating schedule.
+DHW also supports an editable weekly schedule of **blocking times** — windows during which automatic DHW heating is switched off, exposed as a set of Text entities. The controller offers three schedule shapes (whole week, weekdays + weekend, per day) selected by the *DHW Timer Program* entity; only the selected shape's schedule entities are present, the others are disabled. See **[TIMER_SCHEDULES.md](TIMER_SCHEDULES.md)** for the entity list, the `HH:MM-HH:MM/...` format, and an important note on how DHW's blocking-time semantics differ from the heating schedule.
 
 #### 3.1.2 Automating DHW
 Automations for DHW typically use the water heater entity or the Party/Boost mode. Common scenarios include pre-heating before showers, using excess solar energy to heat the tank.

--- a/TIMER_SCHEDULES.md
+++ b/TIMER_SCHEDULES.md
@@ -13,20 +13,31 @@ The controller supports three mutually-exclusive schedule shapes for DHW, up to 
 - **Weekday / Weekend** ("5+2") – one schedule for Monday-Friday, a separate one for Saturday-Sunday.
 - **Per day** – an independent schedule for each individual day of the week.
 
-Only one shape is active at a time. Which shape is active is selected on the physical controller (or its web interface) — this integration does not yet expose a control for that selector, only for editing the time windows themselves.
+Only one shape is active at a time. Which shape is active is exposed as the **DHW Timer Program** select entity, so it can be switched from Home Assistant as well as on the physical controller (or its web interface).
 
 | Name | Entity Type | Description |
 | :--- | :--- | :--- |
-| **DHW Timer Schedule (Week)** | Text | Editable only while the *Week* shape is active. |
-| **DHW Timer Schedule (Weekdays)** | Text | Editable only while *Weekday/Weekend* is active; covers Monday-Friday. |
-| **DHW Timer Schedule (Weekend)** | Text | Editable only while *Weekday/Weekend* is active; covers Saturday-Sunday. |
-| **DHW Timer Schedule (Monday)** … **(Sunday)** | Text | One entity per day of the week, editable only while *Per day* is active. |
+| **DHW Timer Program** | Select | Which schedule shape the controller uses: *Whole week*, *Weekdays + weekend*, or *Per day*. |
+| **DHW Timer Schedule (Week)** | Text | Exists while the *Week* shape is active. |
+| **DHW Timer Schedule (Weekdays)** | Text | Exists while *Weekday/Weekend* is active; covers Monday-Friday. |
+| **DHW Timer Schedule (Weekend)** | Text | Exists while *Weekday/Weekend* is active; covers Saturday-Sunday. |
+| **DHW Timer Schedule (Monday)** … **(Sunday)** | Text | One entity per day of the week, present while *Per day* is active. |
 
 Each entity holds up to 5 blocking windows as a single string of `HH:MM-HH:MM` pairs separated by `/`, for example:
 ```
 12:00-13:00/22:00-23:30
 ```
-This blocks DHW heating over lunch (12:00-13:00) and in the evening (22:00-23:30). Set the value to an empty string to clear all blocking windows for that entity. Entities belonging to a schedule shape other than the one currently active on the controller show as `unavailable` — this is expected, not an error.
+This blocks DHW heating over lunch (12:00-13:00) and in the evening (22:00-23:30). Set the value to an empty string to clear all blocking windows for that entity.
+
+### Only the active shape's entities are present
+
+Only the schedule entities of the shape currently selected in *DHW Timer Program* exist as usable entities. The other shapes' entities are **disabled** rather than left permanently unavailable, so the device page collapses them behind a *"+N disabled entities"* button instead of listing them as broken.
+
+Changing the timer program — from Home Assistant or on the controller itself — swaps the entity set automatically within one polling interval; no restart or integration reload is needed. Because the entities are disabled rather than deleted, everything you attached to them survives the switch: a renamed entity ID, friendly name, icon, area, labels, and their recorder history all come back unchanged when that shape becomes active again.
+
+> **ℹ️ Note:** Home Assistant reloads an integration ~30 seconds after any of its entities is re-enabled, so switching the timer program is followed by a brief reload of the Luxtronik integration. The new shape's schedule entities themselves appear immediately — the reload happens afterwards and needs no action from you.
+
+Entities of an inactive shape keep a stale `unavailable` state in the state machine (Home Assistant's normal behaviour for a registered entity that no integration is currently providing). Nothing surfaces this in the UI, but a dashboard card that references such an entity by ID directly will show it as unavailable while its shape is inactive.
 
 ## Extending to other circuits
 
@@ -40,6 +51,6 @@ The remaining five timer-program circuits share the same underlying shape (mode 
 | Circulation pump (ZIP) | `ID_Einst_SuZIP_akt` | 5 |
 | Pool (Swb) | `ID_Einst_SuSwb_akt` | 3 |
 
-Adding one is additive: define a `_TimerCircuit` in `timer_schedule_entities_predefined.py` (mirroring `_DHW_CIRCUIT`) with that circuit's selector name, row count, and `WO`/`25`/`TG` parameter prefixes, then call `_build_circuit_entities` with a matching set of `SensorKey` entries and translations. No changes to `text.py` itself should be needed — its logic is already generic per `LuxtronikTimerScheduleTextDescription`.
+Adding one is additive: define a `_TimerCircuit` in `timer_schedule_entities_predefined.py` (mirroring `_DHW_CIRCUIT`) with that circuit's selector name, row count, and `WO`/`25`/`TG` parameter prefixes, then call `_build_circuit_entities` with a matching set of `SensorKey` entries and translations. No changes to `text.py` itself should be needed — its logic, including the active-shape sync that enables and disables entities as the program changes, is already generic per `LuxtronikTimerScheduleTextDescription`. A select entity for the new circuit's own mode selector is one description in `select_entities_predefined.py`, reusing `raw_option_map` to map the HA option names onto the raw `week` / `5+2` / `days` values.
 
 Unlike DHW, the heating/mixing/pool circuit schedules define when the circuit is *raised* (comfort setback), not blocking times — the semantics are the opposite of DHW's "Sperrzeiten". Confirm the correct direction for each circuit against the controller manual before writing its documentation, rather than assuming DHW's polarity applies uniformly.

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -403,6 +403,7 @@ class LuxParameter(StrEnum):
     P0002_DHW_TARGET_TEMPERATURE = "parameters.ID_Einst_BWS_akt"
     P0003_MODE_HEATING = "parameters.ID_Ba_Hz_akt"
     P0004_MODE_DHW = "parameters.ID_Ba_Bw_akt"
+    P0405_TIMER_PROGRAM_DHW = "parameters.ID_Einst_SUBW_akt2"
     # luxtronik*_heating_curve*
     P0011_HEATING_CURVE_END_TEMPERATURE = "parameters.ID_Einst_HzHwHKE_akt"
     P0012_HEATING_CURVE_PARALLEL_SHIFT_TEMPERATURE = "parameters.ID_Einst_HzHKRANH_akt"
@@ -953,6 +954,7 @@ class SensorKey(StrEnum):
     EXTRA_DHW_TARGET_TEMPERATURE = "extra_dhw_target_temperature"
     EXTRA_DHW_DURATION = "extra_dhw_duration"
 
+    TIMER_DHW_PROGRAM = "timer_dhw_program"
     TIMER_DHW_SCHEDULE_WEEK = "timer_dhw_schedule_week"
     TIMER_DHW_SCHEDULE_WEEKDAY = "timer_dhw_schedule_weekday"
     TIMER_DHW_SCHEDULE_WEEKEND = "timer_dhw_schedule_weekend"

--- a/custom_components/luxtronik2/model.py
+++ b/custom_components/luxtronik2/model.py
@@ -250,6 +250,11 @@ class LuxtronikSelectEntityDescription(
     """Class describing Luxtronik date entities."""
 
     platform = Platform.SELECT
+    #: Maps the HA-facing option name to the raw value the device expects,
+    #: for parameters whose raw values are not usable as HA options (e.g.
+    #: the timer program's "5+2"). When unset, options are derived from the
+    #: raw values as before.
+    raw_option_map: dict[str, str] | None = None
 
 
 class LuxtronikTimerScheduleTextDescription(

--- a/custom_components/luxtronik2/model.py
+++ b/custom_components/luxtronik2/model.py
@@ -247,7 +247,7 @@ class LuxtronikSelectEntityDescription(
     SelectEntityDescription,
     frozen_or_thawed=True,
 ):
-    """Class describing Luxtronik date entities."""
+    """Class describing Luxtronik select entities."""
 
     platform = Platform.SELECT
     #: Maps the HA-facing option name to the raw value the device expects,

--- a/custom_components/luxtronik2/select.py
+++ b/custom_components/luxtronik2/select.py
@@ -227,12 +227,19 @@ class LuxtronikModeSelector(
         self._lux_parameter = (
             description.luxtronik_key if lux_parameter is None else lux_parameter
         )
-        raw_options = list(options or description.options or [])
-        self._option_to_raw = {
-            _normalize_select_option(raw_option): raw_option
-            for raw_option in raw_options
-        }
+        if description.raw_option_map:
+            self._option_to_raw = dict(description.raw_option_map)
+        else:
+            raw_options = list(options or description.options or [])
+            self._option_to_raw = {
+                _normalize_select_option(raw_option): raw_option
+                for raw_option in raw_options
+            }
         self._attr_options = list(self._option_to_raw)
+        self._raw_to_option = {
+            _normalize_select_option(raw): option
+            for option, raw in self._option_to_raw.items()
+        }
         self._attr_current_option = None
 
         prefix = entry.data[CONF_HA_SENSOR_PREFIX]
@@ -250,7 +257,8 @@ class LuxtronikModeSelector(
             return
 
         current_raw = str(get_sensor_data(data, self._lux_parameter))
-        current = _normalize_select_option(current_raw)
+        normalized = _normalize_select_option(current_raw)
+        current = self._raw_to_option.get(normalized, normalized)
 
         LOGGER.debug(
             "%s raw value from coordinator: %r, normalized value: %r",

--- a/custom_components/luxtronik2/select_entities_predefined.py
+++ b/custom_components/luxtronik2/select_entities_predefined.py
@@ -51,6 +51,15 @@ mode_pv_pool_options: list[str] = [
 
 heating_control_mode_options: list[str] = [m.value for m in LuxHeatingControlModeTypes]
 
+# The device's raw values ("5+2") are not usable as HA option names, so the
+# HA-facing names are mapped explicitly onto them.
+TIMER_PROGRAM_RAW_OPTIONS: dict[str, str] = {
+    "week": "week",
+    "weekday_weekend": "5+2",
+    "daily": "days",
+}
+timer_program_options: list[str] = list(TIMER_PROGRAM_RAW_OPTIONS)
+
 
 # ---- Descriptions directly in SELECT_ENTITIES ---------------------
 SELECT_ENTITIES: list[LuxtronikSelectEntityDescription] = [
@@ -66,6 +75,14 @@ SELECT_ENTITIES: list[LuxtronikSelectEntityDescription] = [
         device_key=DeviceKey.domestic_water,
         luxtronik_key=LuxParameter.P0004_MODE_DHW,
         options=mode_options,
+    ),
+    LuxtronikSelectEntityDescription(
+        key=SK.TIMER_DHW_PROGRAM,
+        device_key=DeviceKey.domestic_water,
+        luxtronik_key=LuxParameter.P0405_TIMER_PROGRAM_DHW,
+        entity_category=EntityCategory.CONFIG,
+        options=timer_program_options,
+        raw_option_map=TIMER_PROGRAM_RAW_OPTIONS,
     ),
     LuxtronikSelectEntityDescription(
         key=SK.HEATING_MODE_SELECTOR,

--- a/custom_components/luxtronik2/text.py
+++ b/custom_components/luxtronik2/text.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 
 from homeassistant.components.text import (
@@ -91,6 +92,12 @@ class _TimerScheduleSync:
         self.coordinator = coordinator
         self.async_add_entities = async_add_entities
         self._entities: dict[str, LuxtronikTimerScheduleText] = {}
+        # Coordinator updates arrive independently of any in-flight apply, and
+        # `async_apply` awaits mid-mutation (each entity removal). Without
+        # serializing here, a second update landing during that await would
+        # compute `desired` against a dict the first call is still mutating,
+        # risking a duplicate registration for the same key.
+        self._lock = asyncio.Lock()
 
     async def async_setup(self) -> None:
         """Add the active program's entities and hide the rest."""
@@ -102,49 +109,63 @@ class _TimerScheduleSync:
         self.entry.async_create_task(self.hass, self.async_apply(), eager_start=False)
 
     async def async_apply(self) -> None:
-        """Bring the live entity set in line with the active program."""
-        desired = {
-            description.key: description
-            for description in _active_schedule_descriptions(
-                self.coordinator, self.coordinator.data
-            )
-        }
-        to_add = [
-            description
-            for key, description in desired.items()
-            if key not in self._entities
-        ]
-        to_remove = [
-            (key, entity)
-            for key, entity in self._entities.items()
-            if key not in desired
-        ]
-        if not to_add and not to_remove:
-            return
+        """Bring the live entity set in line with the active program.
 
-        registry = er.async_get(self.hass)
-        # Unhide before adding: an entity added while its registry entry is
-        # hidden would stay hidden.
-        self._unhide_active(registry, set(desired))
-
-        if to_add:
-            entities = [
-                LuxtronikTimerScheduleText(
-                    self.entry, self.coordinator, description, description.device_key
+        Serialized by `self._lock`: a second call queued behind an in-flight
+        one (e.g. two coordinator updates arriving while the first call is
+        still awaiting an entity removal) waits for it to finish, then
+        re-derives `desired` from the then-current coordinator data instead
+        of acting on a stale snapshot -- otherwise it could compute `desired`
+        and mutate `self._entities` concurrently with the in-flight call,
+        risking a duplicate registration for the same key.
+        """
+        async with self._lock:
+            desired = {
+                description.key: description
+                for description in _active_schedule_descriptions(
+                    self.coordinator, self.coordinator.data
                 )
-                for description in to_add
+            }
+            to_add = [
+                description
+                for key, description in desired.items()
+                if key not in self._entities
             ]
-            for description, entity in zip(to_add, entities, strict=True):
-                self._entities[description.key] = entity
-            self.async_add_entities(entities)
+            to_remove = [
+                (key, entity)
+                for key, entity in self._entities.items()
+                if key not in desired
+            ]
+            if not to_add and not to_remove:
+                return
 
-        for key, entity in to_remove:
-            del self._entities[key]
-            # No force_remove: the registry entry must survive so the user's
-            # customisations and history are still there next time.
-            await entity.async_remove()
+            registry = er.async_get(self.hass)
+            # Unhide before adding: an entity added while its registry entry
+            # is hidden would stay hidden.
+            self._unhide_active(registry, set(desired))
 
-        self._hide_inactive(registry, set(desired))
+            if to_add:
+                entities = [
+                    LuxtronikTimerScheduleText(
+                        self.entry,
+                        self.coordinator,
+                        description,
+                        description.device_key,
+                    )
+                    for description in to_add
+                ]
+                for description, entity in zip(to_add, entities, strict=True):
+                    self._entities[description.key] = entity
+                self.async_add_entities(entities)
+
+            for key, entity in to_remove:
+                del self._entities[key]
+                # No force_remove: the registry entry must survive so the
+                # user's customisations and history are still there next
+                # time.
+                await entity.async_remove()
+
+            self._hide_inactive(registry, set(desired))
 
     def _unhide_active(
         self, registry: er.EntityRegistry, desired_keys: set[str]

--- a/custom_components/luxtronik2/text.py
+++ b/custom_components/luxtronik2/text.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import re
 
 from homeassistant.components.text import (
+    DOMAIN as TEXT_DOMAIN,
     ENTITY_ID_FORMAT,  # pyright: ignore[reportAttributeAccessIssue]
     TextEntity,
     TextMode,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 
 from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
@@ -67,6 +70,119 @@ def _active_schedule_descriptions(
     return descriptions
 
 
+class _TimerScheduleSync:
+    """Keeps the live schedule entities in step with the active timer program.
+
+    Only the blocks of the running program exist as entities. The registry
+    entries of the other blocks are kept but hidden, so a user's rename,
+    area, icon and recorder history survive a program switch -- removing the
+    registry entry would discard all of it.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: LuxtronikConfigEntry,
+        coordinator: LuxtronikCoordinator,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        self.hass = hass
+        self.entry = entry
+        self.coordinator = coordinator
+        self.async_add_entities = async_add_entities
+        self._entities: dict[str, LuxtronikTimerScheduleText] = {}
+
+    async def async_setup(self) -> None:
+        """Add the active program's entities and hide the rest."""
+        await self.async_apply()
+
+    @callback
+    def async_sync(self) -> None:
+        """Coordinator listener: schedule an add/remove pass."""
+        self.entry.async_create_task(self.hass, self.async_apply(), eager_start=False)
+
+    async def async_apply(self) -> None:
+        """Bring the live entity set in line with the active program."""
+        desired = {
+            description.key: description
+            for description in _active_schedule_descriptions(
+                self.coordinator, self.coordinator.data
+            )
+        }
+        to_add = [
+            description
+            for key, description in desired.items()
+            if key not in self._entities
+        ]
+        to_remove = [
+            (key, entity)
+            for key, entity in self._entities.items()
+            if key not in desired
+        ]
+        if not to_add and not to_remove:
+            return
+
+        registry = er.async_get(self.hass)
+        # Unhide before adding: an entity added while its registry entry is
+        # hidden would stay hidden.
+        self._unhide_active(registry, set(desired))
+
+        if to_add:
+            entities = [
+                LuxtronikTimerScheduleText(
+                    self.entry, self.coordinator, description, description.device_key
+                )
+                for description in to_add
+            ]
+            for description, entity in zip(to_add, entities, strict=True):
+                self._entities[description.key] = entity
+            self.async_add_entities(entities)
+
+        for key, entity in to_remove:
+            del self._entities[key]
+            # No force_remove: the registry entry must survive so the user's
+            # customisations and history are still there next time.
+            await entity.async_remove()
+
+        self._hide_inactive(registry, set(desired))
+
+    def _unhide_active(
+        self, registry: er.EntityRegistry, desired_keys: set[str]
+    ) -> None:
+        for description in TIMER_SCHEDULE_ENTITIES:
+            if description.key not in desired_keys:
+                continue
+            entity_id = registry.async_get_entity_id(
+                TEXT_DOMAIN, DOMAIN, _timer_schedule_unique_id(self.entry, description)
+            )
+            if entity_id is None:
+                continue
+            registry_entry = registry.async_get(entity_id)
+            if (
+                registry_entry is not None
+                and registry_entry.hidden_by is RegistryEntryHider.INTEGRATION
+            ):
+                registry.async_update_entity(entity_id, hidden_by=None)
+
+    def _hide_inactive(
+        self, registry: er.EntityRegistry, desired_keys: set[str]
+    ) -> None:
+        for description in TIMER_SCHEDULE_ENTITIES:
+            if description.key in desired_keys:
+                continue
+            entity_id = registry.async_get_entity_id(
+                TEXT_DOMAIN, DOMAIN, _timer_schedule_unique_id(self.entry, description)
+            )
+            if entity_id is None:
+                continue
+            registry_entry = registry.async_get(entity_id)
+            # hidden_by USER is the user's own decision and is left alone.
+            if registry_entry is not None and registry_entry.hidden_by is None:
+                registry.async_update_entity(
+                    entity_id, hidden_by=RegistryEntryHider.INTEGRATION
+                )
+
+
 async def async_setup_entry(  # pragma: no cover
     hass: HomeAssistant,
     entry: LuxtronikConfigEntry,
@@ -77,20 +193,9 @@ async def async_setup_entry(  # pragma: no cover
     if not coordinator.last_update_success:
         return
 
-    async_add_entities(
-        [
-            LuxtronikTimerScheduleText(
-                entry, coordinator, description, description.device_key
-            )
-            for description in TIMER_SCHEDULE_ENTITIES
-            if (
-                coordinator.entity_active(description)
-                and key_exists(
-                    coordinator.data, f"parameters.{description.mode_selector_name}"
-                )
-            )
-        ]
-    )
+    sync = _TimerScheduleSync(hass, entry, coordinator, async_add_entities)
+    await sync.async_setup()
+    entry.async_on_unload(coordinator.async_add_listener(sync.async_sync))
 
 
 def _parse_schedule(value: str, max_rows: int) -> list[tuple[str, str]]:

--- a/custom_components/luxtronik2/text.py
+++ b/custom_components/luxtronik2/text.py
@@ -15,7 +15,10 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.entity_registry import RegistryEntryHider
+from homeassistant.helpers.entity_registry import (
+    RegistryEntryDisabler,
+    RegistryEntryHider,
+)
 
 from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
@@ -64,7 +67,7 @@ def _active_schedule_descriptions(
     `key_exists` cannot tell the two apart for parameter 405, which sits
     inside upstream's defined index range. Reading a transient decode
     failure as "no program is active" would tear down every schedule entity
-    and hide all ten registry entries until the next good poll.
+    and disable all ten registry entries until the next good poll.
     """
     if data is None:
         return None
@@ -94,9 +97,11 @@ class _TimerScheduleSync:
     """Keeps the live schedule entities in step with the active timer program.
 
     Only the blocks of the running program exist as entities. The registry
-    entries of the other blocks are kept but hidden, so a user's rename,
+    entries of the other blocks are kept but disabled, so a user's rename,
     area, icon and recorder history survive a program switch -- removing the
-    registry entry would discard all of it.
+    registry entry would discard all of it. (An earlier build hid the
+    inactive entries instead; see `_enable_active`/`_disable_inactive` for
+    the one-time migration off that mechanism.)
     """
 
     def __init__(
@@ -120,7 +125,7 @@ class _TimerScheduleSync:
         self._closing = False
 
     async def async_setup(self) -> None:
-        """Add the active program's entities and hide the rest."""
+        """Add the active program's entities and disable the rest."""
         await self.async_apply()
 
     @callback
@@ -177,9 +182,11 @@ class _TimerScheduleSync:
                 return
 
             registry = er.async_get(self.hass)
-            # Unhide before adding: an entity added while its registry entry
-            # is hidden would stay hidden.
-            self._unhide_active(registry, set(desired))
+            # Enable before adding: EntityPlatform._async_add_entity calls
+            # add_to_platform_abort() for a disabled registry entry, so an
+            # entity added while its registry entry is still disabled would
+            # never come up.
+            self._enable_active(registry, set(desired))
 
             if to_add:
                 entities = [
@@ -199,7 +206,7 @@ class _TimerScheduleSync:
                 del self._entities[key]
                 await self._async_remove_entity(key, entity)
 
-            self._hide_inactive(registry, set(desired))
+            self._disable_inactive(registry, set(desired))
 
     async def _async_remove_entity(
         self, key: str, entity: LuxtronikTimerScheduleText
@@ -214,7 +221,7 @@ class _TimerScheduleSync:
         reach here before the platform's add task has run at all. Removing
         such an entity would raise on `self.hass.loop`, and - since this runs
         inside one `entry.async_create_task` - would abort the remaining
-        removals and the hide pass with it, so every failure is contained
+        removals and the disable pass with it, so every failure is contained
         and logged instead.
         """
         if entity.hass is None:  # pyright: ignore[reportUnnecessaryComparison]
@@ -231,7 +238,7 @@ class _TimerScheduleSync:
         except Exception:  # pylint: disable=broad-except
             LOGGER.exception("Error removing timer schedule entity %s", key)
 
-    def _unhide_active(
+    def _enable_active(
         self, registry: er.EntityRegistry, desired_keys: set[str]
     ) -> None:
         for description in TIMER_SCHEDULE_ENTITIES:
@@ -247,9 +254,23 @@ class _TimerScheduleSync:
                 registry_entry is not None
                 and registry_entry.hidden_by is RegistryEntryHider.INTEGRATION
             ):
+                # Migration: an earlier build hid inactive blocks instead of
+                # disabling them. Scrub the stale hidden_by so it doesn't
+                # linger on installs that ran that build.
                 registry.async_update_entity(entity_id, hidden_by=None)
+            if (
+                registry_entry is not None
+                and registry_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
+            ):
+                # Clearing here, before the entity is added, is required:
+                # EntityPlatform._async_add_entity calls
+                # add_to_platform_abort() for a disabled registry entry.
+                # This clear makes HA schedule a config-entry reload 30s from
+                # now (config_entries.RELOAD_AFTER_UPDATE_DELAY) - accepted,
+                # since switching timer program is rare.
+                registry.async_update_entity(entity_id, disabled_by=None)
 
-    def _hide_inactive(
+    def _disable_inactive(
         self, registry: er.EntityRegistry, desired_keys: set[str]
     ) -> None:
         for description in TIMER_SCHEDULE_ENTITIES:
@@ -261,10 +282,16 @@ class _TimerScheduleSync:
             if entity_id is None:
                 continue
             registry_entry = registry.async_get(entity_id)
-            # hidden_by USER is the user's own decision and is left alone.
-            if registry_entry is not None and registry_entry.hidden_by is None:
+            if (
+                registry_entry is not None
+                and registry_entry.hidden_by is RegistryEntryHider.INTEGRATION
+            ):
+                # Migration: see _enable_active.
+                registry.async_update_entity(entity_id, hidden_by=None)
+            # disabled_by USER is the user's own decision and is left alone.
+            if registry_entry is not None and registry_entry.disabled_by is None:
                 registry.async_update_entity(
-                    entity_id, hidden_by=RegistryEntryHider.INTEGRATION
+                    entity_id, disabled_by=RegistryEntryDisabler.INTEGRATION
                 )
 
 

--- a/custom_components/luxtronik2/text.py
+++ b/custom_components/luxtronik2/text.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity_registry import RegistryEntryHider
 from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
 from .common import get_sensor_data, key_exists
-from .const import CONF_HA_SENSOR_PREFIX, DOMAIN, DeviceKey
+from .const import CONF_HA_SENSOR_PREFIX, DOMAIN, LOGGER, DeviceKey
 from .coordinator import LuxtronikCoordinator, LuxtronikCoordinatorData
 from .model import LuxtronikTimerScheduleTextDescription
 from .timer_schedule_entities_predefined import TIMER_SCHEDULE_ENTITIES
@@ -48,15 +48,26 @@ def _timer_schedule_unique_id(
 def _active_schedule_descriptions(
     coordinator: LuxtronikCoordinator,
     data: LuxtronikCoordinatorData | None,
-) -> list[LuxtronikTimerScheduleTextDescription]:
+) -> list[LuxtronikTimerScheduleTextDescription] | None:
     """Return the schedule blocks belonging to the circuit's active program.
 
     A block qualifies when the circuit's mode selector is present on this
     controller and its value equals the block's `active_mode`. Every other
     block is meaningless on the device, so no entity is created for it.
+
+    Returns ``None`` -- "no information this poll", as opposed to an empty
+    list meaning "no block is active" -- when there is no coordinator data,
+    or when a selector that *is* present on this controller could not be
+    read. `get_sensor_data` returns ``None`` both for an absent register and
+    for a present one whose datatype could not decode the raw value
+    (``SelectionBase`` returns ``None`` for an unrecognised code), and
+    `key_exists` cannot tell the two apart for parameter 405, which sits
+    inside upstream's defined index range. Reading a transient decode
+    failure as "no program is active" would tear down every schedule entity
+    and hide all ten registry entries until the next good poll.
     """
     if data is None:
-        return []
+        return None
 
     descriptions: list[LuxtronikTimerScheduleTextDescription] = []
     for description in TIMER_SCHEDULE_ENTITIES:
@@ -65,7 +76,15 @@ def _active_schedule_descriptions(
         selector_key = f"parameters.{description.mode_selector_name}"
         if not key_exists(data, selector_key):
             continue
-        if get_sensor_data(data, selector_key) != description.active_mode:
+        mode = get_sensor_data(data, selector_key)
+        if mode is None:
+            LOGGER.debug(
+                "Timer program selector %s could not be read this poll - "
+                "leaving the schedule entities untouched",
+                selector_key,
+            )
+            return None
+        if mode != description.active_mode:
             continue
         descriptions.append(description)
     return descriptions
@@ -98,10 +117,22 @@ class _TimerScheduleSync:
         # compute `desired` against a dict the first call is still mutating,
         # risking a duplicate registration for the same key.
         self._lock = asyncio.Lock()
+        self._closing = False
 
     async def async_setup(self) -> None:
         """Add the active program's entities and hide the rest."""
         await self.async_apply()
+
+    @callback
+    def async_close(self) -> None:
+        """Stop applying: the config entry is unloading.
+
+        HA resets the platforms *before* running the entry's on-unload
+        callbacks and then awaits (rather than cancels) the entry's pending
+        tasks, so an `async_apply` queued just before the unload could
+        otherwise add entities to an already-reset platform.
+        """
+        self._closing = True
 
     @callback
     def async_sync(self) -> None:
@@ -119,13 +150,19 @@ class _TimerScheduleSync:
         and mutate `self._entities` concurrently with the in-flight call,
         risking a duplicate registration for the same key.
         """
+        if self._closing:
+            return
         async with self._lock:
-            desired = {
-                description.key: description
-                for description in _active_schedule_descriptions(
-                    self.coordinator, self.coordinator.data
-                )
-            }
+            if self._closing:
+                return
+            active = _active_schedule_descriptions(
+                self.coordinator, self.coordinator.data
+            )
+            if active is None:
+                # Nothing could be concluded this poll: do not add, remove or
+                # write anything.
+                return
+            desired = {description.key: description for description in active}
             to_add = [
                 description
                 for key, description in desired.items()
@@ -160,12 +197,39 @@ class _TimerScheduleSync:
 
             for key, entity in to_remove:
                 del self._entities[key]
-                # No force_remove: the registry entry must survive so the
-                # user's customisations and history are still there next
-                # time.
-                await entity.async_remove()
+                await self._async_remove_entity(key, entity)
 
             self._hide_inactive(registry, set(desired))
+
+    async def _async_remove_entity(
+        self, key: str, entity: LuxtronikTimerScheduleText
+    ) -> None:
+        """Take one schedule entity out of the state machine.
+
+        `async_add_entities` is a synchronous callback: it only *schedules*
+        the add, so an entry in `self._entities` is not necessarily a live
+        entity. `EntityPlatform._async_add_entity` calls
+        `add_to_platform_abort()` for a disabled registry entry (setting
+        `entity.hass = None`), and a fast enough second program switch can
+        reach here before the platform's add task has run at all. Removing
+        such an entity would raise on `self.hass.loop`, and - since this runs
+        inside one `entry.async_create_task` - would abort the remaining
+        removals and the hide pass with it, so every failure is contained
+        and logged instead.
+        """
+        if entity.hass is None:  # pyright: ignore[reportUnnecessaryComparison]
+            LOGGER.debug(
+                "Timer schedule entity %s was never added to the platform - "
+                "nothing to remove",
+                key,
+            )
+            return
+        try:
+            # No force_remove: the registry entry must survive so the user's
+            # customisations and history are still there next time.
+            await entity.async_remove()
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("Error removing timer schedule entity %s", key)
 
     def _unhide_active(
         self, registry: er.EntityRegistry, desired_keys: set[str]
@@ -215,6 +279,9 @@ async def async_setup_entry(  # pragma: no cover
         return
 
     sync = _TimerScheduleSync(hass, entry, coordinator, async_add_entities)
+    # Registered before the listener so the closing flag is in place for
+    # every pass the listener can ever schedule.
+    entry.async_on_unload(sync.async_close)
     await sync.async_setup()
     entry.async_on_unload(coordinator.async_add_listener(sync.async_sync))
 

--- a/custom_components/luxtronik2/text.py
+++ b/custom_components/luxtronik2/text.py
@@ -27,6 +27,20 @@ _UNSET_TIME = "00:00"
 _PAIR_PATTERN = re.compile(r"^([01]\d|2[0-3]):[0-5]\d-([01]\d|2[0-3]):[0-5]\d$")
 
 
+def _timer_schedule_unique_id(
+    entry: LuxtronikConfigEntry,
+    description: LuxtronikTimerScheduleTextDescription,
+) -> str:
+    """Return the unique_id of a schedule entity.
+
+    Today this is also its default entity_id. The format lives here only, so
+    decoupling unique_id from entity_id later (HA best practice) is a
+    single-site change plus a registry migration.
+    """
+    prefix = entry.data[CONF_HA_SENSOR_PREFIX]
+    return ENTITY_ID_FORMAT.format(f"{prefix}_{description.key}")
+
+
 async def async_setup_entry(  # pragma: no cover
     hass: HomeAssistant,
     entry: LuxtronikConfigEntry,
@@ -98,8 +112,7 @@ class LuxtronikTimerScheduleText(
             description=description,
             device_info_ident=device_info_ident,
         )
-        prefix = entry.data[CONF_HA_SENSOR_PREFIX]
-        self.entity_id = ENTITY_ID_FORMAT.format(f"{prefix}_{description.key}")
+        self.entity_id = _timer_schedule_unique_id(entry, description)
         self._attr_unique_id = self.entity_id
         self._attr_mode = TextMode.TEXT
         self._attr_native_min = 0

--- a/custom_components/luxtronik2/text.py
+++ b/custom_components/luxtronik2/text.py
@@ -41,6 +41,32 @@ def _timer_schedule_unique_id(
     return ENTITY_ID_FORMAT.format(f"{prefix}_{description.key}")
 
 
+def _active_schedule_descriptions(
+    coordinator: LuxtronikCoordinator,
+    data: LuxtronikCoordinatorData | None,
+) -> list[LuxtronikTimerScheduleTextDescription]:
+    """Return the schedule blocks belonging to the circuit's active program.
+
+    A block qualifies when the circuit's mode selector is present on this
+    controller and its value equals the block's `active_mode`. Every other
+    block is meaningless on the device, so no entity is created for it.
+    """
+    if data is None:
+        return []
+
+    descriptions: list[LuxtronikTimerScheduleTextDescription] = []
+    for description in TIMER_SCHEDULE_ENTITIES:
+        if not coordinator.entity_active(description):
+            continue
+        selector_key = f"parameters.{description.mode_selector_name}"
+        if not key_exists(data, selector_key):
+            continue
+        if get_sensor_data(data, selector_key) != description.active_mode:
+            continue
+        descriptions.append(description)
+    return descriptions
+
+
 async def async_setup_entry(  # pragma: no cover
     hass: HomeAssistant,
     entry: LuxtronikConfigEntry,

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -1005,6 +1005,14 @@
                     "2": "Analogov\u00fd vstup"
                 }
             },
+            "timer_dhw_program": {
+                "name": "\u010casov\u00fd program TUV",
+                "state": {
+                    "week": "Cel\u00fd t\u00fdden",
+                    "weekday_weekend": "Pracovn\u00ed dny + v\u00edkend",
+                    "daily": "Jednotliv\u00e9 dny"
+                }
+            },
             "pv_mode_selector": {
                 "name": "PV re\u017eim",
                 "state": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -1005,6 +1005,14 @@
                     "2": "AIn"
                 }
             },
+            "timer_dhw_program": {
+                "name": "Warmwasser Zeitprogramm",
+                "state": {
+                    "week": "Ganze Woche",
+                    "weekday_weekend": "Werktage + Wochenende",
+                    "daily": "Einzelne Tage"
+                }
+            },
             "pv_mode_selector": {
                 "name": "PV Modus",
                 "state": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -1005,6 +1005,14 @@
                     "2": "Analog in"
                 }
             },
+            "timer_dhw_program": {
+                "name": "Hot water timer program",
+                "state": {
+                    "week": "Whole week",
+                    "weekday_weekend": "Weekdays + weekend",
+                    "daily": "Per day"
+                }
+            },
             "pv_mode_selector": {
                 "name": "PV Mode",
                 "state": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -1005,6 +1005,14 @@
                     "2": "Analoge ingang"
                 }
             },
+            "timer_dhw_program": {
+                "name": "Warmwater tijdprogramma",
+                "state": {
+                    "week": "Hele week",
+                    "weekday_weekend": "Werkdagen + weekend",
+                    "daily": "Per dag"
+                }
+            },
             "pv_mode_selector": {
                 "name": "PV Mode",
                 "state": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -1005,6 +1005,14 @@
                     "2": "Wej\u015bcie analogowe"
                 }
             },
+            "timer_dhw_program": {
+                "name": "Program czasowy CWU",
+                "state": {
+                    "week": "Cały tydzień",
+                    "weekday_weekend": "Dni robocze + weekend",
+                    "daily": "Poszczególne dni"
+                }
+            },
             "pv_mode_selector": {
                 "name": "Tryb PV",
                 "state": {

--- a/docs/superpowers/plans/2026-08-11-dhw-timer-program-entity-visibility.md
+++ b/docs/superpowers/plans/2026-08-11-dhw-timer-program-entity-visibility.md
@@ -1,0 +1,907 @@
+# DHW Timer-Program Entity Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Only the DHW schedule text entities of the currently selected timer program exist as live entities; the others are removed from the state machine and hidden in the entity registry, and the timer program itself becomes switchable from HA via a new select entity.
+
+**Architecture:** `text.py` gains a `_TimerScheduleSync` helper that computes the active-mode description set from coordinator data, adds/removes entities, and flips `hidden_by` on the registry entries of inactive modes. It runs once at setup and again on every coordinator update through `coordinator.async_add_listener`. `select.py`/`model.py` gain an explicit HA-option → raw-device-value mapping so the raw value `"5+2"` can be exposed as the HA option `weekday_weekend`.
+
+**Tech Stack:** Home Assistant custom integration, Python 3.14, pytest + pytest-asyncio, ruff, basedpyright.
+
+## Global Constraints
+
+- Design doc: `docs/superpowers/specs/2026-08-11-dhw-timer-program-entity-visibility-design.md`.
+- Work happens on branch `feat/dhw-timer-program-visibility` (already created, spec already committed there).
+- Run every Python command through the py314 env by full path:
+  `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest ...`
+- Before each commit: `python -m ruff check custom_components/luxtronik2 tests`,
+  `python -m ruff format custom_components/luxtronik2 tests`,
+  `python -m basedpyright --pythonpath "C:\Users\rhamm\anaconda3\envs\py314\python.exe" custom_components/luxtronik2` (must be 0 errors).
+- Never scope `--cov` to a leaf submodule; measure at `--cov=custom_components.luxtronik2`.
+- Commit format: `<type>(<scope>): <gitmoji> <description>` (lowercase imperative, no trailing period), body as a bullet list.
+- Entity presence is gated on register existence (`key_exists`), never on firmware version.
+- The raw device values of parameter 405 are exactly `"week"`, `"5+2"`, `"days"` (from `TimerProgram` in `lux_overrides.py`). The HA-facing option names are exactly `week`, `weekday_weekend`, `daily`.
+- A registry entry whose `hidden_by` is `RegistryEntryHider.USER` is never modified.
+
+## File Structure
+
+- `custom_components/luxtronik2/text.py` — modify: add `_timer_schedule_unique_id`, `_active_schedule_descriptions`, `_TimerScheduleSync`; rewrite `async_setup_entry`.
+- `custom_components/luxtronik2/const.py` — modify: add `LuxParameter.P0405_TIMER_PROGRAM_DHW` and `SensorKey.TIMER_DHW_PROGRAM`.
+- `custom_components/luxtronik2/model.py` — modify: add `raw_option_map` field to `LuxtronikSelectEntityDescription`.
+- `custom_components/luxtronik2/select.py` — modify: honour `raw_option_map` in `LuxtronikModeSelector`.
+- `custom_components/luxtronik2/select_entities_predefined.py` — modify: add the timer-program description.
+- `custom_components/luxtronik2/translations/{en,de,nl,cs,pl}.json` — modify: name + state strings for the new select.
+- `tests/test_text.py` — modify: tests for the three new text.py units.
+- `tests/test_select.py` — modify: tests for the option mapping.
+
+---
+
+### Task 1: Single-source the schedule unique_id
+
+**Files:**
+- Modify: `custom_components/luxtronik2/text.py:89-108`
+- Test: `tests/test_text.py`
+
+**Interfaces:**
+- Produces: `_timer_schedule_unique_id(entry: LuxtronikConfigEntry, description: LuxtronikTimerScheduleTextDescription) -> str`, returning e.g. `"text.luxtronik_timer_dhw_schedule_week"`. Tasks 2 and 3 use it to look registry entries up.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_text.py`, at the end of the file:
+
+```python
+# ===========================================================================
+# _timer_schedule_unique_id
+# ===========================================================================
+
+
+class TestTimerScheduleUniqueId:
+    def test_matches_the_entity_id_the_entity_assigns_itself(self):
+        from custom_components.luxtronik2.text import _timer_schedule_unique_id
+
+        description = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_WEEK
+        )
+        assert (
+            _timer_schedule_unique_id(_mock_entry(), description)
+            == f"text.{DOMAIN}_{description.key}"
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_text.py::TestTimerScheduleUniqueId -v`
+Expected: FAIL with `ImportError: cannot import name '_timer_schedule_unique_id'`
+
+- [ ] **Step 3: Add the helper and use it in the entity**
+
+In `custom_components/luxtronik2/text.py`, add after `_PAIR_PATTERN`:
+
+```python
+def _timer_schedule_unique_id(
+    entry: LuxtronikConfigEntry,
+    description: LuxtronikTimerScheduleTextDescription,
+) -> str:
+    """Return the unique_id of a schedule entity.
+
+    Today this is also its default entity_id. The format lives here only, so
+    decoupling unique_id from entity_id later (HA best practice) is a
+    single-site change plus a registry migration.
+    """
+    prefix = entry.data[CONF_HA_SENSOR_PREFIX]
+    return ENTITY_ID_FORMAT.format(f"{prefix}_{description.key}")
+```
+
+Then replace these two lines in `LuxtronikTimerScheduleText.__init__`:
+
+```python
+        prefix = entry.data[CONF_HA_SENSOR_PREFIX]
+        self.entity_id = ENTITY_ID_FORMAT.format(f"{prefix}_{description.key}")
+        self._attr_unique_id = self.entity_id
+```
+
+with:
+
+```python
+        self.entity_id = _timer_schedule_unique_id(entry, description)
+        self._attr_unique_id = self.entity_id
+```
+
+- [ ] **Step 4: Run the text tests**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_text.py -v`
+Expected: PASS (including the pre-existing `test_entity_id`)
+
+- [ ] **Step 5: Lint, typecheck, commit**
+
+```bash
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff format custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff check custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m basedpyright --pythonpath "C:\Users\rhamm\anaconda3\envs\py314\python.exe" custom_components/luxtronik2
+git add custom_components/luxtronik2/text.py tests/test_text.py
+git commit -m "refactor(text): ♻️ single-source the timer schedule unique_id"
+```
+
+---
+
+### Task 2: Compute the active timer program's descriptions
+
+**Files:**
+- Modify: `custom_components/luxtronik2/text.py`
+- Test: `tests/test_text.py`
+
+**Interfaces:**
+- Consumes: `_timer_schedule_unique_id` (Task 1) — not directly, but the same module.
+- Produces: `_active_schedule_descriptions(coordinator: LuxtronikCoordinator, data: LuxtronikCoordinatorData | None) -> list[LuxtronikTimerScheduleTextDescription]`. Task 3 calls it once per sync.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_text.py`:
+
+```python
+# ===========================================================================
+# _active_schedule_descriptions
+# ===========================================================================
+
+
+class TestActiveScheduleDescriptions:
+    _SELECTOR = "ID_Einst_SUBW_akt2"
+
+    def _call(self, parameters, *, entity_active=True):
+        from custom_components.luxtronik2.text import _active_schedule_descriptions
+
+        data = make_coordinator_data(parameters=parameters)
+        coord = _mock_coordinator(data)
+        coord.entity_active.return_value = entity_active
+        return [d.key for d in _active_schedule_descriptions(coord, data)]
+
+    def test_week_mode_yields_only_the_week_block(self):
+        assert self._call({self._SELECTOR: "week"}) == [SK.TIMER_DHW_SCHEDULE_WEEK]
+
+    def test_weekday_weekend_mode_yields_both_blocks(self):
+        assert self._call({self._SELECTOR: "5+2"}) == [
+            SK.TIMER_DHW_SCHEDULE_WEEKDAY,
+            SK.TIMER_DHW_SCHEDULE_WEEKEND,
+        ]
+
+    def test_days_mode_yields_seven_day_blocks(self):
+        keys = self._call({self._SELECTOR: "days"})
+        assert len(keys) == 7
+        assert SK.TIMER_DHW_SCHEDULE_MONDAY in keys
+        assert SK.TIMER_DHW_SCHEDULE_SUNDAY in keys
+
+    def test_missing_selector_parameter_yields_nothing(self):
+        assert self._call({}) == []
+
+    def test_data_none_yields_nothing(self):
+        from custom_components.luxtronik2.text import _active_schedule_descriptions
+
+        assert _active_schedule_descriptions(_mock_coordinator(), None) == []
+
+    def test_inactive_entity_yields_nothing(self):
+        assert self._call({self._SELECTOR: "week"}, entity_active=False) == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_text.py::TestActiveScheduleDescriptions -v`
+Expected: FAIL with `ImportError: cannot import name '_active_schedule_descriptions'`
+
+- [ ] **Step 3: Implement the function**
+
+In `custom_components/luxtronik2/text.py`, add after `_timer_schedule_unique_id`:
+
+```python
+def _active_schedule_descriptions(
+    coordinator: LuxtronikCoordinator,
+    data: LuxtronikCoordinatorData | None,
+) -> list[LuxtronikTimerScheduleTextDescription]:
+    """Return the schedule blocks belonging to the circuit's active program.
+
+    A block qualifies when the circuit's mode selector is present on this
+    controller and its value equals the block's `active_mode`. Every other
+    block is meaningless on the device, so no entity is created for it.
+    """
+    if data is None:
+        return []
+
+    descriptions: list[LuxtronikTimerScheduleTextDescription] = []
+    for description in TIMER_SCHEDULE_ENTITIES:
+        if not coordinator.entity_active(description):
+            continue
+        selector_key = f"parameters.{description.mode_selector_name}"
+        if not key_exists(data, selector_key):
+            continue
+        if get_sensor_data(data, selector_key) != description.active_mode:
+            continue
+        descriptions.append(description)
+    return descriptions
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_text.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Lint, typecheck, commit**
+
+```bash
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff format custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff check custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m basedpyright --pythonpath "C:\Users\rhamm\anaconda3\envs\py314\python.exe" custom_components/luxtronik2
+git add custom_components/luxtronik2/text.py tests/test_text.py
+git commit -m "feat(text): ✨ derive the active timer program's schedule blocks"
+```
+
+---
+
+### Task 3: Sync live entities with the active program
+
+**Files:**
+- Modify: `custom_components/luxtronik2/text.py:30-53` (`async_setup_entry`) plus new class
+- Test: `tests/test_text.py`
+
+**Interfaces:**
+- Consumes: `_timer_schedule_unique_id` (Task 1), `_active_schedule_descriptions` (Task 2).
+- Produces: `_TimerScheduleSync(hass, entry, coordinator, async_add_entities)` with
+  `async def async_setup(self) -> None` (initial add + hide pass) and
+  `@callback def async_sync(self) -> None` (coordinator-listener entry point, schedules the work).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_text.py`:
+
+```python
+# ===========================================================================
+# _TimerScheduleSync
+# ===========================================================================
+
+
+class TestTimerScheduleSync:
+    _SELECTOR = "ID_Einst_SUBW_akt2"
+
+    def _make_sync(self, mode: str):
+        from custom_components.luxtronik2.text import _TimerScheduleSync
+
+        data = make_coordinator_data(parameters={self._SELECTOR: mode})
+        coord = _mock_coordinator(data)
+        entry = _mock_entry()
+        added: list = []
+
+        def _add_entities(entities):
+            added.extend(entities)
+
+        sync = _TimerScheduleSync(MagicMock(), entry, coord, _add_entities)
+        return sync, coord, added
+
+    def _registry(self, known: dict[str, MagicMock]):
+        """Fake entity registry: unique_id -> registry entry."""
+        registry = MagicMock()
+        registry.async_get_entity_id.side_effect = (
+            lambda _domain, _platform, unique_id: unique_id if unique_id in known else None
+        )
+        registry.async_get.side_effect = lambda entity_id: known.get(entity_id)
+        return registry
+
+    def _entry(self, hidden_by=None):
+        registry_entry = MagicMock()
+        registry_entry.hidden_by = hidden_by
+        return registry_entry
+
+    @pytest.mark.asyncio
+    async def test_setup_adds_only_the_active_blocks(self):
+        sync, _coord, added = self._make_sync("week")
+        with patch("custom_components.luxtronik2.text.er.async_get", return_value=self._registry({})), patch(
+            "homeassistant.helpers.frame.report_usage"
+        ):
+            await sync.async_setup()
+        assert [e.entity_description.key for e in added] == [SK.TIMER_DHW_SCHEDULE_WEEK]
+
+    @pytest.mark.asyncio
+    async def test_setup_hides_existing_entries_of_inactive_blocks(self):
+        from custom_components.luxtronik2.text import _timer_schedule_unique_id
+        from homeassistant.helpers.entity_registry import RegistryEntryHider
+
+        sync, _coord, _added = self._make_sync("week")
+        entry = _mock_entry()
+        stale = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_MONDAY
+        )
+        stale_id = _timer_schedule_unique_id(entry, stale)
+        registry = self._registry({stale_id: self._entry()})
+
+        with patch("custom_components.luxtronik2.text.er.async_get", return_value=registry), patch(
+            "homeassistant.helpers.frame.report_usage"
+        ):
+            await sync.async_setup()
+
+        registry.async_update_entity.assert_any_call(
+            stale_id, hidden_by=RegistryEntryHider.INTEGRATION
+        )
+
+    @pytest.mark.asyncio
+    async def test_setup_does_not_touch_a_user_hidden_entry(self):
+        from custom_components.luxtronik2.text import _timer_schedule_unique_id
+        from homeassistant.helpers.entity_registry import RegistryEntryHider
+
+        sync, _coord, _added = self._make_sync("week")
+        entry = _mock_entry()
+        week = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_WEEK
+        )
+        week_id = _timer_schedule_unique_id(entry, week)
+        registry = self._registry({week_id: self._entry(RegistryEntryHider.USER)})
+
+        with patch("custom_components.luxtronik2.text.er.async_get", return_value=registry), patch(
+            "homeassistant.helpers.frame.report_usage"
+        ):
+            await sync.async_setup()
+
+        registry.async_update_entity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_setup_unhides_an_integration_hidden_active_entry(self):
+        from custom_components.luxtronik2.text import _timer_schedule_unique_id
+        from homeassistant.helpers.entity_registry import RegistryEntryHider
+
+        sync, _coord, _added = self._make_sync("week")
+        entry = _mock_entry()
+        week = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_WEEK
+        )
+        week_id = _timer_schedule_unique_id(entry, week)
+        registry = self._registry({week_id: self._entry(RegistryEntryHider.INTEGRATION)})
+
+        with patch("custom_components.luxtronik2.text.er.async_get", return_value=registry), patch(
+            "homeassistant.helpers.frame.report_usage"
+        ):
+            await sync.async_setup()
+
+        registry.async_update_entity.assert_any_call(week_id, hidden_by=None)
+
+    @pytest.mark.asyncio
+    async def test_mode_change_swaps_the_entities(self):
+        from custom_components.luxtronik2.text import LuxtronikTimerScheduleText
+
+        sync, coord, added = self._make_sync("week")
+        registry = self._registry({})
+        with patch("custom_components.luxtronik2.text.er.async_get", return_value=registry), patch(
+            "homeassistant.helpers.frame.report_usage"
+        ):
+            await sync.async_setup()
+            coord.data = make_coordinator_data(parameters={self._SELECTOR: "5+2"})
+            with patch.object(
+                LuxtronikTimerScheduleText, "async_remove", new=AsyncMock()
+            ) as remove:
+                await sync.async_apply()
+
+        assert remove.await_count == 1
+        assert [e.entity_description.key for e in added[1:]] == [
+            SK.TIMER_DHW_SCHEDULE_WEEKDAY,
+            SK.TIMER_DHW_SCHEDULE_WEEKEND,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_unchanged_mode_does_not_touch_anything(self):
+        sync, _coord, added = self._make_sync("week")
+        registry = self._registry({})
+        with patch("custom_components.luxtronik2.text.er.async_get", return_value=registry), patch(
+            "homeassistant.helpers.frame.report_usage"
+        ):
+            await sync.async_setup()
+            registry.async_update_entity.reset_mock()
+            await sync.async_apply()
+
+        assert len(added) == 1
+        registry.async_update_entity.assert_not_called()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_text.py::TestTimerScheduleSync -v`
+Expected: FAIL with `ImportError: cannot import name '_TimerScheduleSync'`
+
+- [ ] **Step 3: Implement the sync helper**
+
+Add these imports at the top of `custom_components/luxtronik2/text.py`:
+
+```python
+from homeassistant.components.text import DOMAIN as TEXT_DOMAIN
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_registry import RegistryEntryHider
+```
+
+Add the class after `_active_schedule_descriptions`:
+
+```python
+class _TimerScheduleSync:
+    """Keeps the live schedule entities in step with the active timer program.
+
+    Only the blocks of the running program exist as entities. The registry
+    entries of the other blocks are kept but hidden, so a user's rename,
+    area, icon and recorder history survive a program switch -- removing the
+    registry entry would discard all of it.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: LuxtronikConfigEntry,
+        coordinator: LuxtronikCoordinator,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        self.hass = hass
+        self.entry = entry
+        self.coordinator = coordinator
+        self.async_add_entities = async_add_entities
+        self._entities: dict[str, LuxtronikTimerScheduleText] = {}
+
+    async def async_setup(self) -> None:
+        """Add the active program's entities and hide the rest."""
+        await self.async_apply()
+
+    @callback
+    def async_sync(self) -> None:
+        """Coordinator listener: schedule an add/remove pass."""
+        self.entry.async_create_task(
+            self.hass, self.async_apply(), eager_start=False
+        )
+
+    async def async_apply(self) -> None:
+        """Bring the live entity set in line with the active program."""
+        desired = {
+            description.key: description
+            for description in _active_schedule_descriptions(
+                self.coordinator, self.coordinator.data
+            )
+        }
+        to_add = [
+            description
+            for key, description in desired.items()
+            if key not in self._entities
+        ]
+        to_remove = [
+            (key, entity)
+            for key, entity in self._entities.items()
+            if key not in desired
+        ]
+        if not to_add and not to_remove:
+            return
+
+        registry = er.async_get(self.hass)
+        # Unhide before adding: an entity added while its registry entry is
+        # hidden would stay hidden.
+        self._unhide_active(registry, set(desired))
+
+        if to_add:
+            entities = [
+                LuxtronikTimerScheduleText(
+                    self.entry, self.coordinator, description, description.device_key
+                )
+                for description in to_add
+            ]
+            for description, entity in zip(to_add, entities, strict=True):
+                self._entities[description.key] = entity
+            self.async_add_entities(entities)
+
+        for key, entity in to_remove:
+            del self._entities[key]
+            # No force_remove: the registry entry must survive so the user's
+            # customisations and history are still there next time.
+            await entity.async_remove()
+
+        self._hide_inactive(registry, set(desired))
+
+    def _unhide_active(
+        self, registry: er.EntityRegistry, desired_keys: set[str]
+    ) -> None:
+        for description in TIMER_SCHEDULE_ENTITIES:
+            if description.key not in desired_keys:
+                continue
+            entity_id = registry.async_get_entity_id(
+                TEXT_DOMAIN, DOMAIN, _timer_schedule_unique_id(self.entry, description)
+            )
+            registry_entry = None if entity_id is None else registry.async_get(entity_id)
+            if (
+                registry_entry is not None
+                and registry_entry.hidden_by is RegistryEntryHider.INTEGRATION
+            ):
+                registry.async_update_entity(entity_id, hidden_by=None)
+
+    def _hide_inactive(
+        self, registry: er.EntityRegistry, desired_keys: set[str]
+    ) -> None:
+        for description in TIMER_SCHEDULE_ENTITIES:
+            if description.key in desired_keys:
+                continue
+            entity_id = registry.async_get_entity_id(
+                TEXT_DOMAIN, DOMAIN, _timer_schedule_unique_id(self.entry, description)
+            )
+            registry_entry = None if entity_id is None else registry.async_get(entity_id)
+            # hidden_by USER is the user's own decision and is left alone.
+            if registry_entry is not None and registry_entry.hidden_by is None:
+                registry.async_update_entity(
+                    entity_id, hidden_by=RegistryEntryHider.INTEGRATION
+                )
+```
+
+Replace the body of `async_setup_entry` with:
+
+```python
+async def async_setup_entry(  # pragma: no cover
+    hass: HomeAssistant,
+    entry: LuxtronikConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator = entry.runtime_data
+
+    if not coordinator.last_update_success:
+        return
+
+    sync = _TimerScheduleSync(hass, entry, coordinator, async_add_entities)
+    await sync.async_setup()
+    entry.async_on_unload(coordinator.async_add_listener(sync.async_sync))
+```
+
+`key_exists` is no longer used by `async_setup_entry` but is still used by
+`_active_schedule_descriptions`, so its import stays.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_text.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full suite with coverage**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest --cov=custom_components.luxtronik2 -q`
+Expected: all pass, coverage not lower than before the branch
+
+- [ ] **Step 6: Lint, typecheck, commit**
+
+```bash
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff format custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff check custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m basedpyright --pythonpath "C:\Users\rhamm\anaconda3\envs\py314\python.exe" custom_components/luxtronik2
+git add custom_components/luxtronik2/text.py tests/test_text.py
+git commit -m "feat(text): ✨ create only the selected timer program's schedule entities"
+```
+
+---
+
+### Task 4: Expose the DHW timer program as a select entity
+
+**Files:**
+- Modify: `custom_components/luxtronik2/const.py` (`LuxParameter`, `SensorKey`)
+- Modify: `custom_components/luxtronik2/model.py:245-252`
+- Modify: `custom_components/luxtronik2/select.py:212-273`
+- Modify: `custom_components/luxtronik2/select_entities_predefined.py`
+- Modify: `custom_components/luxtronik2/translations/{en,de,nl,cs,pl}.json`
+- Test: `tests/test_select.py`
+
+**Interfaces:**
+- Consumes: nothing from Tasks 1-3.
+- Produces: `LuxtronikSelectEntityDescription.raw_option_map: dict[str, str] | None` (HA option → raw device value) honoured by `LuxtronikModeSelector`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_select.py`:
+
+```python
+# ===========================================================================
+# raw_option_map (timer program selector)
+# ===========================================================================
+
+
+class TestRawOptionMap:
+    def _make_selector(self, raw_value: str):
+        from custom_components.luxtronik2.select import LuxtronikModeSelector
+
+        desc = LuxtronikSelectEntityDescription(
+            key=SensorKey.TIMER_DHW_PROGRAM,
+            device_key=DeviceKey.domestic_water,
+            luxtronik_key=LuxParameter.P0405_TIMER_PROGRAM_DHW,
+            options=["week", "weekday_weekend", "daily"],
+            raw_option_map={"week": "week", "weekday_weekend": "5+2", "daily": "days"},
+        )
+        data = make_coordinator_data(
+            parameters={"ID_Einst_SUBW_akt2": raw_value}
+        )
+        coord = _mock_coordinator(data)
+        entity = LuxtronikModeSelector(
+            _mock_entry(), coord, desc, DeviceKey.domestic_water
+        )
+        _patch_entity(entity)
+        return entity, coord
+
+    def test_options_are_the_ha_names(self):
+        entity, _coord = self._make_selector("week")
+        assert entity._attr_options == ["week", "weekday_weekend", "daily"]
+
+    def test_raw_value_maps_to_ha_option(self):
+        entity, _coord = self._make_selector("5+2")
+        entity._handle_coordinator_update()
+        assert entity._attr_current_option == "weekday_weekend"
+
+    @pytest.mark.asyncio
+    async def test_selecting_option_writes_raw_value(self):
+        entity, coord = self._make_selector("week")
+        await entity.async_select_option("weekday_weekend")
+        coord.async_write.assert_awaited_once_with("ID_Einst_SUBW_akt2", "5+2")
+
+    def test_existing_selectors_keep_working_without_a_map(self):
+        from custom_components.luxtronik2.select import LuxtronikModeSelector
+
+        desc = LuxtronikSelectEntityDescription(
+            key=SensorKey.DOMESTIC_WATER_MODE_SELECTOR,
+            device_key=DeviceKey.domestic_water,
+            luxtronik_key=LuxParameter.P0004_MODE_DHW,
+            options=["Automatic", "Off"],
+        )
+        data = make_coordinator_data(parameters={"ID_Ba_Bw_akt": "Automatic"})
+        entity = LuxtronikModeSelector(
+            _mock_entry(), _mock_coordinator(data), desc, DeviceKey.domestic_water
+        )
+        _patch_entity(entity)
+        entity._handle_coordinator_update()
+        assert entity._attr_options == ["automatic", "off"]
+        assert entity._attr_current_option == "automatic"
+```
+
+Add `LuxParameter` to the `custom_components.luxtronik2.const` import block at the
+top of `tests/test_select.py`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_select.py::TestRawOptionMap -v`
+Expected: FAIL with `AttributeError: TIMER_DHW_PROGRAM` (or an unexpected-keyword error for `raw_option_map`)
+
+- [ ] **Step 3: Add the const entries**
+
+In `custom_components/luxtronik2/const.py`, in `class LuxParameter`, next to the other DHW parameters:
+
+```python
+    P0405_TIMER_PROGRAM_DHW = "parameters.ID_Einst_SUBW_akt2"
+```
+
+In `class SensorKey`, directly above `TIMER_DHW_SCHEDULE_WEEK`:
+
+```python
+    TIMER_DHW_PROGRAM = "timer_dhw_program"
+```
+
+- [ ] **Step 4: Add the description field**
+
+In `custom_components/luxtronik2/model.py`, in `LuxtronikSelectEntityDescription`:
+
+```python
+class LuxtronikSelectEntityDescription(
+    LuxtronikEntityDescription,
+    SelectEntityDescription,
+    frozen_or_thawed=True,
+):
+    """Class describing Luxtronik select entities."""
+
+    platform = Platform.SELECT
+    #: Maps the HA-facing option name to the raw value the device expects,
+    #: for parameters whose raw values are not usable as HA options (e.g.
+    #: the timer program's "5+2"). When unset, options are derived from the
+    #: raw values as before.
+    raw_option_map: dict[str, str] | None = None
+```
+
+- [ ] **Step 5: Honour the map in the selector**
+
+In `custom_components/luxtronik2/select.py`, replace this block in `LuxtronikModeSelector.__init__`:
+
+```python
+        raw_options = list(options or description.options or [])
+        self._option_to_raw = {
+            _normalize_select_option(raw_option): raw_option
+            for raw_option in raw_options
+        }
+        self._attr_options = list(self._option_to_raw)
+```
+
+with:
+
+```python
+        if description.raw_option_map:
+            self._option_to_raw = dict(description.raw_option_map)
+        else:
+            raw_options = list(options or description.options or [])
+            self._option_to_raw = {
+                _normalize_select_option(raw_option): raw_option
+                for raw_option in raw_options
+            }
+        self._attr_options = list(self._option_to_raw)
+        self._raw_to_option = {
+            _normalize_select_option(raw): option
+            for option, raw in self._option_to_raw.items()
+        }
+```
+
+and in `_handle_coordinator_update` replace:
+
+```python
+        current_raw = str(get_sensor_data(data, self._lux_parameter))
+        current = _normalize_select_option(current_raw)
+```
+
+with:
+
+```python
+        current_raw = str(get_sensor_data(data, self._lux_parameter))
+        normalized = _normalize_select_option(current_raw)
+        current = self._raw_to_option.get(normalized, normalized)
+```
+
+- [ ] **Step 6: Add the predefined description**
+
+In `custom_components/luxtronik2/select_entities_predefined.py`, add to `SELECT_ENTITIES`:
+
+```python
+    LuxtronikSelectEntityDescription(
+        key=SK.TIMER_DHW_PROGRAM,
+        device_key=DeviceKey.domestic_water,
+        luxtronik_key=LuxParameter.P0405_TIMER_PROGRAM_DHW,
+        entity_category=EntityCategory.CONFIG,
+        options=timer_program_options,
+        raw_option_map=TIMER_PROGRAM_RAW_OPTIONS,
+    ),
+```
+
+and above `SELECT_ENTITIES`:
+
+```python
+# The device's raw values ("5+2") are not usable as HA option names, so the
+# HA-facing names are mapped explicitly onto them.
+TIMER_PROGRAM_RAW_OPTIONS: dict[str, str] = {
+    "week": "week",
+    "weekday_weekend": "5+2",
+    "daily": "days",
+}
+timer_program_options: list[str] = list(TIMER_PROGRAM_RAW_OPTIONS)
+```
+
+- [ ] **Step 7: Run the select tests**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_select.py -v`
+Expected: PASS
+
+- [ ] **Step 8: Add the translations**
+
+In each of the five `custom_components/luxtronik2/translations/*.json` files, add an
+entry inside the `"select"` object (next to `"pv_mode_selector"`), using the exact
+key `"timer_dhw_program"` and exactly the three state keys `week`,
+`weekday_weekend`, `daily`:
+
+`en.json`:
+
+```json
+            "timer_dhw_program": {
+                "name": "Hot water timer program",
+                "state": {
+                    "week": "Whole week",
+                    "weekday_weekend": "Weekdays + weekend",
+                    "daily": "Per day"
+                }
+            },
+```
+
+`de.json`:
+
+```json
+            "timer_dhw_program": {
+                "name": "Warmwasser Zeitprogramm",
+                "state": {
+                    "week": "Ganze Woche",
+                    "weekday_weekend": "Werktage + Wochenende",
+                    "daily": "Einzelne Tage"
+                }
+            },
+```
+
+`nl.json`:
+
+```json
+            "timer_dhw_program": {
+                "name": "Warmwater tijdprogramma",
+                "state": {
+                    "week": "Hele week",
+                    "weekday_weekend": "Werkdagen + weekend",
+                    "daily": "Per dag"
+                }
+            },
+```
+
+`cs.json`:
+
+```json
+            "timer_dhw_program": {
+                "name": "Časový program TUV",
+                "state": {
+                    "week": "Celý týden",
+                    "weekday_weekend": "Pracovní dny + víkend",
+                    "daily": "Jednotlivé dny"
+                }
+            },
+```
+
+`pl.json`:
+
+```json
+            "timer_dhw_program": {
+                "name": "Program czasowy CWU",
+                "state": {
+                    "week": "Cały tydzień",
+                    "weekday_weekend": "Dni robocze + weekend",
+                    "daily": "Poszczególne dni"
+                }
+            },
+```
+
+- [ ] **Step 9: Run the translation-coverage and full test suite**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_translation_coverage.py -v`
+Expected: PASS (all five locales carry the same entity key and state keys)
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest --cov=custom_components.luxtronik2 -q`
+Expected: all pass, no coverage regression
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m codespell_lib custom_components/luxtronik2 tests`
+Expected: no findings
+
+- [ ] **Step 10: Lint, typecheck, commit**
+
+```bash
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff format custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff check custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m basedpyright --pythonpath "C:\Users\rhamm\anaconda3\envs\py314\python.exe" custom_components/luxtronik2
+git add custom_components/luxtronik2 tests/test_select.py
+git commit -m "feat(select): ✨ expose the DHW timer program selector"
+```
+
+---
+
+### Task 5: Verify against the live heat pump
+
+**Files:** none (manual verification)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4.
+
+- [ ] **Step 1: Reload the integration on the live HA instance**
+
+Restart HA (or reload the Luxtronik config entry) with the branch installed.
+
+- [ ] **Step 2: Check the DHW device page**
+
+Expected: exactly the schedule entities of the running program are listed as
+normal entities; the others appear only under "+N hidden entities" (existing
+install) or not at all (fresh install). None of them are unavailable.
+
+- [ ] **Step 3: Switch the program from HA**
+
+Set the new `select.<prefix>_timer_dhw_program` to `weekday_weekend`.
+Expected: within one poll the week block disappears and the weekday + weekend
+blocks appear, with their times read from the device.
+
+- [ ] **Step 4: Switch back and confirm nothing was lost**
+
+Set the select back to `week`.
+Expected: the week block returns with the same entity_id it had before, and any
+rename/area you set on it is still in place.
+
+- [ ] **Step 5: Report the results**
+
+Note anything that deviates; do not claim the feature works without having seen
+steps 2-4 behave as described.
+
+---
+
+## Notes for the implementer
+
+- `zip(..., strict=True)` requires the two lists to be built in the same order — they are, `to_add` and `entities` are parallel.
+- `entry.async_create_task(hass, coro, eager_start=False)` is deliberate: the sync runs from a synchronous coordinator listener callback, and eager start would re-enter the coordinator's update path.
+- Do not add `force_remove=True` to `entity.async_remove()` — that would delete the registry entry and defeat the whole design.
+- The existing `LuxtronikTimerScheduleText.available` mode check stays: it covers the window between a coordinator update carrying a new mode and the scheduled add/remove task running.

--- a/docs/superpowers/specs/2026-08-11-dhw-timer-program-entity-visibility-design.md
+++ b/docs/superpowers/specs/2026-08-11-dhw-timer-program-entity-visibility-design.md
@@ -36,40 +36,76 @@ inherit it when they are added.
   `LuxtronikCoordinatorData`, so it is directly unit-testable.
 - **At setup:** add only the desired entities. For every non-desired key that
   *already has* a registry entry (existing installs, or a mode that was active
-  earlier), set `hidden_by = RegistryEntryHider.INTEGRATION`. On a fresh install
-  the inactive modes were never registered, so nothing exists to hide and the
-  device page shows only the active program's blocks. Registry entries are
-  looked up with `er.async_get_entity_id(TEXT_DOMAIN, DOMAIN, unique_id)`.
+  earlier), set `disabled_by = RegistryEntryDisabler.INTEGRATION`. On a fresh
+  install the inactive modes were never registered, so nothing exists to disable
+  and the device page shows only the active program's blocks. Registry entries
+  are looked up with `er.async_get_entity_id(TEXT_DOMAIN, DOMAIN, unique_id)`.
 - **On change:** the helper is registered as a coordinator listener via
   `entry.async_on_unload(coordinator.async_add_listener(...))`. Each poll it
   recomputes the desired set; when it differs from the live set it
-  1. clears `hidden_by` on the newly active keys (only when it is
-     `INTEGRATION` — a user's own hide is never overridden) and adds their
+  1. clears `disabled_by` on the newly active keys (only when it is
+     `INTEGRATION` — a user's own disable is never overridden) and adds their
      entities through the retained `async_add_entities` callback, and
   2. removes the stale entities from the state machine with
      `entity.async_remove()` (**not** `force_remove=True`: the registry entry
-     must survive) and sets `hidden_by = INTEGRATION` on them.
+     must survive) and sets `disabled_by = INTEGRATION` on them.
 
   Coordinator listener callbacks are synchronous, so the add/remove work is
   scheduled with `entry.async_create_task`.
 
-### Why hide instead of removing the registry entry
+  A one-time migration runs alongside this: any schedule entity still carrying
+  `hidden_by = RegistryEntryHider.INTEGRATION` from the earlier hide-based build
+  (see below) gets it cleared, for both active and inactive keys, on the first
+  sync pass that touches it.
 
-Removing a registry entry discards everything the user attached to it: a
+### Why disable instead of hide, and why not remove the registry entry
+
+The first implementation of this design hid inactive entries
+(`hidden_by = RegistryEntryHider.INTEGRATION`) instead of disabling them. Live
+verification on a real HA instance (2026.7.2) showed that this does not achieve
+the goal: on the **device page**, HA renders hidden entities inline, labelled
+"(Hidden)" and showing `unavailable`:
+
+```
+Tijdschema (dinsdag) (Verborgen)     unavailable
+Tijdschema (week)    (Verborgen)     unavailable
+Tijdschema (weekend)                 00:00-11:00/12:00-14:00/17:00-00:00
+```
+
+*Disabled* entities, by contrast, are collapsed behind a `+N disabled entities`
+button. Hiding only cleans dashboards, entity pickers and auto-generated
+views — not the device page, which is where the clutter was reported. So the
+mechanism is `disabled_by = RegistryEntryDisabler.INTEGRATION`, not `hidden_by`.
+
+Purging the registry entry outright (instead of hiding or disabling it) was
+considered and rejected: it discards everything the user attached to it — a
 renamed entity_id, friendly name, icon, area, labels. Today the entity_id is
 integration-assigned (`unique_id == entity_id == "text.<prefix>_<key>"`), so the
 loss is mostly invisible — but that convention is expected to change toward
-HA best practice, where entity_ids are user-owned. Once it does, a program
-switch silently reverting user renames would be a genuine bug. Hiding keeps the
-registry entry, its customizations, and the recorder history intact; only
-`hidden_by` flips. Cost: the device page shows "+N hidden entities" behind a
-click, and inactive entities remain in the registry.
+HA best practice, where entity_ids are user-owned, and that loss gets worse
+once `unique_id` is decoupled from `entity_id`. A program switch silently
+reverting user renames would be a genuine bug. Disabling keeps the registry
+entry, its customizations, and the recorder history intact; only `disabled_by`
+flips.
 
-Accepted edge case: if a user manually unhides an inactive-mode entity, it stays
-unhidden (with no state) until the next actual program change, which re-hides
-it. The sync only runs its unhide/add/remove/hide pass when the desired entity
-set differs from the live one, so an unchanged poll deliberately writes nothing
-to the registry — no per-poll re-hide loop.
+Cost, accepted because switching timer program is a rare action: clearing
+`disabled_by` makes HA's `EntityRegistryDisabledHandler` schedule a config-entry
+reload 30 seconds later (`config_entries.RELOAD_AFTER_UPDATE_DELAY`) — enabling
+a registry entry is, in HA's model, indistinguishable from a user re-enabling it
+by hand, and both are followed by a reload. There is no way to clear
+`disabled_by` on an entity without triggering this, short of not using
+`disabled_by` at all (which the device-page evidence above rules out). No
+suppression hack is used to work around it.
+
+Accepted edge case: if a user manually re-enables an inactive-mode entity via
+the registry, HA schedules its own 30s reload for that (same mechanism as
+above); on the reload, `_disable_inactive` runs again, finds `disabled_by` is
+`None` for a still-inactive key, and sets it back to `INTEGRATION` — so the
+manual re-enable does not stick past the reload it itself triggers. Outside of
+a reload, the sync only runs its enable/add/remove/disable pass when the
+desired entity set differs from the live one, so an unchanged poll
+deliberately writes nothing to the registry — no per-poll re-disable loop, and
+no per-poll reload either.
 
 Reading the selector is treated as three-valued: "program X", "this controller
 has no such selector" (no blocks — nothing to create), and "unreadable this
@@ -132,14 +168,22 @@ entities swap immediately after the user changes the program in HA.
 - desired-set computation returns the right descriptions for each of `week`,
   `5+2`, `days`, and an empty set when the selector parameter is absent
 - setup adds only the active mode's entities
-- setup hides pre-existing registry entries of the non-active keys, and does
+- setup disables pre-existing registry entries of the non-active keys, and does
   nothing for non-active keys that have no registry entry
-- a mode change on a later coordinator update adds + unhides the new mode's
-  entities and removes + hides the previous ones, with the registry entries of
-  the previous mode still present afterwards
-- a user-set `hidden_by = USER` is not cleared when that mode becomes active
+- a mode change on a later coordinator update adds + enables the new mode's
+  entities and removes + disables the previous ones, with the registry entries
+  of the previous mode still present afterwards
+- a user-set `disabled_by = USER` is not cleared when that mode becomes active
 - no churn (no add, remove, or registry write) when the mode is unchanged
   between polls
+- a `hidden_by = RegistryEntryHider.INTEGRATION` left over from the earlier
+  hide-based build is cleared on the next sync pass, for both an active and an
+  inactive key (the inactive one is then disabled as usual)
+- against a real `hass`/entity registry: entity_id survives a program
+  round-trip, the registry entry survives removal, a user rename survives, and
+  `disabled_by` flips `INTEGRATION` ↔ `None` across the switch — including
+  letting the resulting config-entry reload actually run in-test (the delay is
+  collapsed to 0 via monkeypatch rather than skipped or waited out for real)
 
 `tests/test_select.py` and the predefined-entity/translation-coverage tests
 cover the new selector: description shape, display→raw option mapping, write of

--- a/docs/superpowers/specs/2026-08-11-dhw-timer-program-entity-visibility-design.md
+++ b/docs/superpowers/specs/2026-08-11-dhw-timer-program-entity-visibility-design.md
@@ -1,0 +1,141 @@
+# DHW timer-program entities: only create the selected program
+
+Date: 2026-08-11
+Status: approved design, not yet implemented
+
+## Problem
+
+The DHW timer-program feature creates all 10 schedule text entities
+(`timer_dhw_schedule_week`, `_weekday`, `_weekend`, and one per weekday) for
+every install, regardless of which timer program the heat pump actually runs.
+`LuxtronikTimerScheduleText.available` returns `False` for the blocks whose
+`active_mode` does not match the current value of the mode selector
+(`ID_Einst_SUBW_akt2`, parameter 405), so 7 or 9 of the 10 entities are
+permanently unavailable. They clutter the device page and dashboards.
+
+## Goal
+
+Only the schedule entities belonging to the currently selected timer program
+exist. When the program changes, the entity set follows — without a config
+entry reload or a restart. Additionally, expose the program selector itself as
+a HA `select` entity so the program can be switched from Home Assistant.
+
+Scope is DHW only. The mechanism is written against the existing
+`_TimerCircuit` abstraction so the remaining five circuits (Hkr/Mk1/Mk2/ZIP/Swb)
+inherit it when they are added.
+
+## Design
+
+### 1. Active-mode-only entity set (`text.py`)
+
+`async_setup_entry` builds a small sync helper that owns the lifecycle:
+
+- **Desired set:** the descriptions in `TIMER_SCHEDULE_ENTITIES` whose
+  `mode_selector_name` parameter exists in `coordinator.data` *and* whose
+  `active_mode` equals the current selector value. This is a pure function of
+  `LuxtronikCoordinatorData`, so it is directly unit-testable.
+- **At setup:** add only the desired entities. For every non-desired key that
+  *already has* a registry entry (existing installs, or a mode that was active
+  earlier), set `hidden_by = RegistryEntryHider.INTEGRATION`. On a fresh install
+  the inactive modes were never registered, so nothing exists to hide and the
+  device page shows only the active program's blocks. Registry entries are
+  looked up with `er.async_get_entity_id(TEXT_DOMAIN, DOMAIN, unique_id)`.
+- **On change:** the helper is registered as a coordinator listener via
+  `entry.async_on_unload(coordinator.async_add_listener(...))`. Each poll it
+  recomputes the desired set; when it differs from the live set it
+  1. clears `hidden_by` on the newly active keys (only when it is
+     `INTEGRATION` — a user's own hide is never overridden) and adds their
+     entities through the retained `async_add_entities` callback, and
+  2. removes the stale entities from the state machine with
+     `entity.async_remove()` (**not** `force_remove=True`: the registry entry
+     must survive) and sets `hidden_by = INTEGRATION` on them.
+
+  Coordinator listener callbacks are synchronous, so the add/remove work is
+  scheduled with `entry.async_create_task`.
+
+### Why hide instead of removing the registry entry
+
+Removing a registry entry discards everything the user attached to it: a
+renamed entity_id, friendly name, icon, area, labels. Today the entity_id is
+integration-assigned (`unique_id == entity_id == "text.<prefix>_<key>"`), so the
+loss is mostly invisible — but that convention is expected to change toward
+HA best practice, where entity_ids are user-owned. Once it does, a program
+switch silently reverting user renames would be a genuine bug. Hiding keeps the
+registry entry, its customizations, and the recorder history intact; only
+`hidden_by` flips. Cost: the device page shows "+N hidden entities" behind a
+click, and inactive entities remain in the registry.
+
+Accepted edge case: if a user manually unhides an inactive-mode entity, the next
+sync re-hides it. That matches the feature's intent (only the running program's
+blocks are meaningful) and keeps the logic simple.
+
+### Coupling to the entity_id convention
+
+Both `LuxtronikTimerScheduleText.__init__` and the sync helper need the
+unique_id. The format is written down **once**, in a shared
+`_timer_schedule_unique_id(entry, description)` helper used by both, so that
+decoupling unique_id from entity_id later is a single-site change plus a
+registry migration — not a hunt for duplicated string formatting.
+- **`available` stays.** After this change it is no longer the primary
+  mechanism, but it remains a cheap safety net covering the window between a
+  coordinator update carrying a new mode and the scheduled add/remove task
+  running.
+
+Because the registry entry survives, switching a program away and back restores
+the same entity_id (including a user-chosen one) with its customizations and
+history; dashboard cards and automations referencing it keep working. While a
+program is inactive its entity has no state — dashboard cards referencing it
+show as unavailable, which is the same behaviour as today.
+
+### 2. Timer-program select entity
+
+Parameter 405 already carries the `TimerProgram` datatype defined in
+`lux_overrides.py` (codes `0: "week"`, `1: "5+2"`, `2: "days"`), so no library
+work is needed. Additions:
+
+- `const.py`: `LuxParameter.P0405_TIMER_PROGRAM_DHW = "parameters.ID_Einst_SUBW_akt2"`
+  and `SensorKey.TIMER_DHW_PROGRAM = "timer_dhw_program"`.
+- `select_entities_predefined.py`: a `LuxtronikSelectEntityDescription` on
+  `DeviceKey.domestic_water`, `entity_category=EntityCategory.CONFIG`.
+- Options are HA-side names `week` / `weekday_weekend` / `daily`, mapped to the
+  raw device values `week` / `5+2` / `days`. The raw value `"5+2"` is an awkward
+  HA option and translation key; `LuxtronikModeSelector` already supports a
+  display→raw mapping through `_option_to_raw`, which is extended to carry this
+  explicit mapping instead of relying on `_normalize_select_option`.
+- Presence gating is the existing `key_exists(coordinator.data, luxtronik_key)`
+  check in `select.py` — register existence, not a firmware version gate.
+- Translations for the entity name and the three option states in
+  `en/de/nl/cs/pl.json`.
+
+Writing the selector goes through `coordinator.async_write`, which refreshes the
+coordinator; the refresh fires the text-platform listener, so the schedule
+entities swap immediately after the user changes the program in HA.
+
+### 3. Tests
+
+`tests/test_text.py`:
+
+- desired-set computation returns the right descriptions for each of `week`,
+  `5+2`, `days`, and an empty set when the selector parameter is absent
+- setup adds only the active mode's entities
+- setup hides pre-existing registry entries of the non-active keys, and does
+  nothing for non-active keys that have no registry entry
+- a mode change on a later coordinator update adds + unhides the new mode's
+  entities and removes + hides the previous ones, with the registry entries of
+  the previous mode still present afterwards
+- a user-set `hidden_by = USER` is not cleared when that mode becomes active
+- no churn (no add, remove, or registry write) when the mode is unchanged
+  between polls
+
+`tests/test_select.py` and the predefined-entity/translation-coverage tests
+cover the new selector: description shape, display→raw option mapping, write of
+`5+2` for the `weekday_weekend` option, and presence of the name/state strings
+in all five language files.
+
+## Out of scope
+
+- The other five timer circuits.
+- Decoupling `unique_id` from `entity_id` (HA best practice) and the registry
+  migration that would need — this design only makes sure it stays a
+  single-site change.
+- Any change to schedule parsing/writing in `LuxtronikTimerScheduleText`.

--- a/docs/superpowers/specs/2026-08-11-dhw-timer-program-entity-visibility-design.md
+++ b/docs/superpowers/specs/2026-08-11-dhw-timer-program-entity-visibility-design.md
@@ -65,9 +65,22 @@ registry entry, its customizations, and the recorder history intact; only
 `hidden_by` flips. Cost: the device page shows "+N hidden entities" behind a
 click, and inactive entities remain in the registry.
 
-Accepted edge case: if a user manually unhides an inactive-mode entity, the next
-sync re-hides it. That matches the feature's intent (only the running program's
-blocks are meaningful) and keeps the logic simple.
+Accepted edge case: if a user manually unhides an inactive-mode entity, it stays
+unhidden (with no state) until the next actual program change, which re-hides
+it. The sync only runs its unhide/add/remove/hide pass when the desired entity
+set differs from the live one, so an unchanged poll deliberately writes nothing
+to the registry — no per-poll re-hide loop.
+
+Reading the selector is treated as three-valued: "program X", "this controller
+has no such selector" (no blocks — nothing to create), and "unreadable this
+poll". The last one is not the same as "no program active":
+`get_sensor_data` returns `None` both for an absent register and for a present
+register whose datatype could not decode the raw value (`SelectionBase` returns
+`None` for an unrecognised code), and `key_exists` cannot separate them for
+parameter 405, which lies inside upstream's defined index range. So an
+unreadable selector makes the sync a complete no-op for that poll — otherwise a
+single glitched read would remove all live schedule entities and hide all ten
+registry entries, to be undone again by the next good poll.
 
 ### Coupling to the entity_id convention
 

--- a/docs/superpowers/specs/2026-08-11-dhw-timer-program-entity-visibility-design.md
+++ b/docs/superpowers/specs/2026-08-11-dhw-timer-program-entity-visibility-design.md
@@ -89,10 +89,11 @@ unique_id. The format is written down **once**, in a shared
 `_timer_schedule_unique_id(entry, description)` helper used by both, so that
 decoupling unique_id from entity_id later is a single-site change plus a
 registry migration — not a hunt for duplicated string formatting.
-- **`available` stays.** After this change it is no longer the primary
-  mechanism, but it remains a cheap safety net covering the window between a
-  coordinator update carrying a new mode and the scheduled add/remove task
-  running.
+
+`LuxtronikTimerScheduleText.available` keeps its mode check. After this change
+it is no longer the primary mechanism, but it remains a cheap safety net
+covering the window between a coordinator update carrying a new mode and the
+scheduled add/remove task running.
 
 Because the registry entry survives, switching a program away and back restores
 the same entity_id (including a user-chosen one) with its customizations and

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -17,6 +17,7 @@ from custom_components.luxtronik2.const import (
     DOMAIN,
     DeviceKey,
     LuxDaySelectorParameter,
+    LuxParameter,
     LuxPoolPVMode,
     SensorKey,
 )
@@ -204,3 +205,61 @@ class TestBuildSelectDescriptions:
         for d in descriptions:
             if d.key != SensorKey.PV_MODE_SELECTOR:
                 assert d.options is not None
+
+
+# ===========================================================================
+# raw_option_map (timer program selector)
+# ===========================================================================
+
+
+class TestRawOptionMap:
+    def _make_selector(self, raw_value: str):
+        from custom_components.luxtronik2.select import LuxtronikModeSelector
+
+        desc = LuxtronikSelectEntityDescription(
+            key=SensorKey.TIMER_DHW_PROGRAM,
+            device_key=DeviceKey.domestic_water,
+            luxtronik_key=LuxParameter.P0405_TIMER_PROGRAM_DHW,
+            options=["week", "weekday_weekend", "daily"],
+            raw_option_map={"week": "week", "weekday_weekend": "5+2", "daily": "days"},
+        )
+        data = make_coordinator_data(parameters={"ID_Einst_SUBW_akt2": raw_value})
+        coord = _mock_coordinator(data)
+        entity = LuxtronikModeSelector(
+            _mock_entry(), coord, desc, DeviceKey.domestic_water
+        )
+        _patch_entity(entity)
+        return entity, coord
+
+    def test_options_are_the_ha_names(self):
+        entity, _coord = self._make_selector("week")
+        assert entity._attr_options == ["week", "weekday_weekend", "daily"]
+
+    def test_raw_value_maps_to_ha_option(self):
+        entity, _coord = self._make_selector("5+2")
+        entity._handle_coordinator_update()
+        assert entity._attr_current_option == "weekday_weekend"
+
+    @pytest.mark.asyncio
+    async def test_selecting_option_writes_raw_value(self):
+        entity, coord = self._make_selector("week")
+        await entity.async_select_option("weekday_weekend")
+        coord.async_write.assert_awaited_once_with("ID_Einst_SUBW_akt2", "5+2")
+
+    def test_existing_selectors_keep_working_without_a_map(self):
+        from custom_components.luxtronik2.select import LuxtronikModeSelector
+
+        desc = LuxtronikSelectEntityDescription(
+            key=SensorKey.DOMESTIC_WATER_MODE_SELECTOR,
+            device_key=DeviceKey.domestic_water,
+            luxtronik_key=LuxParameter.P0004_MODE_DHW,
+            options=["Automatic", "Off"],
+        )
+        data = make_coordinator_data(parameters={"ID_Ba_Bw_akt": "Automatic"})
+        entity = LuxtronikModeSelector(
+            _mock_entry(), _mock_coordinator(data), desc, DeviceKey.domestic_water
+        )
+        _patch_entity(entity)
+        entity._handle_coordinator_update()
+        assert entity._attr_options == ["automatic", "off"]
+        assert entity._attr_current_option == "automatic"

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -346,3 +346,173 @@ class TestActiveScheduleDescriptions:
 
     def test_inactive_entity_yields_nothing(self):
         assert self._call({self._SELECTOR: "week"}, entity_active=False) == []
+
+
+# ===========================================================================
+# _TimerScheduleSync
+# ===========================================================================
+
+
+class TestTimerScheduleSync:
+    _SELECTOR = "ID_Einst_SUBW_akt2"
+
+    def _make_sync(self, mode: str):
+        from custom_components.luxtronik2.text import _TimerScheduleSync
+
+        data = make_coordinator_data(parameters={self._SELECTOR: mode})
+        coord = _mock_coordinator(data)
+        entry = _mock_entry()
+        added: list = []
+
+        def _add_entities(entities):
+            added.extend(entities)
+
+        sync = _TimerScheduleSync(MagicMock(), entry, coord, _add_entities)
+        return sync, coord, added
+
+    def _registry(self, known: dict[str, MagicMock]):
+        """Fake entity registry: unique_id -> registry entry."""
+        registry = MagicMock()
+        registry.async_get_entity_id.side_effect = (
+            lambda _domain, _platform, unique_id: (
+                unique_id if unique_id in known else None
+            )
+        )
+        registry.async_get.side_effect = lambda entity_id: known.get(entity_id)
+        return registry
+
+    def _entry(self, hidden_by=None):
+        registry_entry = MagicMock()
+        registry_entry.hidden_by = hidden_by
+        return registry_entry
+
+    @pytest.mark.asyncio
+    async def test_setup_adds_only_the_active_blocks(self):
+        sync, _coord, added = self._make_sync("week")
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get",
+                return_value=self._registry({}),
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_setup()
+        assert [e.entity_description.key for e in added] == [SK.TIMER_DHW_SCHEDULE_WEEK]
+
+    @pytest.mark.asyncio
+    async def test_setup_hides_existing_entries_of_inactive_blocks(self):
+        from homeassistant.helpers.entity_registry import RegistryEntryHider
+
+        from custom_components.luxtronik2.text import _timer_schedule_unique_id
+
+        sync, _coord, _added = self._make_sync("week")
+        entry = _mock_entry()
+        stale = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_MONDAY
+        )
+        stale_id = _timer_schedule_unique_id(entry, stale)
+        registry = self._registry({stale_id: self._entry()})
+
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_setup()
+
+        registry.async_update_entity.assert_any_call(
+            stale_id, hidden_by=RegistryEntryHider.INTEGRATION
+        )
+
+    @pytest.mark.asyncio
+    async def test_setup_does_not_touch_a_user_hidden_entry(self):
+        from homeassistant.helpers.entity_registry import RegistryEntryHider
+
+        from custom_components.luxtronik2.text import _timer_schedule_unique_id
+
+        sync, _coord, _added = self._make_sync("week")
+        entry = _mock_entry()
+        week = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_WEEK
+        )
+        week_id = _timer_schedule_unique_id(entry, week)
+        registry = self._registry({week_id: self._entry(RegistryEntryHider.USER)})
+
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_setup()
+
+        registry.async_update_entity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_setup_unhides_an_integration_hidden_active_entry(self):
+        from homeassistant.helpers.entity_registry import RegistryEntryHider
+
+        from custom_components.luxtronik2.text import _timer_schedule_unique_id
+
+        sync, _coord, _added = self._make_sync("week")
+        entry = _mock_entry()
+        week = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_WEEK
+        )
+        week_id = _timer_schedule_unique_id(entry, week)
+        registry = self._registry(
+            {week_id: self._entry(RegistryEntryHider.INTEGRATION)}
+        )
+
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_setup()
+
+        registry.async_update_entity.assert_any_call(week_id, hidden_by=None)
+
+    @pytest.mark.asyncio
+    async def test_mode_change_swaps_the_entities(self):
+        from custom_components.luxtronik2.text import LuxtronikTimerScheduleText
+
+        sync, coord, added = self._make_sync("week")
+        registry = self._registry({})
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_setup()
+            coord.data = make_coordinator_data(parameters={self._SELECTOR: "5+2"})
+            with patch.object(
+                LuxtronikTimerScheduleText, "async_remove", new=AsyncMock()
+            ) as remove:
+                await sync.async_apply()
+
+        assert remove.await_count == 1
+        assert [e.entity_description.key for e in added[1:]] == [
+            SK.TIMER_DHW_SCHEDULE_WEEKDAY,
+            SK.TIMER_DHW_SCHEDULE_WEEKEND,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_unchanged_mode_does_not_touch_anything(self):
+        sync, _coord, added = self._make_sync("week")
+        registry = self._registry({})
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_setup()
+            registry.async_update_entity.reset_mock()
+            await sync.async_apply()
+
+        assert len(added) == 1
+        registry.async_update_entity.assert_not_called()

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
@@ -499,6 +500,63 @@ class TestTimerScheduleSync:
             SK.TIMER_DHW_SCHEDULE_WEEKDAY,
             SK.TIMER_DHW_SCHEDULE_WEEKEND,
         ]
+
+    @pytest.mark.asyncio
+    async def test_overlapping_apply_calls_are_serialized(self):
+        """Two overlapping `async_apply()` calls must not interleave.
+
+        Regression test: without a lock, a second coordinator update landing
+        while a first `async_apply()` is suspended mid-removal would compute
+        `desired` and mutate `self._entities` concurrently with the first
+        call, risking a duplicate registration for the same key.
+        """
+        from custom_components.luxtronik2.text import LuxtronikTimerScheduleText
+
+        sync, coord, _added = self._make_sync("week")
+        registry = self._registry({})
+
+        remove_started = asyncio.Event()
+        release_remove = asyncio.Event()
+
+        async def _slow_remove(self_entity):
+            remove_started.set()
+            await release_remove.wait()
+
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_setup()
+            coord.data = make_coordinator_data(parameters={self._SELECTOR: "5+2"})
+
+            with patch.object(
+                LuxtronikTimerScheduleText, "async_remove", new=_slow_remove
+            ):
+                first = asyncio.create_task(sync.async_apply())
+                await remove_started.wait()
+
+                # A second coordinator update lands (mode flips back to
+                # "week") while the first apply is still suspended awaiting
+                # the removal it started.
+                coord.data = make_coordinator_data(parameters={self._SELECTOR: "week"})
+                second = asyncio.create_task(sync.async_apply())
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+
+                # The lock must keep the second call from starting its own
+                # add/remove pass until the first call has fully finished.
+                assert not second.done()
+                assert sync._lock.locked()
+
+                release_remove.set()
+                await first
+                await second
+
+        # The entity set ends up matching the final ("week") mode, with no
+        # duplicate registration for the week key.
+        assert list(sync._entities) == [SK.TIMER_DHW_SCHEDULE_WEEK]
 
     @pytest.mark.asyncio
     async def test_unchanged_mode_does_not_touch_anything(self):

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -285,3 +285,21 @@ class TestLuxtronikTimerScheduleText:
             await entity.async_set_value("not-a-schedule")
         coord.async_write.assert_not_called()
         coord.async_write_many.assert_not_called()
+
+
+# ===========================================================================
+# _timer_schedule_unique_id
+# ===========================================================================
+
+
+class TestTimerScheduleUniqueId:
+    def test_matches_the_entity_id_the_entity_assigns_itself(self):
+        from custom_components.luxtronik2.text import _timer_schedule_unique_id
+
+        description = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_WEEK
+        )
+        assert (
+            _timer_schedule_unique_id(_mock_entry(), description)
+            == f"text.{DOMAIN}_{description.key}"
+        )

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -3,17 +3,23 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_registry import RegistryEntryHider
 from luxtronik.parameters import Parameters
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from conftest import make_coordinator_data
+from conftest import DEFAULT_PARAMETERS, make_coordinator_data
 from custom_components.luxtronik2.const import (
     CONF_HA_SENSOR_PREFIX,
     CONF_MAX_DATA_LENGTH,
+    CONFIG_ENTRY_VERSION,
     DEFAULT_MAX_DATA_LENGTH,
     DEFAULT_PORT,
     DEFAULT_TIMEOUT,
@@ -338,12 +344,29 @@ class TestActiveScheduleDescriptions:
         assert SK.TIMER_DHW_SCHEDULE_SUNDAY in keys
 
     def test_missing_selector_parameter_yields_nothing(self):
+        """A selector that this controller does not have is a real answer: no blocks."""
         assert self._call({}) == []
 
-    def test_data_none_yields_nothing(self):
+    def test_data_none_yields_no_information(self):
+        """No coordinator data at all is "unknown", not "no program active"."""
         from custom_components.luxtronik2.text import _active_schedule_descriptions
 
-        assert _active_schedule_descriptions(_mock_coordinator(), None) == []
+        assert _active_schedule_descriptions(_mock_coordinator(), None) is None
+
+    def test_undecodable_selector_yields_no_information(self):
+        """A present-but-unreadable selector must not read as "no program active".
+
+        `get_sensor_data` returns None both for an absent register and for a
+        register whose datatype could not decode the raw value this poll
+        (`SelectionBase` returns None for an unrecognised code). Treating the
+        latter as "nothing is active" would drop all 10 entities and hide all
+        10 registry entries on a single glitched read.
+        """
+        from custom_components.luxtronik2.text import _active_schedule_descriptions
+
+        data = make_coordinator_data(parameters={self._SELECTOR: None})
+        coord = _mock_coordinator(data)
+        assert _active_schedule_descriptions(coord, data) is None
 
     def test_inactive_entity_yields_nothing(self):
         assert self._call({self._SELECTOR: "week"}, entity_active=False) == []
@@ -364,11 +387,18 @@ class TestTimerScheduleSync:
         coord = _mock_coordinator(data)
         entry = _mock_entry()
         added: list = []
+        hass = MagicMock()
 
         def _add_entities(entities):
+            for entity in entities:
+                # Stand in for what the platform's `add_to_platform_start`
+                # does once it actually runs the scheduled add. The sync
+                # keys its removal guard off this, because an add that was
+                # aborted (or has not run yet) leaves `hass` unset.
+                entity.hass = hass
             added.extend(entities)
 
-        sync = _TimerScheduleSync(MagicMock(), entry, coord, _add_entities)
+        sync = _TimerScheduleSync(hass, entry, coord, _add_entities)
         return sync, coord, added
 
     def _registry(self, known: dict[str, MagicMock]):
@@ -559,6 +589,148 @@ class TestTimerScheduleSync:
         assert list(sync._entities) == [SK.TIMER_DHW_SCHEDULE_WEEK]
 
     @pytest.mark.asyncio
+    async def test_unreadable_selector_does_not_remove_or_hide_anything(self):
+        """A glitched selector read must be a no-op, not a full teardown.
+
+        Regression test: treating an undecodable selector value as "no
+        program active" removed every live schedule entity and wrote
+        `hidden_by = INTEGRATION` on all 10 registry entries, with the next
+        good poll re-adding and unhiding them - entity churn, registry writes
+        and a recorder gap caused by one transient read.
+        """
+        from custom_components.luxtronik2.text import LuxtronikTimerScheduleText
+
+        sync, coord, _added = self._make_sync("week")
+        registry = self._registry({})
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_setup()
+            registry.async_update_entity.reset_mock()
+            coord.data = make_coordinator_data(parameters={self._SELECTOR: None})
+            with patch.object(
+                LuxtronikTimerScheduleText, "async_remove", new=AsyncMock()
+            ) as remove:
+                await sync.async_apply()
+
+        remove.assert_not_awaited()
+        registry.async_update_entity.assert_not_called()
+        assert list(sync._entities) == [SK.TIMER_DHW_SCHEDULE_WEEK]
+
+    @pytest.mark.asyncio
+    async def test_removal_of_an_entity_that_never_reached_the_platform(self):
+        """An entity whose add was aborted must be dropped without crashing.
+
+        `async_add_entities` only schedules the add. If the registry entry is
+        disabled, `EntityPlatform._async_add_entity` calls
+        `add_to_platform_abort()`, which sets `entity.hass = None`; a later
+        `entity.async_remove()` would then blow up on
+        `self.hass.loop.create_future()` inside the sync task, skipping the
+        rest of the removal loop and the hide pass.
+        """
+        from homeassistant.helpers.entity_registry import RegistryEntryHider
+
+        from custom_components.luxtronik2.text import _timer_schedule_unique_id
+
+        sync, coord, _added = self._make_sync("week")
+        entry = _mock_entry()
+        week = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_WEEK
+        )
+        week_id = _timer_schedule_unique_id(entry, week)
+        registry = self._registry({week_id: self._entry()})
+
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_setup()
+            # The platform aborted the add (disabled registry entry).
+            sync._entities[SK.TIMER_DHW_SCHEDULE_WEEK].hass = None  # type: ignore[assignment]
+            registry.async_update_entity.reset_mock()
+            coord.data = make_coordinator_data(parameters={self._SELECTOR: "5+2"})
+            await sync.async_apply()
+
+        assert SK.TIMER_DHW_SCHEDULE_WEEK not in sync._entities
+        # The rest of the pass still ran: the now-inactive week block is hidden.
+        registry.async_update_entity.assert_any_call(
+            week_id, hidden_by=RegistryEntryHider.INTEGRATION
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_failing_removal_does_not_abort_the_pass(self):
+        """One entity failing to remove must not skip the others or the hide pass."""
+        from custom_components.luxtronik2.text import LuxtronikTimerScheduleText
+
+        sync, coord, _added = self._make_sync("days")
+        registry = self._registry({})
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_setup()
+            assert len(sync._entities) == 7
+            coord.data = make_coordinator_data(parameters={self._SELECTOR: "week"})
+            calls: list = []
+
+            async def _boom(self_entity):
+                calls.append(self_entity)
+                raise RuntimeError("removal exploded")
+
+            with patch.object(LuxtronikTimerScheduleText, "async_remove", new=_boom):
+                await sync.async_apply()
+
+        assert len(calls) == 7
+        assert list(sync._entities) == [SK.TIMER_DHW_SCHEDULE_WEEK]
+
+    @pytest.mark.asyncio
+    async def test_apply_after_close_is_a_no_op(self):
+        """A task queued before unload must not add entities to a reset platform."""
+        sync, _coord, added = self._make_sync("week")
+        registry = self._registry({})
+        sync.async_close()
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_apply()
+
+        assert added == []
+        registry.async_update_entity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_close_while_waiting_for_the_lock_stops_the_queued_pass(self):
+        """The unload can land while a pass is already queued behind the lock."""
+        sync, _coord, added = self._make_sync("week")
+        registry = self._registry({})
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync._lock.acquire()
+            queued = asyncio.create_task(sync.async_apply())
+            await asyncio.sleep(0)
+            assert not queued.done()
+
+            sync.async_close()
+            sync._lock.release()
+            await queued
+
+        assert added == []
+        registry.async_update_entity.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_unchanged_mode_does_not_touch_anything(self):
         sync, _coord, added = self._make_sync("week")
         registry = self._registry({})
@@ -574,3 +746,156 @@ class TestTimerScheduleSync:
 
         assert len(added) == 1
         registry.async_update_entity.assert_not_called()
+
+
+# ===========================================================================
+# Real-hass integration tests
+# ===========================================================================
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+class TestTimerScheduleSyncAgainstRealHass:
+    """The swap mechanism against a real `hass` and a real entity registry.
+
+    The unit tests above drive `_TimerScheduleSync` with a MagicMock registry
+    and a stubbed `async_remove`, so they cannot pin the HA contracts this
+    design actually rests on: that `async_remove()` without `force_remove`
+    keeps the registry entry (and leaves a `restored` state behind), that
+    re-adding the same unique_id after a swap-back succeeds instead of
+    tripping "Entity id already exists", and that an entity whose add was
+    aborted (disabled registry entry) does not break the next pass.
+    """
+
+    _SELECTOR = "ID_Einst_SUBW_akt2"
+    _WEEK_ID = f"text.{DOMAIN}_{SK.TIMER_DHW_SCHEDULE_WEEK}"
+    _WEEKDAY_ID = f"text.{DOMAIN}_{SK.TIMER_DHW_SCHEDULE_WEEKDAY}"
+    _WEEKEND_ID = f"text.{DOMAIN}_{SK.TIMER_DHW_SCHEDULE_WEEKEND}"
+
+    def _client(self, mode: str):
+        from test_setup_integration import FakeLuxtronikClient
+
+        parameters: dict[str, Any] = DEFAULT_PARAMETERS.copy()
+        parameters[self._SELECTOR] = mode
+        return FakeLuxtronikClient(
+            host="192.168.1.100",
+            port=DEFAULT_PORT,
+            socket_timeout=10,
+            max_data_length=1024,
+            parameters=parameters,
+        )
+
+    async def _setup(self, hass: HomeAssistant, monkeypatch, client) -> MockConfigEntry:
+        monkeypatch.setattr(
+            "custom_components.luxtronik2.coordinator.Luxtronik",
+            lambda **kwargs: client,
+        )
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            version=CONFIG_ENTRY_VERSION,
+            data={
+                CONF_HOST: "192.168.1.100",
+                CONF_PORT: DEFAULT_PORT,
+                CONF_HA_SENSOR_PREFIX: DOMAIN,
+            },
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        return entry
+
+    async def _switch_to(self, hass: HomeAssistant, entry, client, mode: str) -> None:
+        client.parameters.set(self._SELECTOR, mode)
+        await entry.runtime_data.async_refresh()
+        await hass.async_block_till_done()
+
+    async def test_program_round_trip_keeps_the_registry_entry(
+        self, hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = self._client("week")
+        entry = await self._setup(hass, monkeypatch, client)
+        registry = er.async_get(hass)
+
+        # Active program: entity live, registry entry visible.
+        assert hass.states.get(self._WEEK_ID) is not None
+        assert hass.states.get(self._WEEKDAY_ID) is None
+        week_entry = registry.async_get(self._WEEK_ID)
+        assert week_entry is not None
+        assert week_entry.hidden_by is None
+
+        await self._switch_to(hass, entry, client, "5+2")
+
+        # The week block is gone from the state machine (async_remove without
+        # force_remove leaves a `restored` placeholder because the registry
+        # entry survives), and its registry entry is hidden, not removed.
+        week_state = hass.states.get(self._WEEK_ID)
+        assert week_state is None or week_state.attributes.get("restored") is True
+        week_entry = registry.async_get(self._WEEK_ID)
+        assert week_entry is not None
+        assert week_entry.hidden_by is RegistryEntryHider.INTEGRATION
+        assert hass.states.get(self._WEEKDAY_ID) is not None
+        assert hass.states.get(self._WEEKEND_ID) is not None
+
+        await self._switch_to(hass, entry, client, "week")
+
+        # Swapping back re-adds under the same entity_id and unhides it.
+        week_state = hass.states.get(self._WEEK_ID)
+        assert week_state is not None
+        assert week_state.attributes.get("restored") is not True
+        week_entry = registry.async_get(self._WEEK_ID)
+        assert week_entry is not None
+        assert week_entry.hidden_by is None
+
+    async def test_a_user_rename_survives_the_round_trip(
+        self, hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The whole point of hiding instead of removing the registry entry."""
+        client = self._client("week")
+        entry = await self._setup(hass, monkeypatch, client)
+        registry = er.async_get(hass)
+        renamed_id = "text.my_dhw_week_schedule"
+        registry.async_update_entity(
+            self._WEEK_ID, new_entity_id=renamed_id, name="My week schedule"
+        )
+        await hass.async_block_till_done()
+
+        await self._switch_to(hass, entry, client, "5+2")
+        await self._switch_to(hass, entry, client, "week")
+
+        renamed_entry = registry.async_get(renamed_id)
+        assert renamed_entry is not None
+        assert renamed_entry.name == "My week schedule"
+        assert renamed_entry.hidden_by is None
+        assert hass.states.get(renamed_id) is not None
+
+    async def test_a_disabled_schedule_entity_does_not_break_the_swap(
+        self, hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A user-disabled block is never added, so it must not be removed either.
+
+        Regression test: `async_add_entities` only schedules the add, and
+        `EntityPlatform._async_add_entity` aborts it for a disabled registry
+        entry (setting `entity.hass = None`). The next program switch then
+        raised inside the sync task, skipping the remaining removals and the
+        hide pass entirely.
+        """
+        client = self._client("week")
+        registry = er.async_get(hass)
+        registry.async_get_or_create(
+            "text",
+            DOMAIN,
+            self._WEEK_ID,
+            suggested_object_id=f"{DOMAIN}_{SK.TIMER_DHW_SCHEDULE_WEEK}",
+            disabled_by=er.RegistryEntryDisabler.USER,
+        )
+        entry = await self._setup(hass, monkeypatch, client)
+        assert hass.states.get(self._WEEK_ID) is None
+
+        await self._switch_to(hass, entry, client, "5+2")
+
+        # The pass completed: the new program's entities exist and the
+        # inactive week entry was hidden.
+        assert hass.states.get(self._WEEKDAY_ID) is not None
+        assert hass.states.get(self._WEEKEND_ID) is not None
+        week_entry = registry.async_get(self._WEEK_ID)
+        assert week_entry is not None
+        assert week_entry.hidden_by is RegistryEntryHider.INTEGRATION

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -10,7 +10,10 @@ from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_registry import RegistryEntryHider
+from homeassistant.helpers.entity_registry import (
+    RegistryEntryDisabler,
+    RegistryEntryHider,
+)
 from luxtronik.parameters import Parameters
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -359,8 +362,8 @@ class TestActiveScheduleDescriptions:
         `get_sensor_data` returns None both for an absent register and for a
         register whose datatype could not decode the raw value this poll
         (`SelectionBase` returns None for an unrecognised code). Treating the
-        latter as "nothing is active" would drop all 10 entities and hide all
-        10 registry entries on a single glitched read.
+        latter as "nothing is active" would drop all 10 entities and disable
+        all 10 registry entries on a single glitched read.
         """
         from custom_components.luxtronik2.text import _active_schedule_descriptions
 
@@ -412,8 +415,9 @@ class TestTimerScheduleSync:
         registry.async_get.side_effect = lambda entity_id: known.get(entity_id)
         return registry
 
-    def _entry(self, hidden_by=None):
+    def _entry(self, disabled_by=None, hidden_by=None):
         registry_entry = MagicMock()
+        registry_entry.disabled_by = disabled_by
         registry_entry.hidden_by = hidden_by
         return registry_entry
 
@@ -431,9 +435,7 @@ class TestTimerScheduleSync:
         assert [e.entity_description.key for e in added] == [SK.TIMER_DHW_SCHEDULE_WEEK]
 
     @pytest.mark.asyncio
-    async def test_setup_hides_existing_entries_of_inactive_blocks(self):
-        from homeassistant.helpers.entity_registry import RegistryEntryHider
-
+    async def test_setup_disables_existing_entries_of_inactive_blocks(self):
         from custom_components.luxtronik2.text import _timer_schedule_unique_id
 
         sync, _coord, _added = self._make_sync("week")
@@ -453,13 +455,11 @@ class TestTimerScheduleSync:
             await sync.async_setup()
 
         registry.async_update_entity.assert_any_call(
-            stale_id, hidden_by=RegistryEntryHider.INTEGRATION
+            stale_id, disabled_by=RegistryEntryDisabler.INTEGRATION
         )
 
     @pytest.mark.asyncio
-    async def test_setup_does_not_touch_a_user_hidden_entry(self):
-        from homeassistant.helpers.entity_registry import RegistryEntryHider
-
+    async def test_setup_does_not_touch_a_user_disabled_entry(self):
         from custom_components.luxtronik2.text import _timer_schedule_unique_id
 
         sync, _coord, _added = self._make_sync("week")
@@ -468,7 +468,7 @@ class TestTimerScheduleSync:
             d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_WEEK
         )
         week_id = _timer_schedule_unique_id(entry, week)
-        registry = self._registry({week_id: self._entry(RegistryEntryHider.USER)})
+        registry = self._registry({week_id: self._entry(RegistryEntryDisabler.USER)})
 
         with (
             patch(
@@ -481,9 +481,7 @@ class TestTimerScheduleSync:
         registry.async_update_entity.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_setup_unhides_an_integration_hidden_active_entry(self):
-        from homeassistant.helpers.entity_registry import RegistryEntryHider
-
+    async def test_setup_enables_an_integration_disabled_active_entry(self):
         from custom_components.luxtronik2.text import _timer_schedule_unique_id
 
         sync, _coord, _added = self._make_sync("week")
@@ -493,7 +491,32 @@ class TestTimerScheduleSync:
         )
         week_id = _timer_schedule_unique_id(entry, week)
         registry = self._registry(
-            {week_id: self._entry(RegistryEntryHider.INTEGRATION)}
+            {week_id: self._entry(RegistryEntryDisabler.INTEGRATION)}
+        )
+
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_setup()
+
+        registry.async_update_entity.assert_any_call(week_id, disabled_by=None)
+
+    @pytest.mark.asyncio
+    async def test_setup_migrates_a_hidden_active_entry_without_disabling_it(self):
+        """An earlier build hid the active entry too; the migration just clears it."""
+        from custom_components.luxtronik2.text import _timer_schedule_unique_id
+
+        sync, _coord, _added = self._make_sync("week")
+        entry = _mock_entry()
+        week = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_WEEK
+        )
+        week_id = _timer_schedule_unique_id(entry, week)
+        registry = self._registry(
+            {week_id: self._entry(hidden_by=RegistryEntryHider.INTEGRATION)}
         )
 
         with (
@@ -505,6 +528,37 @@ class TestTimerScheduleSync:
             await sync.async_setup()
 
         registry.async_update_entity.assert_any_call(week_id, hidden_by=None)
+        for call in registry.async_update_entity.call_args_list:
+            assert "disabled_by" not in call.kwargs
+
+    @pytest.mark.asyncio
+    async def test_setup_migrates_a_hidden_inactive_entry_and_disables_it(self):
+        """An inactive entry left over from the hidden-based build gets both:
+        the stale hidden_by is scrubbed and disabled_by is now set."""
+        from custom_components.luxtronik2.text import _timer_schedule_unique_id
+
+        sync, _coord, _added = self._make_sync("week")
+        entry = _mock_entry()
+        stale = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_MONDAY
+        )
+        stale_id = _timer_schedule_unique_id(entry, stale)
+        registry = self._registry(
+            {stale_id: self._entry(hidden_by=RegistryEntryHider.INTEGRATION)}
+        )
+
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_setup()
+
+        registry.async_update_entity.assert_any_call(stale_id, hidden_by=None)
+        registry.async_update_entity.assert_any_call(
+            stale_id, disabled_by=RegistryEntryDisabler.INTEGRATION
+        )
 
     @pytest.mark.asyncio
     async def test_mode_change_swaps_the_entities(self):
@@ -589,14 +643,14 @@ class TestTimerScheduleSync:
         assert list(sync._entities) == [SK.TIMER_DHW_SCHEDULE_WEEK]
 
     @pytest.mark.asyncio
-    async def test_unreadable_selector_does_not_remove_or_hide_anything(self):
+    async def test_unreadable_selector_does_not_remove_or_disable_anything(self):
         """A glitched selector read must be a no-op, not a full teardown.
 
         Regression test: treating an undecodable selector value as "no
         program active" removed every live schedule entity and wrote
-        `hidden_by = INTEGRATION` on all 10 registry entries, with the next
-        good poll re-adding and unhiding them - entity churn, registry writes
-        and a recorder gap caused by one transient read.
+        `disabled_by = INTEGRATION` on all 10 registry entries, with the next
+        good poll re-adding and re-enabling them - entity churn, registry
+        writes and a recorder gap caused by one transient read.
         """
         from custom_components.luxtronik2.text import LuxtronikTimerScheduleText
 
@@ -629,10 +683,8 @@ class TestTimerScheduleSync:
         `add_to_platform_abort()`, which sets `entity.hass = None`; a later
         `entity.async_remove()` would then blow up on
         `self.hass.loop.create_future()` inside the sync task, skipping the
-        rest of the removal loop and the hide pass.
+        rest of the removal loop and the disable pass.
         """
-        from homeassistant.helpers.entity_registry import RegistryEntryHider
-
         from custom_components.luxtronik2.text import _timer_schedule_unique_id
 
         sync, coord, _added = self._make_sync("week")
@@ -657,14 +709,14 @@ class TestTimerScheduleSync:
             await sync.async_apply()
 
         assert SK.TIMER_DHW_SCHEDULE_WEEK not in sync._entities
-        # The rest of the pass still ran: the now-inactive week block is hidden.
+        # The rest of the pass still ran: the now-inactive week block is disabled.
         registry.async_update_entity.assert_any_call(
-            week_id, hidden_by=RegistryEntryHider.INTEGRATION
+            week_id, disabled_by=RegistryEntryDisabler.INTEGRATION
         )
 
     @pytest.mark.asyncio
     async def test_a_failing_removal_does_not_abort_the_pass(self):
-        """One entity failing to remove must not skip the others or the hide pass."""
+        """One entity failing to remove must not skip the others or the disable pass."""
         from custom_components.luxtronik2.text import LuxtronikTimerScheduleText
 
         sync, coord, _added = self._make_sync("days")
@@ -815,40 +867,52 @@ class TestTimerScheduleSyncAgainstRealHass:
         entry = await self._setup(hass, monkeypatch, client)
         registry = er.async_get(hass)
 
-        # Active program: entity live, registry entry visible.
+        # Active program: entity live, registry entry enabled.
         assert hass.states.get(self._WEEK_ID) is not None
         assert hass.states.get(self._WEEKDAY_ID) is None
         week_entry = registry.async_get(self._WEEK_ID)
         assert week_entry is not None
-        assert week_entry.hidden_by is None
+        assert week_entry.disabled_by is None
 
         await self._switch_to(hass, entry, client, "5+2")
 
         # The week block is gone from the state machine (async_remove without
         # force_remove leaves a `restored` placeholder because the registry
-        # entry survives), and its registry entry is hidden, not removed.
+        # entry survives), and its registry entry is disabled, not removed.
         week_state = hass.states.get(self._WEEK_ID)
         assert week_state is None or week_state.attributes.get("restored") is True
         week_entry = registry.async_get(self._WEEK_ID)
         assert week_entry is not None
-        assert week_entry.hidden_by is RegistryEntryHider.INTEGRATION
+        assert week_entry.disabled_by is RegistryEntryDisabler.INTEGRATION
         assert hass.states.get(self._WEEKDAY_ID) is not None
         assert hass.states.get(self._WEEKEND_ID) is not None
 
-        await self._switch_to(hass, entry, client, "week")
+        # Clearing disabled_by makes HA schedule a config-entry reload 30s
+        # from now (config_entries.RELOAD_AFTER_UPDATE_DELAY) via
+        # EntityRegistryDisabledHandler. Collapse that delay to 0 so the
+        # reload actually runs inside this test instead of leaving a 30s
+        # timer pending - both to exercise the real end-to-end behaviour and
+        # to avoid a lingering-timer teardown warning.
+        monkeypatch.setattr("homeassistant.config_entries.RELOAD_AFTER_UPDATE_DELAY", 0)
 
-        # Swapping back re-adds under the same entity_id and unhides it.
+        await self._switch_to(hass, entry, client, "week")
+        # Let the (now near-instant) reload timer fire and the resulting
+        # config-entry reload task finish.
+        await hass.async_block_till_done()
+
+        # Swapping back re-adds under the same entity_id and re-enables it -
+        # surviving the config-entry reload that clearing disabled_by causes.
         week_state = hass.states.get(self._WEEK_ID)
         assert week_state is not None
         assert week_state.attributes.get("restored") is not True
         week_entry = registry.async_get(self._WEEK_ID)
         assert week_entry is not None
-        assert week_entry.hidden_by is None
+        assert week_entry.disabled_by is None
 
     async def test_a_user_rename_survives_the_round_trip(
         self, hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The whole point of hiding instead of removing the registry entry."""
+        """The whole point of disabling instead of removing the registry entry."""
         client = self._client("week")
         entry = await self._setup(hass, monkeypatch, client)
         registry = er.async_get(hass)
@@ -858,13 +922,19 @@ class TestTimerScheduleSyncAgainstRealHass:
         )
         await hass.async_block_till_done()
 
+        # See test_program_round_trip_keeps_the_registry_entry: re-enabling
+        # the week block on the way back schedules HA's 30s config-entry
+        # reload; collapse it so it actually runs in this test.
+        monkeypatch.setattr("homeassistant.config_entries.RELOAD_AFTER_UPDATE_DELAY", 0)
+
         await self._switch_to(hass, entry, client, "5+2")
         await self._switch_to(hass, entry, client, "week")
+        await hass.async_block_till_done()
 
         renamed_entry = registry.async_get(renamed_id)
         assert renamed_entry is not None
         assert renamed_entry.name == "My week schedule"
-        assert renamed_entry.hidden_by is None
+        assert renamed_entry.disabled_by is None
         assert hass.states.get(renamed_id) is not None
 
     async def test_a_disabled_schedule_entity_does_not_break_the_swap(
@@ -876,7 +946,7 @@ class TestTimerScheduleSyncAgainstRealHass:
         `EntityPlatform._async_add_entity` aborts it for a disabled registry
         entry (setting `entity.hass = None`). The next program switch then
         raised inside the sync task, skipping the remaining removals and the
-        hide pass entirely.
+        disable pass entirely.
         """
         client = self._client("week")
         registry = er.async_get(hass)
@@ -893,9 +963,50 @@ class TestTimerScheduleSyncAgainstRealHass:
         await self._switch_to(hass, entry, client, "5+2")
 
         # The pass completed: the new program's entities exist and the
-        # inactive week entry was hidden.
+        # user-disabled, now-inactive week entry is left exactly as the user
+        # set it.
         assert hass.states.get(self._WEEKDAY_ID) is not None
         assert hass.states.get(self._WEEKEND_ID) is not None
         week_entry = registry.async_get(self._WEEK_ID)
         assert week_entry is not None
-        assert week_entry.hidden_by is RegistryEntryHider.INTEGRATION
+        assert week_entry.disabled_by is er.RegistryEntryDisabler.USER
+
+    async def test_hidden_by_from_the_previous_hide_based_build_is_cleared(
+        self, hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Installs that ran the interim hidden-based build must not keep it.
+
+        Both an active and an inactive schedule entity carrying the old
+        `hidden_by = INTEGRATION` from that build get it cleared on the next
+        sync pass - the inactive one is disabled instead, the active one is
+        left enabled.
+        """
+        client = self._client("week")
+        registry = er.async_get(hass)
+        registry.async_get_or_create(
+            "text",
+            DOMAIN,
+            self._WEEK_ID,
+            suggested_object_id=f"{DOMAIN}_{SK.TIMER_DHW_SCHEDULE_WEEK}",
+            hidden_by=RegistryEntryHider.INTEGRATION,
+        )
+        registry.async_get_or_create(
+            "text",
+            DOMAIN,
+            self._WEEKDAY_ID,
+            suggested_object_id=f"{DOMAIN}_{SK.TIMER_DHW_SCHEDULE_WEEKDAY}",
+            hidden_by=RegistryEntryHider.INTEGRATION,
+        )
+
+        entry = await self._setup(hass, monkeypatch, client)
+        assert entry.state.value == "loaded"
+
+        week_entry = registry.async_get(self._WEEK_ID)
+        assert week_entry is not None
+        assert week_entry.hidden_by is None
+        assert week_entry.disabled_by is None
+
+        weekday_entry = registry.async_get(self._WEEKDAY_ID)
+        assert weekday_entry is not None
+        assert weekday_entry.hidden_by is None
+        assert weekday_entry.disabled_by is RegistryEntryDisabler.INTEGRATION

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -303,3 +303,46 @@ class TestTimerScheduleUniqueId:
             _timer_schedule_unique_id(_mock_entry(), description)
             == f"text.{DOMAIN}_{description.key}"
         )
+
+
+# ===========================================================================
+# _active_schedule_descriptions
+# ===========================================================================
+
+
+class TestActiveScheduleDescriptions:
+    _SELECTOR = "ID_Einst_SUBW_akt2"
+
+    def _call(self, parameters, *, entity_active=True):
+        from custom_components.luxtronik2.text import _active_schedule_descriptions
+
+        data = make_coordinator_data(parameters=parameters)
+        coord = _mock_coordinator(data)
+        coord.entity_active.return_value = entity_active
+        return [d.key for d in _active_schedule_descriptions(coord, data)]
+
+    def test_week_mode_yields_only_the_week_block(self):
+        assert self._call({self._SELECTOR: "week"}) == [SK.TIMER_DHW_SCHEDULE_WEEK]
+
+    def test_weekday_weekend_mode_yields_both_blocks(self):
+        assert self._call({self._SELECTOR: "5+2"}) == [
+            SK.TIMER_DHW_SCHEDULE_WEEKDAY,
+            SK.TIMER_DHW_SCHEDULE_WEEKEND,
+        ]
+
+    def test_days_mode_yields_seven_day_blocks(self):
+        keys = self._call({self._SELECTOR: "days"})
+        assert len(keys) == 7
+        assert SK.TIMER_DHW_SCHEDULE_MONDAY in keys
+        assert SK.TIMER_DHW_SCHEDULE_SUNDAY in keys
+
+    def test_missing_selector_parameter_yields_nothing(self):
+        assert self._call({}) == []
+
+    def test_data_none_yields_nothing(self):
+        from custom_components.luxtronik2.text import _active_schedule_descriptions
+
+        assert _active_schedule_descriptions(_mock_coordinator(), None) == []
+
+    def test_inactive_entity_yields_nothing(self):
+        assert self._call({self._SELECTOR: "week"}, entity_active=False) == []


### PR DESCRIPTION
## ✨ What

The DHW timer-program feature created all 10 schedule text entities (week, weekday, weekend, and one per weekday) on every install, leaving 7 or 9 of them permanently `unavailable` because they belong to a timer program the heat pump is not running. This makes only the running program's schedule entities exist, and adds a select entity so the program can be switched from Home Assistant.

- Only the active program's schedule blocks are created as entities.
- The other programs' registry entries are **disabled** (`disabled_by = INTEGRATION`), never removed — the device page collapses them behind "+N disabled entities", while a user's rename, area, icon, labels and recorder history all survive a program switch.
- The entity set re-syncs on every coordinator update, so a program change made on the heat-pump panel or from HA swaps the entities without a config-entry reload or restart.
- New `select.<prefix>_timer_dhw_program` exposes parameter 405 (`ID_Einst_SUBW_akt2`) with options `week` / `weekday_weekend` / `daily`, mapped onto the raw device values `week` / `5+2` / `days` via a new `raw_option_map` on `LuxtronikSelectEntityDescription`. Translations in en/de/nl/cs/pl.
- Installs that ran the intermediate hide-based build get their leftover `hidden_by = INTEGRATION` cleared automatically.

## 🧠 Why disabling, not hiding or purging

Both alternatives were tried or considered and rejected on evidence:

- **Hiding** (`hidden_by`) was implemented first and verified on a live HA 2026.7.2 instance: the device page renders hidden entities *inline*, labelled "(Hidden)" with state `unavailable`. It only cleans dashboards and entity pickers — not the device page, which is where the clutter was reported.
- **Purging the registry entry** cleans the device page but discards the user's rename, area, icon and labels on every program switch, and that loss gets worse once `unique_id` is decoupled from `entity_id`.

Accepted cost of disabling: clearing `disabled_by` makes HA schedule a config-entry reload 30 s later (`RELOAD_AFTER_UPDATE_DELAY`). The new blocks appear immediately regardless — the sync clears the flag before adding — and switching timer program is a rare action. No suppression hack is used.

## 🛡️ Robustness

- The sync is serialized with an `asyncio.Lock`, so two coordinator updates in quick succession cannot interleave add/remove passes.
- A removal of an entity that never reached the platform (aborted add on a user-disabled entry) is skipped rather than crashing, and one failed removal cannot abort the pass.
- The selector read is three-valued: "program X", "this controller has no such selector", and "unreadable this poll". The last is a complete no-op — otherwise one glitched read (`SelectionBase` returns `None` for an unrecognised code) would remove every schedule entity and disable all ten registry entries.
- A `_closing` guard set on unload prevents a queued sync from adding entities to an already-reset platform.

## 🧪 Testing

- 957 tests pass, package coverage stays at 100 %; `ruff check`/`format`, `basedpyright` (0 errors) and `codespell` clean.
- Unit tests cover the active-program derivation, add/remove/enable/disable transitions, the USER-set-value guard in both directions, the unreadable-selector no-op, overlapping sync calls, and the `hidden_by` migration.
- Integration tests run the text platform against a real `hass` and a real entity registry: program round trip, entity_id stability, registry-entry survival, a user rename surviving, and a disabled entity not breaking the swap.
- Verified live on a physical Alpha Innotec MSW4-16 (firmware V3.92.1): device page shows only the running program's blocks with the rest behind "+8 disabled entities", switching the program swaps the entity set immediately in both directions, times and entity_ids intact, HA's scheduled reload fires cleanly.

## 📋 Scope

DHW only. The mechanism is written against the existing `_TimerCircuit` abstraction, so the remaining five circuits (Hkr/Mk1/Mk2/ZIP/Swb) inherit it when they are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
