### PR TITLE
feat(sensor): ✨ expose the four ventilation stage setpoints

### DIFF
--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -503,6 +503,17 @@ class LuxParameter(StrEnum):
     # from the heating/DHW mode numbering, which also has second_heatsource.
     # Irrelevant to the select, which works on the library's decoded strings.
     P0894_VENTILATION_MODE = "parameters.ID_Einst_BA_Lueftung_akt"
+    # The four DIN 1946-6 ventilation stages. Both the pinned library and
+    # upstream's rewrite type these as Unknown/UINT32 and non-writeable, so
+    # the value is the raw register with no conversion and the unit is
+    # unconfirmed - see the sensor descriptions for why they are exposed
+    # read-only and unitless for now (#729).
+    P0960_VENTILATION_STAGE_HUMIDITY_PROTECTION = (
+        "parameters.ID_Einst_Luf_Feuchteschutz_akt"
+    )
+    P0961_VENTILATION_STAGE_REDUCED = "parameters.ID_Einst_Luf_Reduziert_akt"
+    P0962_VENTILATION_STAGE_NOMINAL = "parameters.ID_Einst_Luf_Nennlueftung_akt"
+    P0963_VENTILATION_STAGE_INTENSIVE = "parameters.ID_Einst_Luf_Intensivlueftung_akt"
     P0966_COOLING_TARGET_TEMPERATURE_MK3 = "parameters.ID_Sollwert_KuCft3_akt"
     P0973_MAX_DHW_TEMPERATURE = "parameters.ID_Einst_BW_max"
     P0979_HEATING_MIN_FLOW_OUT_TEMPERATURE = (
@@ -796,6 +807,10 @@ class SensorKey(StrEnum):
     VENTILATION_EXHAUST_AIR_TEMPERATURE = "ventilation_exhaust_air_temperature"
     VENTILATION_SUPPLY_FAN = "ventilation_supply_fan"
     VENTILATION_EXHAUST_FAN = "ventilation_exhaust_fan"
+    VENTILATION_STAGE_HUMIDITY_PROTECTION = "ventilation_stage_humidity_protection"
+    VENTILATION_STAGE_REDUCED = "ventilation_stage_reduced"
+    VENTILATION_STAGE_NOMINAL = "ventilation_stage_nominal"
+    VENTILATION_STAGE_INTENSIVE = "ventilation_stage_intensive"
     CURRENT_HEAT_OUTPUT = "current_heat_output"
     CURRENT_POWER_CONSUMPTION = "current_power_consumption"
     PUMP_FREQUENCY = "pump_frequency"

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -407,6 +407,43 @@ SENSORS: list[descr] = [
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
     ),
+    # The four configured ventilation stages (DIN 1946-6: humidity
+    # protection, reduced, nominal, intensive). Read-only and unitless on
+    # purpose: both the pinned library and upstream's rewrite type these as
+    # Unknown/UINT32 and non-writeable, so no conversion runs and the value
+    # is the raw register. The names and a typical 100/150/230/300 reading
+    # point at m3/h, but per mille of a fan setpoint would look identical,
+    # and a `number` entity would have to commit to a scale before writing
+    # real airflow into someone's house. Exposing them read-only first turns
+    # the diagnostics corpus into the evidence needed to promote them (#729).
+    #
+    # Gated on the ventilation device rather than the ID_Visi_Einst_Luf_*
+    # flags: those are the same flag family that reads 0 on a working module,
+    # which is why has_ventilation ignores them (see coordinator).
+    descr(
+        key=SensorKey.VENTILATION_STAGE_HUMIDITY_PROTECTION,
+        device_key=DeviceKey.ventilation,
+        luxtronik_key=LP.P0960_VENTILATION_STAGE_HUMIDITY_PROTECTION,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    descr(
+        key=SensorKey.VENTILATION_STAGE_REDUCED,
+        device_key=DeviceKey.ventilation,
+        luxtronik_key=LP.P0961_VENTILATION_STAGE_REDUCED,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    descr(
+        key=SensorKey.VENTILATION_STAGE_NOMINAL,
+        device_key=DeviceKey.ventilation,
+        luxtronik_key=LP.P0962_VENTILATION_STAGE_NOMINAL,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    descr(
+        key=SensorKey.VENTILATION_STAGE_INTENSIVE,
+        device_key=DeviceKey.ventilation,
+        luxtronik_key=LP.P0963_VENTILATION_STAGE_INTENSIVE,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     descr(
         key=SensorKey.CURRENT_HEAT_OUTPUT,
         luxtronik_key=LC.C0257_CURRENT_HEAT_OUTPUT,

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -934,6 +934,18 @@
             },
             "ventilation_exhaust_fan": {
                 "name": "Žádaná hodnota ventilátoru odvodu"
+            },
+            "ventilation_stage_humidity_protection": {
+                "name": "Stupeň ochrany proti vlhkosti"
+            },
+            "ventilation_stage_reduced": {
+                "name": "Redukovaný stupeň"
+            },
+            "ventilation_stage_nominal": {
+                "name": "Nominální stupeň"
+            },
+            "ventilation_stage_intensive": {
+                "name": "Intenzivní stupeň"
             }
         },
         "date": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -934,6 +934,18 @@
             },
             "ventilation_exhaust_fan": {
                 "name": "Abluftventilator Sollwert"
+            },
+            "ventilation_stage_humidity_protection": {
+                "name": "Stufe Feuchteschutz"
+            },
+            "ventilation_stage_reduced": {
+                "name": "Stufe Reduziert"
+            },
+            "ventilation_stage_nominal": {
+                "name": "Stufe Nennlüftung"
+            },
+            "ventilation_stage_intensive": {
+                "name": "Stufe Intensivlüftung"
             }
         },
         "date": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -934,6 +934,18 @@
             },
             "ventilation_exhaust_fan": {
                 "name": "Exhaust fan setpoint"
+            },
+            "ventilation_stage_humidity_protection": {
+                "name": "Humidity protection stage"
+            },
+            "ventilation_stage_reduced": {
+                "name": "Reduced stage"
+            },
+            "ventilation_stage_nominal": {
+                "name": "Nominal stage"
+            },
+            "ventilation_stage_intensive": {
+                "name": "Intensive stage"
             }
         },
         "date": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -934,6 +934,18 @@
             },
             "ventilation_exhaust_fan": {
                 "name": "Afvoerventilator instelwaarde"
+            },
+            "ventilation_stage_humidity_protection": {
+                "name": "Stand vochtbescherming"
+            },
+            "ventilation_stage_reduced": {
+                "name": "Stand gereduceerd"
+            },
+            "ventilation_stage_nominal": {
+                "name": "Stand nominaal"
+            },
+            "ventilation_stage_intensive": {
+                "name": "Stand intensief"
             }
         },
         "date": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -934,6 +934,18 @@
             },
             "ventilation_exhaust_fan": {
                 "name": "Wentylator wywiewu - wartość zadana"
+            },
+            "ventilation_stage_humidity_protection": {
+                "name": "Stopień ochrony przed wilgocią"
+            },
+            "ventilation_stage_reduced": {
+                "name": "Stopień zredukowany"
+            },
+            "ventilation_stage_nominal": {
+                "name": "Stopień nominalny"
+            },
+            "ventilation_stage_intensive": {
+                "name": "Stopień intensywny"
             }
         },
         "date": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -30,6 +30,7 @@ from custom_components.luxtronik2.const import (
     LuxSmartGridStatus,
     LuxStatus1Option,
     LuxStatus3Option,
+    LuxVisibility,
     SensorKey,
 )
 from custom_components.luxtronik2.lux_overrides import parameters_to_add_update
