### PR TITLE
fix(sensor,coordinator): 🐛 correct analog/fan output units and ventilation detection

### DIFF
--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -74,6 +74,13 @@ WRITE_CONFIRM_MAX_ATTEMPTS = 6
 WRITE_CONFIRM_INITIAL_DELAY = 0.1
 WRITE_CONFIRM_MAX_DELAY = 1.0
 
+# Values a temperature register reports when nothing is wired to it. 0.0 is
+# the absent-hardware reading; 5.0 and 75.0 are the controller's placeholders,
+# observed on unconnected TRL_ext / TEE / TFB1-3 channels (issue #729) and
+# already relied on by _detect_solar_present() for the collector (5.0) and
+# buffer (150.0, buffer-specific and deliberately not in this set) sensors.
+LUX_TEMPERATURE_SENTINELS: Final[frozenset[float]] = frozenset({0.0, 5.0, 75.0})
+
 
 def _write_confirmed(written: Any, confirmed: Any) -> bool:
     """Return True if a write's post-refresh read-back matches what was written.
@@ -702,24 +709,44 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         visibility flags, which are unreliable: issue #729's reporter runs a
         working ventilation module while ID_Visi_Lueftung reads 0, so those
         flags cannot be trusted in either direction and are deliberately not
-        consulted anywhere for ventilation. A unit without the module reports
-        a flat 0.0 on both channels instead (measured on an Alpha Innotec
-        MSW4-16), while a real module reports room-temperature exhaust air
-        and tempered supply air.
+        consulted anywhere for ventilation.
 
-        Both channels are required, so a single stuck or unwired channel
-        cannot conjure a phantom ventilation device. This is the only gate
-        the ventilation entities have - they carry no visibility of their
-        own - so it has to be the conservative one.
+        Only one channel has to read plausibly. Requiring both was wrong:
+        #729's reporter has a module with no exhaust sensor, whose channel
+        sits on the controller's unwired-sensor sentinel (5.0, unchanged
+        across 18 h of recorder history while supply drifted realistically
+        through 229 states). A unit without a module reports a flat 0.0 on
+        both channels (measured on an Alpha Innotec MSW4-16), so demanding
+        two live channels would hide the device from exactly the
+        installations that asked for it.
 
-        Same shape as _detect_solar_present()'s sentinel checks (5.0 / 150.0).
+        Sentinels are therefore treated as absent readings rather than as
+        values, the same shape as _detect_solar_present()'s 5.0 / 150.0
+        checks.
         """
-        supply = self.get_value(LC.C0159_VENTILATION_SUPPLY_AIR_TEMPERATURE)
-        exhaust = self.get_value(LC.C0160_VENTILATION_EXHAUST_AIR_TEMPERATURE)
-        if supply is None or exhaust is None:
+        return any(
+            self._is_plausible_reading(self.get_value(key))
+            for key in (
+                LC.C0159_VENTILATION_SUPPLY_AIR_TEMPERATURE,
+                LC.C0160_VENTILATION_EXHAUST_AIR_TEMPERATURE,
+            )
+        )
+
+    @staticmethod
+    def _is_plausible_reading(value: Any) -> bool:
+        """Is this air temperature a measurement rather than a sentinel.
+
+        0.0 is the missing-module reading, 5.0 and 75.0 are the controller's
+        unwired-sensor placeholders - the same values unconnected TRL_ext,
+        TEE and TFB1-3 channels report on the #729 reporter's LWC407.
+        Whether 5.0 / 75.0 hold across controller generations is unverified,
+        but treating them as readings is the worse failure: it fabricates a
+        room temperature that never moves.
+        """
+        if value is None:
             return False
         try:
-            return float(supply) != 0.0 and float(exhaust) != 0.0
+            return float(value) not in LUX_TEMPERATURE_SENTINELS
         except (TypeError, ValueError):
             return False
 

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -3,6 +3,7 @@
 # region Imports
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
+    PERCENTAGE,
     EntityCategory,
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -332,6 +333,20 @@ SENSORS: list[descr] = [
         # 0.1 kWh raw unit, applied by the Energy datatype (see 1059 above).
         native_precision=1,
     ),
