### PR TITLE
Fix | Unable to save options when sensor field is empty

### DIFF
--- a/custom_components/luxtronik2/schema_helper.py
+++ b/custom_components/luxtronik2/schema_helper.py
@@ -46,7 +46,6 @@ def build_options_schema(
         {
             vol.Optional(
                 CONF_HA_SENSOR_INDOOR_TEMPERATURE,
-                default=current_indoor_temp,
                 description={"suggested_value": current_indoor_temp},
             ): selector.EntitySelector(
                 selector.EntitySelectorConfig(
@@ -55,7 +54,6 @@ def build_options_schema(
             ),
             vol.Optional(
                 CONF_HA_SENSOR_CURRENT_POWER_CONSUMPTION,
-                default=current_power_consumption_sensor,
                 description={"suggested_value": current_power_consumption_sensor},
             ): selector.EntitySelector(
                 selector.EntitySelectorConfig(domain="sensor", device_class="power")

--- a/tests/test_schema_helper.py
+++ b/tests/test_schema_helper.py
@@ -12,7 +12,11 @@ import voluptuous as vol
 import voluptuous_serialize
 
 from custom_components.luxtronik2.const import (
+    CONF_HA_SENSOR_CURRENT_POWER_CONSUMPTION,
+    CONF_HA_SENSOR_INDOOR_TEMPERATURE,
+    CONF_UPDATE_INTERVAL,
     DEFAULT_PORT,
+    DEFAULT_UPDATE_INTERVAL_OPTION,
 )
 from custom_components.luxtronik2.schema_helper import (
     build_options_schema,
@@ -95,6 +99,69 @@ class TestBuildOptionsSchema:
             current_interval="1 minute",
         )
         assert isinstance(schema, vol.Schema)
+
+    def test_empty_submission_omits_unset_entity_sensors(self):
+        """Regression test for PR #743.
+
+        Submitting the options form with the optional entity fields left empty
+        must validate. Giving them ``default=None`` makes voluptuous force the
+        keys into the validated output as ``None``, which ``EntitySelector``
+        rejects with "Entity None is neither a valid entity ID nor a valid
+        UUID" - failing the whole form, so even the update interval can't be
+        saved.
+        """
+        schema = build_options_schema()
+        result = cast(dict[str, Any], schema({}))
+        assert result == {CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL_OPTION}
+
+    def test_one_entity_sensor_set_does_not_require_the_other(self):
+        """Picking only one of the two sensors must not fail on the other."""
+        schema = build_options_schema()
+        result = cast(
+            dict[str, Any],
+            schema(
+                {
+                    CONF_HA_SENSOR_CURRENT_POWER_CONSUMPTION: "sensor.power",
+                    CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL_OPTION,
+                }
+            ),
+        )
+        assert result[CONF_HA_SENSOR_CURRENT_POWER_CONSUMPTION] == "sensor.power"
+        assert CONF_HA_SENSOR_INDOOR_TEMPERATURE not in result
+
+    @pytest.mark.parametrize(
+        "cleared_key",
+        [CONF_HA_SENSOR_INDOOR_TEMPERATURE, CONF_HA_SENSOR_CURRENT_POWER_CONSUMPTION],
+    )
+    def test_clearing_a_previously_set_sensor_drops_the_key(self, cleared_key: str):
+        """A cleared field must not be resurrected by a stale default.
+
+        The frontend omits emptied optional keys from the submission. With
+        ``default=current_value`` voluptuous re-inserts the *previous* sensor,
+        so clearing silently did nothing. The key must stay absent instead, so
+        the options flow can store an explicit ``None`` and shadow any value
+        left over in ``config_entry.data``.
+        """
+        keys = {
+            CONF_HA_SENSOR_INDOOR_TEMPERATURE: "sensor.indoor_temp",
+            CONF_HA_SENSOR_CURRENT_POWER_CONSUMPTION: "sensor.power",
+        }
+        schema = build_options_schema(
+            current_indoor_temp=keys[CONF_HA_SENSOR_INDOOR_TEMPERATURE],
+            current_power_consumption_sensor=keys[
+                CONF_HA_SENSOR_CURRENT_POWER_CONSUMPTION
+            ],
+        )
+        submitted = {
+            key: value for key, value in keys.items() if key != cleared_key
+        } | {CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL_OPTION}
+
+        result = cast(dict[str, Any], schema(submitted))
+
+        assert cleared_key not in result
+        for key, value in keys.items():
+            if key != cleared_key:
+                assert result[key] == value
 
     def test_default_schema_is_json_serializable(self):
         """Regression test for issue #656.


### PR DESCRIPTION
**Home Assistant Core version:** 2026.8.1
**Heat pump firmware:** 3.92.3
**Model:** Alpha Innotec WZSV 62K3M

### Bug description
Submitting the options form (Settings → Devices & Services → Luxtronik → Configure) with the
"indoor temperature sensor" and/or "power consumption sensor" fields left empty raises:
`Entity None is neither a valid entity ID nor a valid UUID`. Happens on a fresh config entry,
or any time these optional fields aren't set. Since the whole form fails validation, this also
blocks saving the update interval.

<img width="596" height="782" alt="image" src="https://github.com/user-attachments/assets/3594e516-42d8-4676-a1e3-895af10cb7c3" />

### Root cause
In `schema_helper.py`, `build_options_schema()`, both fields use `vol.Optional(key, default=current_value, ...)`.
When `current_value` is `None`, Voluptuous forces the key into the validated output as `None`,
which `EntitySelector` rejects. The update-interval field avoids this because it already falls
back with `default=current_interval or DEFAULT_UPDATE_INTERVAL_OPTION`.

### Fix
Drop `default=` on both entity-selector fields; `description={"suggested_value": ...}` already
handles the UI pre-fill independently, so nothing is lost.

### Testing
- Empty fields now save without error; `options` correctly omits the keys entirely.
- Clearing a previously-set sensor and saving stores an explicit `null`, which `climate.py`
  and `sensor.py` both already handle correctly.
- Existing valid selections are unaffected.