### PR TITLE
feat(sensor): ✨ report the ventilation stages in m³/h

### DIFF
--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     UnitOfPressure,
     UnitOfTemperature,
     UnitOfTime,
+    UnitOfVolumeFlowRate,
 )
 
 from .const import (
@@ -385,14 +386,15 @@ SENSORS: list[descr] = [
     ),
     # VZU/VAB are analog fan outputs, so they carry the modulation level a
     # binary sensor would discard. Same per-mille encoding as the analog
-    # outputs above, but reported as percent rather than volts: the quantity
-    # is a fan modulation level, which is what the controller's ventilation
-    # stages are configured in, and percent needs no factor. #729's LWC407
-    # reports 34.0 in the reduced stage and 68.7 in the nominal one - two
-    # clean stages either way (34 % / 69 %, or 3.4 V / 6.9 V of a 10 V scale).
-    # They are setpoints, not measured speeds - they never reach 0 and do not
-    # follow the unit being switched off by other means - which is why they
-    # are named "... fan setpoint".
+    # outputs above, but reported as percent rather than volts, and without
+    # the factor: the value handed out is the undivided register, and #729's
+    # controller displays 3.25 V for the 32.5 this integration shows. Labelled
+    # V that would read as 32.5 volts - ten times the real output - while as
+    # percent it is right, since the same point is 32.5 % of the 10 V scale.
+    # Confirmed against that controller's web UI at three operating points
+    # (32.5 / 50.0 / 62.5), each matching a configured stage below divided by
+    # the unit size. Percent also keeps the number free of an assumed full
+    # scale, which volts would not.
     descr(
         key=SensorKey.VENTILATION_SUPPLY_FAN,
         device_key=DeviceKey.ventilation,
@@ -408,14 +410,19 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=PERCENTAGE,
     ),
     # The four configured ventilation stages (DIN 1946-6: humidity
-    # protection, reduced, nominal, intensive). Read-only and unitless on
-    # purpose: both the pinned library and upstream's rewrite type these as
-    # Unknown/UINT32 and non-writeable, so no conversion runs and the value
-    # is the raw register. The names and a typical 100/150/230/300 reading
-    # point at m3/h, but per mille of a fan setpoint would look identical,
-    # and a `number` entity would have to commit to a scale before writing
-    # real airflow into someone's house. Exposing them read-only first turns
-    # the diagnostics corpus into the evidence needed to promote them (#729).
+    # protection, reduced, nominal, intensive). The register is the airflow
+    # in m3/h with no conversion - both the pinned library and upstream's
+    # rewrite type these as Unknown/UINT32, so the raw value is what arrives.
+    # #729's LWC407, configured for a 400 m3/h unit, reported 130 / 200 / 250
+    # against fan outputs of 32.5 % / 50.0 % / 62.5 % at the same moments:
+    # three operating points where stage / unit size lands exactly on the fan
+    # output, which per mille of the fan setpoint would not do. Intensive was
+    # never observed - that stage is not reachable through the mode parameter
+    # on that controller - so it rides on the other three.
+    #
+    # Still read-only. That is one system, and a `number` entity would have to
+    # commit to the scale before writing real airflow into someone's house;
+    # a wrong unit on a sensor is a label, a wrong unit on a write is not.
     #
     # Gated on the ventilation device rather than the ID_Visi_Einst_Luf_*
     # flags: those are the same flag family that reads 0 on a working module,
@@ -425,24 +432,32 @@ SENSORS: list[descr] = [
         device_key=DeviceKey.ventilation,
         luxtronik_key=LP.P0960_VENTILATION_STAGE_HUMIDITY_PROTECTION,
         entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+        native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
     ),
     descr(
         key=SensorKey.VENTILATION_STAGE_REDUCED,
         device_key=DeviceKey.ventilation,
         luxtronik_key=LP.P0961_VENTILATION_STAGE_REDUCED,
         entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+        native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
     ),
     descr(
         key=SensorKey.VENTILATION_STAGE_NOMINAL,
         device_key=DeviceKey.ventilation,
         luxtronik_key=LP.P0962_VENTILATION_STAGE_NOMINAL,
         entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+        native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
     ),
     descr(
         key=SensorKey.VENTILATION_STAGE_INTENSIVE,
         device_key=DeviceKey.ventilation,
         luxtronik_key=LP.P0963_VENTILATION_STAGE_INTENSIVE,
         entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+        native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
     ),
     descr(
         key=SensorKey.CURRENT_HEAT_OUTPUT,

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -1087,7 +1087,7 @@
                 "state": {
                     "off": "Aus",
                     "automatic": "Automatisch",
-                    "party": "Hochleistung",
+                    "party": "Party",
                     "holidays": "Ferien"
                 }
             }

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -1041,7 +1041,7 @@
                     "off": "Aus",
                     "automatic": "Automatisch",
                     "second_heatsource": "Zweiter W\u00e4rmeerzeuger",
-                    "party": "Hochleistung",
+                    "party": "Party",
                     "holidays": "Ferien"
                 }
             },