+    # The analog outputs are per mille of a 10 V full scale, so the library's
+    # Voltage datatype (raw / 10) lands on 0-100 and `factor` supplies the
+    # remaining tenth: raw 1000 -> 100.0 -> 10.0 V. Removing the factor (as
+    # 2026.08.11 briefly did) reports an impossible 100 V; across 45
+    # diagnostics dumps AnalogOut1-4 never exceed 100.0 and pile up on
+    # 0.0 / 50.0 / 100.0. The analog *inputs* differ - AnalogIn3 reads 3.3 for
+    # 3.3 V - which is what made this look like a scaling bug from either
+    # side (#729).
+    #
+    # 0/50/100 is equally round read as percent, so the dumps cannot tell
+    # volts from percent here; volts is kept because the controller
+    # configures and displays these outputs as a 0-10 V signal. The
+    # ventilation fan outputs below share the encoding but not that
+    # reasoning, and are percent.
     descr(
         key=SensorKey.ANALOG_OUT1,
         luxtronik_key=LC.C0156_ANALOG_OUT1,
@@ -340,6 +355,7 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         visibility=LV.V0248_ANALOG_OUT1,
         entity_registry_enabled_default=False,
+        factor=0.1,
     ),
     descr(
         key=SensorKey.ANALOG_OUT2,
@@ -349,6 +365,7 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         visibility=LV.V0249_ANALOG_OUT2,
         entity_registry_enabled_default=False,
+        factor=0.1,
     ),
     descr(
         key=SensorKey.VENTILATION_SUPPLY_AIR_TEMPERATURE,
@@ -366,24 +383,29 @@ SENSORS: list[descr] = [
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
-    # VZU/VAB are analog 0-10 V fan-speed outputs, so they carry the
-    # modulation level a binary sensor would discard. The library's Voltage
-    # datatype already scales raw/10, hence no factor here.
+    # VZU/VAB are analog fan outputs, so they carry the modulation level a
+    # binary sensor would discard. Same per-mille encoding as the analog
+    # outputs above, but reported as percent rather than volts: the quantity
+    # is a fan modulation level, which is what the controller's ventilation
+    # stages are configured in, and percent needs no factor. #729's LWC407
+    # reports 34.0 in the reduced stage and 68.7 in the nominal one - two
+    # clean stages either way (34 % / 69 %, or 3.4 V / 6.9 V of a 10 V scale).
+    # They are setpoints, not measured speeds - they never reach 0 and do not
+    # follow the unit being switched off by other means - which is why they
+    # are named "... fan setpoint".
     descr(
         key=SensorKey.VENTILATION_SUPPLY_FAN,
         device_key=DeviceKey.ventilation,
         luxtronik_key=LC.C0164_VENTILATION_SUPPLY_FAN,
         state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        native_unit_of_measurement=PERCENTAGE,
     ),
     descr(
         key=SensorKey.VENTILATION_EXHAUST_FAN,
         device_key=DeviceKey.ventilation,
         luxtronik_key=LC.C0165_VENTILATION_EXHAUST_FAN,
         state_class=SensorStateClass.MEASUREMENT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        native_unit_of_measurement=PERCENTAGE,
     ),
     descr(
         key=SensorKey.CURRENT_HEAT_OUTPUT,

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -930,10 +930,10 @@
                 "name": "Teplota odváděného vzduchu"
             },
             "ventilation_supply_fan": {
-                "name": "Ventilátor přívodu"
+                "name": "Žádaná hodnota ventilátoru přívodu"
             },
             "ventilation_exhaust_fan": {
-                "name": "Ventilátor odvodu"
+                "name": "Žádaná hodnota ventilátoru odvodu"
             }
         },
         "date": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -930,10 +930,10 @@
                 "name": "Ablufttemperatur"
             },
             "ventilation_supply_fan": {
-                "name": "Zuluftventilator"
+                "name": "Zuluftventilator Sollwert"
             },
             "ventilation_exhaust_fan": {
-                "name": "Abluftventilator"
+                "name": "Abluftventilator Sollwert"
             }
         },
         "date": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -930,10 +930,10 @@
                 "name": "Exhaust air temperature"
             },
             "ventilation_supply_fan": {
-                "name": "Supply fan"
+                "name": "Supply fan setpoint"
             },
             "ventilation_exhaust_fan": {
-                "name": "Exhaust fan"
+                "name": "Exhaust fan setpoint"
             }
         },
         "date": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -930,10 +930,10 @@
                 "name": "Afvoerluchttemperatuur"
             },
             "ventilation_supply_fan": {
-                "name": "Toevoerventilator"
+                "name": "Toevoerventilator instelwaarde"
             },
             "ventilation_exhaust_fan": {
-                "name": "Afvoerventilator"
+                "name": "Afvoerventilator instelwaarde"
             }
         },
         "date": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -930,10 +930,10 @@
                 "name": "Temperatura powietrza wywiewanego"
             },
             "ventilation_supply_fan": {
-                "name": "Wentylator nawiewu"
+                "name": "Wentylator nawiewu - wartość zadana"
             },
             "ventilation_exhaust_fan": {
-                "name": "Wentylator wywiewu"
+                "name": "Wentylator wywiewu - wartość zadana"
             }
         },
         "date": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -336,13 +336,37 @@ class TestDeviceKeyActive:
         )
         assert coord.device_key_active(DeviceKey.ventilation) is False
 