@@ -753,6 +754,46 @@ def _assert_raw_converts_to(
     entity = _make_sensor(description, data)
     entity._handle_coordinator_update(data)
     assert entity._attr_native_value == expected
+
+
+class TestVentilationStageSetpoints:
+    """The four ventilation stages are exposed read-only and unitless while
+    their scale is unconfirmed: the library types them Unknown/UINT32 and
+    non-writeable, so no conversion runs and the raw register is the value.
+    Claiming a unit (or promoting them to a `number`) would commit to a scale
+    that the diagnostics evidence does not yet settle (#729)."""
+
+    STAGE_KEYS = (
+        SensorKey.VENTILATION_STAGE_HUMIDITY_PROTECTION,
+        SensorKey.VENTILATION_STAGE_REDUCED,
+        SensorKey.VENTILATION_STAGE_NOMINAL,
+        SensorKey.VENTILATION_STAGE_INTENSIVE,
+    )
+
+    def test_stages_are_unitless_and_unscaled(self):
+        for key in self.STAGE_KEYS:
+            description = next(d for d in SENSORS if d.key == key)
+            assert description.native_unit_of_measurement is None
+            assert description.device_class is None
+            assert description.factor is None
+            assert description.device_key == DeviceKey.ventilation
+
+    def test_stage_value_is_the_raw_register(self):
+        """100/150/230/300 on #729's controller, passed through untouched."""
+        for key, raw in zip(self.STAGE_KEYS, (100, 150, 230, 300), strict=True):
+            description = next(d for d in SENSORS if d.key == key)
+            group, sensor_id = description.luxtronik_key.split(".", 1)
+            data = make_coordinator_data(**{group: {sensor_id: raw}})
+            entity = _make_sensor(description, data)
+            entity._handle_coordinator_update(data)
+            assert entity._attr_native_value == raw
+
+    def test_stages_are_not_gated_on_the_ventilation_visibility_flags(self):
+        """Same flag family that reads 0 on a working module, which is why
+        has_ventilation ignores it - the ventilation device is the gate."""
+        for key in self.STAGE_KEYS:
+            description = next(d for d in SENSORS if d.key == key)
+            assert description.visibility == LuxVisibility.UNSET
 
 
 class TestAnalogOutScaling:


### PR DESCRIPTION
Follow-up to #729. Adds read-only sensors for the four DIN 1946-6 ventilation stages on the **Ventilation** device.

| Entity | Parameter | Typical value |
|---|---|---|
| Humidity protection stage | `ID_Einst_Luf_Feuchteschutz_akt` (960) | 100 |
| Reduced stage | `ID_Einst_Luf_Reduziert_akt` (961) | 150 |
| Nominal stage | `ID_Einst_Luf_Nennlueftung_akt` (962) | 230 |
| Intensive stage | `ID_Einst_Luf_Intensivlueftung_akt` (963) | 300 |

## 🔍 Why unitless, and why sensors rather than numbers

Both the pinned library (0.3.14) and upstream's `main` rewrite type all four as `Unknown` / `UINT32` / `writeable: False` — `luxtronik/definitions/parameters.py` and `tests/test_compatibility.py` upstream both pin that. So **no conversion runs**: the value is the raw register, and no unit is claimed anywhere.

The stage names and a 100/150/230/300 reading point at m³/h, which would be a textbook set for a single-family unit. But per mille of a fan setpoint would look identical in the register, and the one cross-check available doesn't close: if the fan output is airflow as a fraction of maximum, @McGismo's reduced-stage `34.0` against `Reduziert`=150 implies a ~440 m³/h maximum, and his Automatic `68.7` then matches `Intensivlüftung`=300 (68.2 %) — but *not* `Nennlüftung`=230 (52 %). That only works if he was running intensive, while his `ID_Visi_Einst_Luf_Intensivlueftung_akt` reads 0.

Hence: **sensors, not `number` entities.** A `number` is a write path, and it would have to commit to a scale and a min/max before writing real airflow into someone's house — on registers the library says are not writeable. Exposing them read-only first costs nothing and turns the diagnostics corpus into the evidence needed to promote them, once a user confirms the values against the figures on their controller display.

Gated on the ventilation device rather than the `ID_Visi_Einst_Luf_*` flags — that's the same flag family that reads 0 on a working module, which is why `has_ventilation` ignores it.

## 🔀 Rebased on #744

Rebased onto `main` after #744 merged. The overlap was in the five translation files (the `... fan setpoint` rename landing next to these new keys) and in `test_sensor.py`, where #744 lifted the raw-conversion helper to module level; both sides are kept. `sensor_entities_predefined.py` merged automatically — these four descriptions simply follow the percent-scaled fan outputs.

## ✅ Verification

Re-run after the rebase, against merged `main`:

- `ruff check` / `ruff format --check` clean, `codespell` clean
- `basedpyright`: 0 errors, 0 warnings
- `pytest --cov`: **970 passed, 100 % coverage** (no regression)
- `TestVentilationStageSetpoints` pins the contract: unitless, no `device_class`, no `factor`, raw value passed through, on the ventilation device, and not gated on the `ID_Visi_Einst_Luf_*` flags — so a later "let's add a unit" change has to be deliberate

Refs #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)