@@ -1051,7 +1051,7 @@
                     "off": "Aus",
                     "automatic": "Automatisch",
                     "second_heatsource": "Zweiter W\u00e4rmeerzeuger",
-                    "party": "Hochleistung",
+                    "party": "Party",
                     "holidays": "Ferien"
                 }
             },
@@ -1060,7 +1060,7 @@
                 "state": {
                     "off": "Aus",
                     "automatic": "Automatisch",
-                    "party": "Hochleistung",
+                    "party": "Party",
                     "holidays": "Ferien"
                 }
             },
@@ -1069,7 +1069,7 @@
                 "state": {
                     "off": "Aus",
                     "automatic": "Automatisch",
-                    "party": "Hochleistung",
+                    "party": "Party",
                     "holidays": "Ferien"
                 }
             },
@@ -1078,7 +1078,7 @@
                 "state": {
                     "off": "Aus",
                     "automatic": "Automatisch",
-                    "party": "Hochleistung",
+                    "party": "Party",
                     "holidays": "Ferien"
                 }
             },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     CONF_TIMEOUT,
     PERCENTAGE,
     UnitOfElectricPotential,
+    UnitOfVolumeFlowRate,
 )
 from luxtronik.calculations import Calculations
 
@@ -757,11 +758,12 @@ def _assert_raw_converts_to(
 
 
 class TestVentilationStageSetpoints:
-    """The four ventilation stages are exposed read-only and unitless while
-    their scale is unconfirmed: the library types them Unknown/UINT32 and
-    non-writeable, so no conversion runs and the raw register is the value.
-    Claiming a unit (or promoting them to a `number`) would commit to a scale
-    that the diagnostics evidence does not yet settle (#729)."""
+    """The four ventilation stages hold the configured airflow in m3/h: the
+    library types them Unknown/UINT32, so no conversion runs and the raw
+    register is the value. #729's LWC407 (400 m3/h unit) read 130 / 200 / 250
+    against fan outputs of 32.5 % / 50.0 % / 62.5 % at the same moments.
+    They stay read-only - that is one system, and a `number` would commit to
+    the scale before writing real airflow."""
 
     STAGE_KEYS = (
         SensorKey.VENTILATION_STAGE_HUMIDITY_PROTECTION,
@@ -770,17 +772,22 @@ class TestVentilationStageSetpoints:
         SensorKey.VENTILATION_STAGE_INTENSIVE,
     )
 
-    def test_stages_are_unitless_and_unscaled(self):
+    def test_stages_are_airflow_and_unscaled(self):
         for key in self.STAGE_KEYS:
             description = next(d for d in SENSORS if d.key == key)
-            assert description.native_unit_of_measurement is None
-            assert description.device_class is None
+            assert (
+                description.native_unit_of_measurement
+                == UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR
+            )
+            assert description.device_class == SensorDeviceClass.VOLUME_FLOW_RATE
             assert description.factor is None
             assert description.device_key == DeviceKey.ventilation
 
     def test_stage_value_is_the_raw_register(self):
-        """100/150/230/300 on #729's controller, passed through untouched."""
-        for key, raw in zip(self.STAGE_KEYS, (100, 150, 230, 300), strict=True):
+        """130/200/250 on #729's controller, passed through untouched. The
+        intensive value is synthetic - that stage is not reachable through the
+        mode parameter there, so it was never observed."""
+        for key, raw in zip(self.STAGE_KEYS, (130, 200, 250, 400), strict=True):
             description = next(d for d in SENSORS if d.key == key)
             group, sensor_id = description.luxtronik_key.split(".", 1)
             data = make_coordinator_data(**{group: {sensor_id: raw}})
@@ -810,10 +817,11 @@ class TestAnalogOutScaling:
         _assert_raw_converts_to(SensorKey.ANALOG_OUT2, 550, 5.5)
 
     def test_analog_outs_are_volts(self):
-        """0/50/100 is equally round read as percent, so the dumps cannot
-        settle volts vs percent here. Volts is a deliberate choice - the
-        controller configures these as a 0-10 V signal - and the factor only
-        makes sense alongside it, so the two are asserted together."""
+        """0/50/100 is equally round read as percent, so the dumps alone
+        cannot settle volts vs percent. #729's controller web UI does:
+        AnalogOut2 85.0 displays as 8.50 V, AnalogOut3 50.0 as 5.00 V. The
+        factor only makes sense alongside volts, so the two are asserted
+        together."""
         for key in (SensorKey.ANALOG_OUT1, SensorKey.ANALOG_OUT2):
             description = next(d for d in SENSORS if d.key == key)
             assert description.device_class == SensorDeviceClass.VOLTAGE
@@ -825,9 +833,10 @@ class TestAnalogOutScaling:
 
 class TestVentilationFanScaling:
     """The fan outputs share the analog outputs' per-mille encoding but are
-    reported as a modulation percentage, which is what the controller's
-    ventilation stages are set in - so the datatype is the whole conversion
-    and no `factor` belongs here. Raw values from #729's LWC407."""
+    reported as a modulation percentage without a `factor`: the value handed
+    out is the undivided register, and #729's controller displays 3.25 V where
+    this integration shows 32.5 - correct as percent of the 10 V scale, ten
+    times too large as volts. Raw values from that LWC407."""
 
     def test_supply_fan_scaling(self):
         """340 in the reduced ventilation stage."""


### PR DESCRIPTION
## 📋 Summary

Parameters 960-963 (the four DIN 1946-6 ventilation stages) were exposed read-only and deliberately unitless in #745, because the register could equally have been m³/h or per mille of the fan setpoint. Follow-up measurements in #729 settle it: they are the configured airflow in **m³/h**.

This adds the unit and device class. **The value itself does not change** — the register is still passed through with no conversion and no `factor`.

## 🔬 Evidence

#729's LWC407 is configured for a 400 m³/h unit. Stage registers read against the fan outputs at the same moments:

| Stage | Register | ÷ 400 | Fan output in that stage |
|---|---|---|---|
| Humidity protection (960) | 130 | 32.5 % | 32.5 |
| Reduced (961) | 200 | 50.0 % | 50.0 |
| Nominal (962) | 250 | 62.5 % | 62.5 |

Three operating points where stage ÷ unit size lands exactly on the fan output. Per mille of the fan setpoint would not produce that relationship.

Intensive (963) was never observed — that stage is not reachable through the mode parameter on that controller — so it rides on the other three. Noted in both the code comment and the test.

## 🔒 Still read-only

One system, one unit size, and one unobserved stage. A `number` entity would have to commit to the scale before writing real airflow into someone's house; a wrong unit on a sensor is a label, a wrong unit on a write is not.

## 🇩🇪 German party mode

`party` renamed from **"Hochleistung"** to **"Party"** across all five German selects — `ventilation_mode`, `heating_mode`, `dhw_mode` and `heating_mode_mk1/2/3`.

The reporter checked the controller directly: the ventilation, heating and DHW Betriebsart pages all display "Party" in the hardware's own German UI, so someone looking for the mode they know from the unit would not find it under "Hochleistung". MK1-3 follow for consistency — same option set as the main heating select — though those pages were not checked separately.

`second_heatsource` is left as "Zweiter Wärmeerzeuger"; the controller shows the truncated "Zus. Wärmeerz", which is a display constraint HA does not share. The other four languages already said "Party".

## 📝 Comment corrections

Two comments asserted things that later measurements in the same issue contradicted:

- The fan block claimed the outputs *"never reach 0 and do not follow the unit being switched off"*. They do — 68.7 % → 0.0 % within 12 minutes, with the controller reporting `Ventilation: Aus`. The "… setpoint" naming stays (the reporter agrees it fits), but the justification is replaced with the argument that actually settles the unit: the integration hands out the **undivided** register, and the controller displays 3.25 V where HA shows 32.5. Labelled V that reads as 32.5 volts, ten times the real output; as % it is correct.
- The AnalogOut docstring said the diagnostics dumps *"cannot settle volts vs percent"*. The controller's web UI does: `AnalogOut2 85.0 → 8.50 V`, `AnalogOut3 50.0 → 5.00 V`, `AnalogOut1 0.0 → 0.00 V`. Now cited instead of left open.

No behaviour changes from either — same units, same values as 2026.08.12.

## ✅ Checks

- `pytest --cov=custom_components.luxtronik2` → **970 passed, 100 % coverage**
- `ruff check` / `ruff format --check` clean
- `basedpyright` 0 errors

Refs #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)