-    def test_ventilation_inactive_when_only_one_air_temperature_reports(self):
-        """Both channels are required. Gating fails open elsewhere in
-        entity_visible, so a half-signal must not create the device."""
+    def test_ventilation_active_when_only_one_air_temperature_reports(self):
+        """One live channel is enough. #729's reporter runs a working module
+        whose exhaust channel has no sensor, so requiring both would hide the
+        device from the installation that asked for it."""
         coord = _make_coordinator(
             calculations={
                 "ID_WEB_Temp_Lueftung_Zuluft": 0.0,
                 "ID_WEB_Temp_Lueftung_Abluft": 21.2,
+            }
+        )
+        assert coord.device_key_active(DeviceKey.ventilation) is True
+
+    def test_ventilation_active_when_other_channel_is_a_sentinel(self):
+        """5.0 is the unwired-sensor placeholder, not a reading: #729's
+        exhaust channel held it for 18 h without a single state change while
+        supply drifted through 229. The live supply channel decides."""
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_Temp_Lueftung_Zuluft": 24.1,
+                "ID_WEB_Temp_Lueftung_Abluft": 5.0,
+            }
+        )
+        assert coord.device_key_active(DeviceKey.ventilation) is True
+
+    def test_ventilation_inactive_when_both_channels_are_sentinels(self):
+        """5.0 / 75.0 are the same placeholders unconnected TRL_ext, TEE and
+        TFB1-3 channels report, so two of them are no evidence of a module."""
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_Temp_Lueftung_Zuluft": 75.0,
+                "ID_WEB_Temp_Lueftung_Abluft": 5.0,
             }
         )
         assert coord.device_key_active(DeviceKey.ventilation) is False

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PORT,
+    CONF_TIMEOUT,
+    PERCENTAGE,
+    UnitOfElectricPotential,
+)
 from luxtronik.calculations import Calculations
 
 from conftest import make_coordinator_data
@@ -733,31 +740,71 @@ def _energy_input_case(
     return description, datatype
 
 
-class TestAnalogOutScaling:
-    """The library's Voltage datatype already applies its own scaling_factor
-    of 0.1, and the coordinator surfaces that decoded value. An additional
-    `factor` in the description would scale a second time and report a tenth
-    of the real voltage, so no factor belongs here - as with the energy
-    counters below, the datatype is the whole conversion."""
+def _assert_raw_converts_to(
+    sensor_key: SensorKey, raw_value: int, expected: float
+) -> None:
+    """Push a raw register value through the real datatype and description."""
+    description = next(d for d in SENSORS if d.key == sensor_key)
+    raw_name = description.luxtronik_key.rsplit(".", 1)[1]
+    datatype = Calculations().get(raw_name)
+    converted = datatype.from_heatpump(raw_value)
+    group, sensor_id = description.luxtronik_key.split(".", 1)
+    data = make_coordinator_data(**{group: {sensor_id: converted}})
+    entity = _make_sensor(description, data)
+    entity._handle_coordinator_update(data)
+    assert entity._attr_native_value == expected
 
-    def _assert_raw_converts_to(
-        self, sensor_key: SensorKey, raw_value: int, expected_volt: float
-    ) -> None:
-        description = next(d for d in SENSORS if d.key == sensor_key)
-        raw_name = description.luxtronik_key.rsplit(".", 1)[1]
-        datatype = Calculations().get(raw_name)
-        converted = datatype.from_heatpump(raw_value)
-        group, sensor_id = description.luxtronik_key.split(".", 1)
-        data = make_coordinator_data(**{group: {sensor_id: converted}})
-        entity = _make_sensor(description, data)
-        entity._handle_coordinator_update(data)
-        assert entity._attr_native_value == expected_volt
+
+class TestAnalogOutScaling:
+    """The analog outputs are per mille of a 10 V full scale: the library's
+    Voltage datatype (raw / 10) lands on 0-100 and the description's `factor`
+    supplies the remaining tenth. Dropping the factor reports raw 1000 as
+    100 V on a 10 V output - across 45 diagnostics dumps AnalogOut1-4 never
+    exceed 100.0 and cluster on 0.0 / 50.0 / 100.0 (#729)."""
 
     def test_analog_out1_scaling(self):
-        self._assert_raw_converts_to(SensorKey.ANALOG_OUT1, 105, 10.5)
+        _assert_raw_converts_to(SensorKey.ANALOG_OUT1, 1000, 10.0)
 
     def test_analog_out2_scaling(self):
-        self._assert_raw_converts_to(SensorKey.ANALOG_OUT2, 55, 5.5)
+        _assert_raw_converts_to(SensorKey.ANALOG_OUT2, 550, 5.5)
+
+    def test_analog_outs_are_volts(self):
+        """0/50/100 is equally round read as percent, so the dumps cannot
+        settle volts vs percent here. Volts is a deliberate choice - the
+        controller configures these as a 0-10 V signal - and the factor only
+        makes sense alongside it, so the two are asserted together."""
+        for key in (SensorKey.ANALOG_OUT1, SensorKey.ANALOG_OUT2):
+            description = next(d for d in SENSORS if d.key == key)
+            assert description.device_class == SensorDeviceClass.VOLTAGE
+            assert (
+                description.native_unit_of_measurement == UnitOfElectricPotential.VOLT
+            )
+            assert description.factor == 0.1
+
+
+class TestVentilationFanScaling:
+    """The fan outputs share the analog outputs' per-mille encoding but are
+    reported as a modulation percentage, which is what the controller's
+    ventilation stages are set in - so the datatype is the whole conversion
+    and no `factor` belongs here. Raw values from #729's LWC407."""
+
+    def test_supply_fan_scaling(self):
+        """340 in the reduced ventilation stage."""
+        _assert_raw_converts_to(SensorKey.VENTILATION_SUPPLY_FAN, 340, 34.0)
+
+    def test_exhaust_fan_scaling(self):
+        """625 on the exhaust channel in the nominal stage."""
+        _assert_raw_converts_to(SensorKey.VENTILATION_EXHAUST_FAN, 625, 62.5)
+
+    def test_fans_are_percent_without_factor(self):
+        for key in (
+            SensorKey.VENTILATION_SUPPLY_FAN,
+            SensorKey.VENTILATION_EXHAUST_FAN,
+        ):
+            description = next(d for d in SENSORS if d.key == key)
+            assert description.native_unit_of_measurement == PERCENTAGE
+            assert description.device_class is None
+            assert description.factor is None
 
 
 class TestEnergyInputScaling:


### PR DESCRIPTION
Follow-up to the #729 field testing. Two independent fixes, one commit each.

## 🐛 Analog outputs: restore the volt scaling

`cfca4a5` (shipped in 2026.08.10 and 2026.08.11) removed `factor=0.1` from `ANALOG_OUT1/2` on the assumption that the raw register is tenths of a volt. It is per mille of a 10 V full scale, so the library's `Voltage` datatype (`raw / 10`) only gets partway there and the factor supplies the rest.

Evidence — decoded values across 45 diagnostics dumps:

| Register | Observed |
|---|---|
| `AnalogOut1` | `100.0` ×36, `0.0` ×5, `50.0` ×2 |
| `AnalogOut2` | `0.0` ×29, `100.0` ×5, `50.0` ×2, plus `2.5` / `1.1` / `18.0` / `19.0` / `27.0` / `70.0` |
| `AnalogOut3` | `0.0` ×42, `50.0` |
| `AnalogOut4` | `0.0` ×42, `82.5` |

Nothing exceeds `100.0`, so "the decoded value is volts" is impossible on a 0–10 V output. raw 1000 → **10.0 V** again, as in 2026.08.08 and earlier.

Note the analog *inputs* genuinely are tenths of a volt (`AnalogIn3` reads `3.3` for 3.3 V). That asymmetry is what made this look like a scaling bug from either direction.

## 🌬️ Ventilation fan outputs: percent, not volts

`VZU`/`VAB` share the per-mille encoding but are reported as a percentage. **Values are unchanged from 2026.08.10** — only the unit and the name change. @McGismo's LWC407 reads `34.0` in the reduced stage and `68.7` in the nominal one; as volts that was 10× too high, as percent it is two clean modulation stages.

Renamed to *"... fan setpoint"* in all five languages, per his observation that they never reach 0 and do not follow the unit being switched off by other means.

⚠️ The unit change (V → %) raises Home Assistant's *"units changed"* statistics warning for anyone running the two pre-releases; it needs accepting once under **Developer tools → Statistics**.

## 🔍 Ventilation detection: one plausible channel

`has_ventilation` required *both* air temperature channels to be non-zero. @McGismo's module has no exhaust sensor, so that channel sits on the controller's unwired-sensor sentinel `5.0` — his system passed the test by accident, and an install whose sentinel happens to be `0.0` would have been hidden.

`0.0` / `5.0` / `75.0` are now treated as absent readings and one plausible channel is enough. Evidence for `5.0`: over 18 h of recorder history his exhaust channel produced **exactly one state** while supply drifted through 229, and unconnected `TRL_ext`, `TEE` and `TFB1-3` report the same placeholders on that controller. A unit with no module still reports a flat `0.0` on both channels, so it stays undetected.

Whether `5.0` / `75.0` hold across controller generations is unverified. Treating them as readings is the worse failure — it fabricates a room temperature that never moves.

## ⚖️ What the evidence does *not* settle

`0`/`50`/`100` is equally round read as percent or as volts, so the dumps cannot distinguish the two for the analog outputs. Volts is a deliberate choice — the controller configures and displays them as a 0–10 V signal — while the fan outputs are percent because the quantity is a modulation level. Both the descriptions and the tests state this, so the next reader doesn't re-derive it from the same ambiguous data and flip it back.

The library sides with neither: `Voltage` and `Percent` are the same `raw / 10`, and `measurement_type` is a label nothing consumes. No `lux_overrides.py` change was made for that reason.

## ✅ Verification

- `ruff check` / `ruff format --check` clean, `codespell` clean
- `basedpyright`: 0 errors, 0 warnings
- `pytest --cov`: **967 passed, 100 % coverage** (no regression)
- `TestAnalogOutScaling` and `TestVentilationFanScaling` pin each unit/factor choice separately; three ventilation-detection cases cover the live, sentinel and no-module paths

Resolves #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)