### PR TITLE
feat(text): ✨ add heating and ventilation timer program entities

### DIFF
--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -992,6 +992,17 @@ class SensorKey(StrEnum):
     TIMER_HEATING_SCHEDULE_SATURDAY = "timer_heating_schedule_saturday"
     TIMER_HEATING_SCHEDULE_SUNDAY = "timer_heating_schedule_sunday"
 
+    TIMER_VENTILATION_SCHEDULE_WEEK = "timer_ventilation_schedule_week"
+    TIMER_VENTILATION_SCHEDULE_WEEKDAY = "timer_ventilation_schedule_weekday"
+    TIMER_VENTILATION_SCHEDULE_WEEKEND = "timer_ventilation_schedule_weekend"
+    TIMER_VENTILATION_SCHEDULE_MONDAY = "timer_ventilation_schedule_monday"
+    TIMER_VENTILATION_SCHEDULE_TUESDAY = "timer_ventilation_schedule_tuesday"
+    TIMER_VENTILATION_SCHEDULE_WEDNESDAY = "timer_ventilation_schedule_wednesday"
+    TIMER_VENTILATION_SCHEDULE_THURSDAY = "timer_ventilation_schedule_thursday"
+    TIMER_VENTILATION_SCHEDULE_FRIDAY = "timer_ventilation_schedule_friday"
+    TIMER_VENTILATION_SCHEDULE_SATURDAY = "timer_ventilation_schedule_saturday"
+    TIMER_VENTILATION_SCHEDULE_SUNDAY = "timer_ventilation_schedule_sunday"
+
 
 # endregion Keys
 

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -981,6 +981,17 @@ class SensorKey(StrEnum):
     TIMER_DHW_SCHEDULE_SATURDAY = "timer_dhw_schedule_saturday"
     TIMER_DHW_SCHEDULE_SUNDAY = "timer_dhw_schedule_sunday"
 
+    TIMER_HEATING_SCHEDULE_WEEK = "timer_heating_schedule_week"
+    TIMER_HEATING_SCHEDULE_WEEKDAY = "timer_heating_schedule_weekday"
+    TIMER_HEATING_SCHEDULE_WEEKEND = "timer_heating_schedule_weekend"
+    TIMER_HEATING_SCHEDULE_MONDAY = "timer_heating_schedule_monday"
+    TIMER_HEATING_SCHEDULE_TUESDAY = "timer_heating_schedule_tuesday"
+    TIMER_HEATING_SCHEDULE_WEDNESDAY = "timer_heating_schedule_wednesday"
+    TIMER_HEATING_SCHEDULE_THURSDAY = "timer_heating_schedule_thursday"
+    TIMER_HEATING_SCHEDULE_FRIDAY = "timer_heating_schedule_friday"
+    TIMER_HEATING_SCHEDULE_SATURDAY = "timer_heating_schedule_saturday"
+    TIMER_HEATING_SCHEDULE_SUNDAY = "timer_heating_schedule_sunday"
+
 
 # endregion Keys
 

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -403,6 +403,7 @@ class LuxParameter(StrEnum):
     P0002_DHW_TARGET_TEMPERATURE = "parameters.ID_Einst_BWS_akt"
     P0003_MODE_HEATING = "parameters.ID_Ba_Hz_akt"
     P0004_MODE_DHW = "parameters.ID_Ba_Bw_akt"
+    P0222_TIMER_PROGRAM_HEATING = "parameters.ID_Einst_SuHkr_akt"
     P0405_TIMER_PROGRAM_DHW = "parameters.ID_Einst_SUBW_akt2"
     # luxtronik*_heating_curve*
     P0011_HEATING_CURVE_END_TEMPERATURE = "parameters.ID_Einst_HzHwHKE_akt"
@@ -503,6 +504,7 @@ class LuxParameter(StrEnum):
     # from the heating/DHW mode numbering, which also has second_heatsource.
     # Irrelevant to the select, which works on the library's decoded strings.
     P0894_VENTILATION_MODE = "parameters.ID_Einst_BA_Lueftung_akt"
+    P0895_TIMER_PROGRAM_VENTILATION = "parameters.ID_Einst_SuLuf_akt"
     # The four DIN 1946-6 ventilation stages. Both the pinned library and
     # upstream's rewrite type these as Unknown/UINT32 and non-writeable, so
     # the value is the raw register with no conversion and the unit is
@@ -970,6 +972,8 @@ class SensorKey(StrEnum):
     EXTRA_DHW_DURATION = "extra_dhw_duration"
 
     TIMER_DHW_PROGRAM = "timer_dhw_program"
+    TIMER_HEATING_PROGRAM = "timer_heating_program"
+    TIMER_VENTILATION_PROGRAM = "timer_ventilation_program"
     TIMER_DHW_SCHEDULE_WEEK = "timer_dhw_schedule_week"
     TIMER_DHW_SCHEDULE_WEEKDAY = "timer_dhw_schedule_weekday"
     TIMER_DHW_SCHEDULE_WEEKEND = "timer_dhw_schedule_weekend"

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -117,6 +117,8 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         self.device_infos = dict[str, DeviceInfo]()
         # Deadline for the DHW transition hold; see _update_dhw_transition_hold().
         self._dhw_hold_until: datetime | None = None
+        # Latch for the ventilation module; see has_ventilation.
+        self._ventilation_detected = False
 
         update_interval: timedelta = DEFAULT_UPDATE_INTERVAL
         raw = config.get(CONF_UPDATE_INTERVAL)
@@ -723,14 +725,32 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         Sentinels are therefore treated as absent readings rather than as
         values, the same shape as _detect_solar_present()'s 5.0 / 150.0
         checks.
+
+        Latched on: once a plausible reading has been seen, this stays True
+        for the lifetime of the config entry. The evidence is a live
+        temperature, so it can legitimately land on a sentinel later -- a
+        supply-air channel genuinely passing through 0.0 or 5.0 C while the
+        exhaust channel is an unwired 5.0 makes both look absent for that
+        poll. Without the latch the device would come and go across polls,
+        and `text.py` (the only per-poll caller of `entity_active`) would
+        tear its schedule entities down and rebuild them each time. The
+        other capability gates do not need this: `has_domestic_water` and
+        `has_cooling` read cumulative operating-hour counters, which cannot
+        decrease.
+
+        Not persisted, so a restart re-detects from scratch. That also
+        clears the latch if the module is genuinely removed.
         """
-        return any(
+        if self._ventilation_detected:
+            return True
+        self._ventilation_detected = any(
             self._is_plausible_reading(self.get_value(key))
             for key in (
                 LC.C0159_VENTILATION_SUPPLY_AIR_TEMPERATURE,
                 LC.C0160_VENTILATION_EXHAUST_AIR_TEMPERATURE,
             )
         )
+        return self._ventilation_detected
 
     @staticmethod
     def _is_plausible_reading(value: Any) -> bool:

--- a/custom_components/luxtronik2/lux_overrides.py
+++ b/custom_components/luxtronik2/lux_overrides.py
@@ -236,9 +236,14 @@ def update_Luxtronik_Parameters():
     update_Luxtronik_Parameter_Classes(delta_temperature_numbers, Kelvin)
 
     # Timer program schedule parameters: mostly TimeOfDay entries, with a
-    # handful of TimerProgram mode selectors interspersed in the range.
-    timer_program_numbers = {222, 283, 344, 405, 506, 607}
-    time_of_day_numbers = [n for n in range(162, 668) if n not in timer_program_numbers]
+    # handful of TimerProgram mode selectors interspersed. 162-667 holds the
+    # heating, mixing, DHW, circulation-pump and pool circuits; the
+    # ventilation circuit sits apart at 895 (selector) and 896-955 (times).
+    timer_program_numbers = {222, 283, 344, 405, 506, 607, 895}
+    schedule_numbers = list(range(162, 668)) + list(range(895, 956))
+    time_of_day_numbers = [
+        n for n in schedule_numbers if n not in timer_program_numbers
+    ]
     update_Luxtronik_Parameter_Classes(time_of_day_numbers, TimeOfDay)
     update_Luxtronik_Parameter_Classes(list(timer_program_numbers), TimerProgram)
 

--- a/custom_components/luxtronik2/lux_overrides.py
+++ b/custom_components/luxtronik2/lux_overrides.py
@@ -88,7 +88,17 @@ class FrequencyAutomatic(Base):
 
 
 class TimeOfDay(Base):
-    """TimeOfDay datatype, converts from and to TimeOfDay."""
+    """TimeOfDay datatype, converts from and to TimeOfDay.
+
+    Always renders "HH:MM". The registers this covers are timer-program
+    schedule times, and the heat pump's own controller can only set those to
+    a whole minute, so a raw value carrying seconds is a register artefact
+    rather than a setting anyone made. Rendering it as "HH:MM:SS" would only
+    widen the string past what the consuming text entities allow. The seconds
+    are dropped on display only: `to_heatpump` still accepts them, and an
+    untouched row is never written back, so the raw value on the device is
+    left as it is.
+    """
 
     datatype_class = "timeofday"
 
@@ -98,9 +108,8 @@ class TimeOfDay(Base):
             return None
         hours = value // 3600
         minutes = (value // 60) % 60
-        seconds = value % 60
 
-        return f"{hours:02d}:{minutes:02d}" + (f":{seconds:02d}" if seconds > 0 else "")
+        return f"{hours:02d}:{minutes:02d}"
 
     @classmethod
     def to_heatpump(cls, value):

--- a/custom_components/luxtronik2/select.py
+++ b/custom_components/luxtronik2/select.py
@@ -241,6 +241,11 @@ class LuxtronikModeSelector(
             for option, raw in self._option_to_raw.items()
         }
         self._attr_current_option = None
+        # Raw values already reported as unrecognised. The coordinator polls
+        # every few seconds, so a register whose code mapping is simply wrong
+        # for this controller would otherwise log the same warning forever;
+        # each distinct value is worth exactly one.
+        self._reported_unknown_raw: set[str] = set()
 
         prefix = entry.data[CONF_HA_SENSOR_PREFIX]
         self.entity_id = ENTITY_ID_FORMAT.format(f"{prefix}_{description.key}")
@@ -268,12 +273,14 @@ class LuxtronikModeSelector(
         )
 
         if current not in self._attr_options:
-            LOGGER.warning(
-                "%s value %r not in options %r",
-                self.entity_id,
-                current_raw,
-                self._attr_options,
-            )
+            if current_raw not in self._reported_unknown_raw:
+                self._reported_unknown_raw.add(current_raw)
+                LOGGER.warning(
+                    "%s value %r not in options %r",
+                    self.entity_id,
+                    current_raw,
+                    self._attr_options,
+                )
             return
 
         if self._attr_current_option != current:

--- a/custom_components/luxtronik2/select_entities_predefined.py
+++ b/custom_components/luxtronik2/select_entities_predefined.py
@@ -85,6 +85,22 @@ SELECT_ENTITIES: list[LuxtronikSelectEntityDescription] = [
         raw_option_map=TIMER_PROGRAM_RAW_OPTIONS,
     ),
     LuxtronikSelectEntityDescription(
+        key=SK.TIMER_HEATING_PROGRAM,
+        device_key=DeviceKey.heating,
+        luxtronik_key=LuxParameter.P0222_TIMER_PROGRAM_HEATING,
+        entity_category=EntityCategory.CONFIG,
+        options=timer_program_options,
+        raw_option_map=TIMER_PROGRAM_RAW_OPTIONS,
+    ),
+    LuxtronikSelectEntityDescription(
+        key=SK.TIMER_VENTILATION_PROGRAM,
+        device_key=DeviceKey.ventilation,
+        luxtronik_key=LuxParameter.P0895_TIMER_PROGRAM_VENTILATION,
+        entity_category=EntityCategory.CONFIG,
+        options=timer_program_options,
+        raw_option_map=TIMER_PROGRAM_RAW_OPTIONS,
+    ),
+    LuxtronikSelectEntityDescription(
         key=SK.HEATING_MODE_SELECTOR,
         device_key=DeviceKey.heating,
         luxtronik_key=LuxParameter.P0003_MODE_HEATING,

--- a/custom_components/luxtronik2/text.py
+++ b/custom_components/luxtronik2/text.py
@@ -387,7 +387,9 @@ class LuxtronikTimerScheduleText(
         self._attr_unique_id = self.entity_id
         self._attr_mode = TextMode.TEXT
         self._attr_native_min = 0
-        # Each "HH:MM-HH:MM" pair is 11 chars, joined by a single "/".
+        # Each "HH:MM-HH:MM" pair is 11 chars, joined by a single "/". The
+        # width is guaranteed by the `TimeOfDay` datatype, which always
+        # renders "HH:MM" - see its docstring in `lux_overrides`.
         self._attr_native_max = len(description.row_names) * 12 - 1
         self._attr_native_value = None
 

--- a/custom_components/luxtronik2/text.py
+++ b/custom_components/luxtronik2/text.py
@@ -51,46 +51,54 @@ def _timer_schedule_unique_id(
 def _active_schedule_descriptions(
     coordinator: LuxtronikCoordinator,
     data: LuxtronikCoordinatorData | None,
-) -> list[LuxtronikTimerScheduleTextDescription] | None:
-    """Return the schedule blocks belonging to the circuit's active program.
+) -> tuple[list[LuxtronikTimerScheduleTextDescription], set[str]] | None:
+    """Return the active schedule blocks and the unreadable selectors.
 
-    A block qualifies when the circuit's mode selector is present on this
+    A block qualifies when its circuit's mode selector is present on this
     controller and its value equals the block's `active_mode`. Every other
     block is meaningless on the device, so no entity is created for it.
 
-    Returns ``None`` -- "no information this poll", as opposed to an empty
-    list meaning "no block is active" -- when there is no coordinator data,
-    or when a selector that *is* present on this controller could not be
-    read. `get_sensor_data` returns ``None`` both for an absent register and
-    for a present one whose datatype could not decode the raw value
+    The second element holds the `mode_selector_name`s that could not be read
+    this poll. `get_sensor_data` returns ``None`` both for an absent register
+    and for a present one whose datatype could not decode the raw value
     (``SelectionBase`` returns ``None`` for an unrecognised code), and
-    `key_exists` cannot tell the two apart for parameter 405, which sits
-    inside upstream's defined index range. Reading a transient decode
-    failure as "no program is active" would tear down every schedule entity
-    and disable all ten registry entries until the next good poll.
+    `key_exists` cannot tell the two apart for a parameter inside upstream's
+    defined index range. Reading a transient decode failure as "no program is
+    active" would tear down that circuit's schedule entities and disable their
+    registry entries until the next good poll, so the caller leaves those
+    circuits untouched instead. The failure is per circuit: an unreadable
+    selector on one circuit must not freeze the others.
+
+    Returns ``None`` -- "no information about anything this poll" -- only when
+    there is no coordinator data at all.
     """
     if data is None:
         return None
 
     descriptions: list[LuxtronikTimerScheduleTextDescription] = []
+    unreadable: set[str] = set()
     for description in TIMER_SCHEDULE_ENTITIES:
         if not coordinator.entity_active(description):
             continue
-        selector_key = f"parameters.{description.mode_selector_name}"
+        selector_name = description.mode_selector_name
+        if selector_name in unreadable:
+            continue
+        selector_key = f"parameters.{selector_name}"
         if not key_exists(data, selector_key):
             continue
         mode = get_sensor_data(data, selector_key)
         if mode is None:
             LOGGER.debug(
                 "Timer program selector %s could not be read this poll - "
-                "leaving the schedule entities untouched",
+                "leaving its schedule entities untouched",
                 selector_key,
             )
-            return None
+            unreadable.add(selector_name)
+            continue
         if mode != description.active_mode:
             continue
         descriptions.append(description)
-    return descriptions
+    return descriptions, unreadable
 
 
 class _TimerScheduleSync:
@@ -101,7 +109,10 @@ class _TimerScheduleSync:
     area, icon and recorder history survive a program switch -- removing the
     registry entry would discard all of it. (An earlier build hid the
     inactive entries instead; see `_enable_active`/`_disable_inactive` for
-    the one-time migration off that mechanism.)
+    the one-time migration off that mechanism.) The exception is a circuit
+    whose mode selector could not be read this poll: its blocks are left
+    exactly as they were, neither removed nor disabled, since a transient
+    decode failure is not evidence that the circuit's program changed.
     """
 
     def __init__(
@@ -154,20 +165,34 @@ class _TimerScheduleSync:
         of acting on a stale snapshot -- otherwise it could compute `desired`
         and mutate `self._entities` concurrently with the in-flight call,
         risking a duplicate registration for the same key.
+
+        A circuit whose mode selector could not be read this poll is frozen:
+        its blocks are excluded from both `to_remove` and the disable pass,
+        so they survive untouched until a poll can actually read that
+        selector again.
         """
         if self._closing:
             return
         async with self._lock:
             if self._closing:
                 return
-            active = _active_schedule_descriptions(
+            result = _active_schedule_descriptions(
                 self.coordinator, self.coordinator.data
             )
-            if active is None:
+            if result is None:
                 # Nothing could be concluded this poll: do not add, remove or
                 # write anything.
                 return
+            active, unreadable = result
             desired = {description.key: description for description in active}
+            # A circuit whose selector could not be read keeps whatever it
+            # has: its blocks are neither removed nor disabled, because we
+            # cannot tell which of them the device is actually running.
+            frozen = {
+                description.key
+                for description in TIMER_SCHEDULE_ENTITIES
+                if description.mode_selector_name in unreadable
+            }
             to_add = [
                 description
                 for key, description in desired.items()
@@ -176,7 +201,7 @@ class _TimerScheduleSync:
             to_remove = [
                 (key, entity)
                 for key, entity in self._entities.items()
-                if key not in desired
+                if key not in desired and key not in frozen
             ]
             if not to_add and not to_remove:
                 return
@@ -206,7 +231,7 @@ class _TimerScheduleSync:
                 del self._entities[key]
                 await self._async_remove_entity(key, entity)
 
-            self._disable_inactive(registry, set(desired))
+            self._disable_inactive(registry, set(desired) | frozen)
 
     async def _async_remove_entity(
         self, key: str, entity: LuxtronikTimerScheduleText

--- a/custom_components/luxtronik2/timer_schedule_entities_predefined.py
+++ b/custom_components/luxtronik2/timer_schedule_entities_predefined.py
@@ -1,8 +1,8 @@
 """Predefined timer-program schedule text entities.
 
-Covers the DHW (Bw) and heating (Hkr) circuits. The remaining timer-program
-circuits (Mk1/Mk2/ZIP/Swb) follow the same pattern and need one
-`_TimerCircuit` instance plus translations each; see the
+Covers the DHW (Bw), heating (Hkr) and ventilation (Luf) circuits. The
+remaining timer-program circuits (Mk1/Mk2/ZIP/Swb) follow the same pattern
+and need one `_TimerCircuit` instance plus translations each; see the
 "lux-timer-program-parameter-layout" memory for their selector/prefix values.
 """
 
@@ -74,6 +74,25 @@ def _row_names_row_slot(
     )
 
 
+def _row_names_block_row_col(
+    prefix: str, rows: int, col: int
+) -> tuple[tuple[str, str], ...]:
+    """Build the (start_name, end_name) pairs for a `<0|1>_<row>_<col>` block.
+
+    The ventilation circuit names its slots ``<prefix>_zeit_<0|1>_<row>_<2*col>``
+    with the start/end index *first*, so its start times (896-925) and end
+    times (926-955) form two interleaved blocks rather than adjacent pairs.
+
+    Inferred from the parameter naming, not from a diagnostics dump: no unit
+    with a ventilation module has been sampled yet. If a dump ever shows the
+    leading index is not start/end, this function is the only thing to change.
+    """
+    return tuple(
+        (f"{prefix}_zeit_0_{row}_{2 * col}", f"{prefix}_zeit_1_{row}_{2 * col}")
+        for row in range(rows)
+    )
+
+
 # Numbers verified against a real diagnostics dump for parameters 162-667.
 _DHW_CIRCUIT = _TimerCircuit(
     mode_selector_name="ID_Einst_SUBW_akt2",
@@ -115,6 +134,28 @@ _HEATING_WEEKDAYS: tuple[tuple[SK, int], ...] = (
     (SK.TIMER_HEATING_SCHEDULE_FRIDAY, 4),
     (SK.TIMER_HEATING_SCHEDULE_SATURDAY, 5),
     (SK.TIMER_HEATING_SCHEDULE_SUNDAY, 6),
+)
+
+_VENTILATION_CIRCUIT = _TimerCircuit(
+    mode_selector_name="ID_Einst_SuLuf_akt",
+    rows=3,
+    same_schedule_prefix="ID_Einst_SuLufWo",
+    weekday_weekend_prefix="ID_Einst_SuLuf25",
+    per_day_prefix="ID_Einst_SuLufTg",
+    name_builder=_row_names_block_row_col,
+    device_key=DeviceKey.ventilation,
+)
+# The selector's week/5+2/days codes are assumed to match the other circuits;
+# see lux_overrides.update_Luxtronik_Parameters. Also inferred, not sampled.
+
+_VENTILATION_WEEKDAYS: tuple[tuple[SK, int], ...] = (
+    (SK.TIMER_VENTILATION_SCHEDULE_MONDAY, 0),
+    (SK.TIMER_VENTILATION_SCHEDULE_TUESDAY, 1),
+    (SK.TIMER_VENTILATION_SCHEDULE_WEDNESDAY, 2),
+    (SK.TIMER_VENTILATION_SCHEDULE_THURSDAY, 3),
+    (SK.TIMER_VENTILATION_SCHEDULE_FRIDAY, 4),
+    (SK.TIMER_VENTILATION_SCHEDULE_SATURDAY, 5),
+    (SK.TIMER_VENTILATION_SCHEDULE_SUNDAY, 6),
 )
 
 
@@ -188,5 +229,12 @@ TIMER_SCHEDULE_ENTITIES: list[LuxtronikTimerScheduleTextDescription] = (
         weekday_key=SK.TIMER_HEATING_SCHEDULE_WEEKDAY,
         weekend_key=SK.TIMER_HEATING_SCHEDULE_WEEKEND,
         day_keys=_HEATING_WEEKDAYS,
+    )
+    + _build_circuit_entities(
+        _VENTILATION_CIRCUIT,
+        week_key=SK.TIMER_VENTILATION_SCHEDULE_WEEK,
+        weekday_key=SK.TIMER_VENTILATION_SCHEDULE_WEEKDAY,
+        weekend_key=SK.TIMER_VENTILATION_SCHEDULE_WEEKEND,
+        day_keys=_VENTILATION_WEEKDAYS,
     )
 )

--- a/custom_components/luxtronik2/timer_schedule_entities_predefined.py
+++ b/custom_components/luxtronik2/timer_schedule_entities_predefined.py
@@ -30,14 +30,16 @@ class _TimerCircuit:
     - ``per_day_prefix`` ("TG"/"Tg", German "täglich"): a separate,
       independently editable schedule for each individual day of the week.
 
-    Each prefix is also the parameter-name prefix: the firmware exposes the
-    actual start/end times as ``<prefix>_zeit_<row>_<slot>``, where ``row``
-    is the schedule slot within a day (0-based, up to `rows` per day) and
-    ``slot`` is an even number for the start time and that same number + 1
-    for its matching end time. For the weekday/weekend and per-day blocks,
-    ``slot`` also encodes which day-group the row belongs to
-    (``slot = 2 * column``, where ``column`` is 0/1 for weekday/weekend, or
-    0-6 for Monday-Sunday) -- see `_row_names_row_slot` below.
+    Each prefix is also the parameter-name prefix under which the firmware
+    exposes the actual start/end times, but the circuits do not agree on the
+    name shape that follows it: DHW and heating use
+    ``<prefix>_zeit_<row>_<slot>`` while ventilation uses
+    ``<prefix>_zeit_<0|1>_<row>_<2*col>``. Which one applies is decided per
+    circuit by `name_builder` below -- see the two `_row_names_*` functions
+    for each layout. Common to both: ``row`` is the schedule slot within a
+    day (0-based, up to `rows` per day) and ``column`` is 0 for the
+    same-schedule block, 0/1 for weekday/weekend, and 0-6 for
+    Monday-Sunday.
     """
 
     #: Raw parameter name of the mode selector that picks which of the three

--- a/custom_components/luxtronik2/timer_schedule_entities_predefined.py
+++ b/custom_components/luxtronik2/timer_schedule_entities_predefined.py
@@ -1,11 +1,12 @@
 """Predefined timer-program schedule text entities.
 
-Only the DHW (Bw) circuit is wired up so far, to validate the approach
-before rolling out to the other 5 timer-program circuits (Hkr/Mk1/Mk2/ZIP/
-Swb). See the "lux-timer-program-parameter-layout" memory for their
-selector/prefix values once this is extended.
+Covers the DHW (Bw) and heating (Hkr) circuits. The remaining timer-program
+circuits (Mk1/Mk2/ZIP/Swb) follow the same pattern and need one
+`_TimerCircuit` instance plus translations each; see the
+"lux-timer-program-parameter-layout" memory for their selector/prefix values.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from homeassistant.const import EntityCategory
@@ -36,7 +37,7 @@ class _TimerCircuit:
     for its matching end time. For the weekday/weekend and per-day blocks,
     ``slot`` also encodes which day-group the row belongs to
     (``slot = 2 * column``, where ``column`` is 0/1 for weekday/weekend, or
-    0-6 for Monday-Sunday) -- see `_row_names` below.
+    0-6 for Monday-Sunday) -- see `_row_names_row_slot` below.
     """
 
     #: Raw parameter name of the mode selector that picks which of the three
@@ -50,7 +51,27 @@ class _TimerCircuit:
     same_schedule_prefix: str
     weekday_weekend_prefix: str
     per_day_prefix: str
+    #: Builds the (start_name, end_name) pairs for one block. Circuits do not
+    #: share a single naming scheme, so the layout is per circuit -- see the
+    #: two `_row_names_*` functions. Deliberately has no default: a default
+    #: here would make it a class attribute and bind as a method on access.
+    name_builder: Callable[[str, int, int], tuple[tuple[str, str], ...]]
     device_key: DeviceKey
+
+
+def _row_names_row_slot(
+    prefix: str, rows: int, col: int
+) -> tuple[tuple[str, str], ...]:
+    """Build the (start_name, end_name) pairs for a `<row>_<slot>` block.
+
+    Matches the firmware's ``<prefix>_zeit_<row>_<slot>`` numbering, where
+    slot is ``2*col`` (start) / ``2*col + 1`` (end). Used by the DHW and
+    heating circuits.
+    """
+    return tuple(
+        (f"{prefix}_zeit_{row}_{2 * col}", f"{prefix}_zeit_{row}_{2 * col + 1}")
+        for row in range(rows)
+    )
 
 
 # Numbers verified against a real diagnostics dump for parameters 162-667.
@@ -60,6 +81,7 @@ _DHW_CIRCUIT = _TimerCircuit(
     same_schedule_prefix="ID_Einst_SuBwWO",
     weekday_weekend_prefix="ID_Einst_SuBw25",
     per_day_prefix="ID_Einst_SuBwTG",
+    name_builder=_row_names_row_slot,
     device_key=DeviceKey.domestic_water,
 )
 
@@ -73,17 +95,27 @@ _DHW_WEEKDAYS: tuple[tuple[SK, int], ...] = (
     (SK.TIMER_DHW_SCHEDULE_SUNDAY, 6),
 )
 
+_HEATING_CIRCUIT = _TimerCircuit(
+    mode_selector_name="ID_Einst_SuHkr_akt",
+    rows=3,
+    # `W0` ends in a digit zero and `TG` is uppercase: these are the upstream
+    # library's literal names and differ from the DHW spellings.
+    same_schedule_prefix="ID_Einst_SuHkrW0",
+    weekday_weekend_prefix="ID_Einst_SuHkr25",
+    per_day_prefix="ID_Einst_SuHkrTG",
+    name_builder=_row_names_row_slot,
+    device_key=DeviceKey.heating,
+)
 
-def _row_names(prefix: str, rows: int, col: int) -> tuple[tuple[str, str], ...]:
-    """Build the ordered (start_name, end_name) pairs for one schedule block.
-
-    Matches the firmware's ``<prefix>_zeit_<row>_<slot>`` numbering, where
-    slot is ``2*col`` (start) / ``2*col + 1`` (end).
-    """
-    return tuple(
-        (f"{prefix}_zeit_{row}_{2 * col}", f"{prefix}_zeit_{row}_{2 * col + 1}")
-        for row in range(rows)
-    )
+_HEATING_WEEKDAYS: tuple[tuple[SK, int], ...] = (
+    (SK.TIMER_HEATING_SCHEDULE_MONDAY, 0),
+    (SK.TIMER_HEATING_SCHEDULE_TUESDAY, 1),
+    (SK.TIMER_HEATING_SCHEDULE_WEDNESDAY, 2),
+    (SK.TIMER_HEATING_SCHEDULE_THURSDAY, 3),
+    (SK.TIMER_HEATING_SCHEDULE_FRIDAY, 4),
+    (SK.TIMER_HEATING_SCHEDULE_SATURDAY, 5),
+    (SK.TIMER_HEATING_SCHEDULE_SUNDAY, 6),
+)
 
 
 def _build_circuit_entities(
@@ -101,7 +133,9 @@ def _build_circuit_entities(
             entity_category=EntityCategory.CONFIG,
             mode_selector_name=circuit.mode_selector_name,
             active_mode="week",
-            row_names=_row_names(circuit.same_schedule_prefix, circuit.rows, 0),
+            row_names=circuit.name_builder(
+                circuit.same_schedule_prefix, circuit.rows, 0
+            ),
         ),
         LuxtronikTimerScheduleTextDescription(
             key=weekday_key,
@@ -109,7 +143,9 @@ def _build_circuit_entities(
             entity_category=EntityCategory.CONFIG,
             mode_selector_name=circuit.mode_selector_name,
             active_mode="5+2",
-            row_names=_row_names(circuit.weekday_weekend_prefix, circuit.rows, 0),
+            row_names=circuit.name_builder(
+                circuit.weekday_weekend_prefix, circuit.rows, 0
+            ),
         ),
         LuxtronikTimerScheduleTextDescription(
             key=weekend_key,
@@ -117,7 +153,9 @@ def _build_circuit_entities(
             entity_category=EntityCategory.CONFIG,
             mode_selector_name=circuit.mode_selector_name,
             active_mode="5+2",
-            row_names=_row_names(circuit.weekday_weekend_prefix, circuit.rows, 1),
+            row_names=circuit.name_builder(
+                circuit.weekday_weekend_prefix, circuit.rows, 1
+            ),
         ),
     ]
     entities.extend(
@@ -127,7 +165,9 @@ def _build_circuit_entities(
             entity_category=EntityCategory.CONFIG,
             mode_selector_name=circuit.mode_selector_name,
             active_mode="days",
-            row_names=_row_names(circuit.per_day_prefix, circuit.rows, day_index),
+            row_names=circuit.name_builder(
+                circuit.per_day_prefix, circuit.rows, day_index
+            ),
         )
         for day_key, day_index in day_keys
     )
@@ -141,5 +181,12 @@ TIMER_SCHEDULE_ENTITIES: list[LuxtronikTimerScheduleTextDescription] = (
         weekday_key=SK.TIMER_DHW_SCHEDULE_WEEKDAY,
         weekend_key=SK.TIMER_DHW_SCHEDULE_WEEKEND,
         day_keys=_DHW_WEEKDAYS,
+    )
+    + _build_circuit_entities(
+        _HEATING_CIRCUIT,
+        week_key=SK.TIMER_HEATING_SCHEDULE_WEEK,
+        weekday_key=SK.TIMER_HEATING_SCHEDULE_WEEKDAY,
+        weekend_key=SK.TIMER_HEATING_SCHEDULE_WEEKEND,
+        day_keys=_HEATING_WEEKDAYS,
     )
 )

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -1085,6 +1085,22 @@
                     "daily": "Jednotliv\u00e9 dny"
                 }
             },
+            "timer_heating_program": {
+                "name": "\u010casov\u00fd program vyt\u00e1p\u011bn\u00ed",
+                "state": {
+                    "week": "Cel\u00fd t\u00fdden",
+                    "weekday_weekend": "Pracovn\u00ed dny + v\u00edkend",
+                    "daily": "Jednotliv\u00e9 dny"
+                }
+            },
+            "timer_ventilation_program": {
+                "name": "\u010casov\u00fd program v\u011btr\u00e1n\u00ed",
+                "state": {
+                    "week": "Cel\u00fd t\u00fdden",
+                    "weekday_weekend": "Pracovn\u00ed dny + v\u00edkend",
+                    "daily": "Jednotliv\u00e9 dny"
+                }
+            },
             "pv_mode_selector": {
                 "name": "PV re\u017eim",
                 "state": {

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -1022,6 +1022,36 @@
             },
             "timer_heating_schedule_sunday": {
                 "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (ned\u011ble)"
+            },
+            "timer_ventilation_schedule_week": {
+                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (t\u00fdden)"
+            },
+            "timer_ventilation_schedule_weekday": {
+                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (pracovn\u00ed dny)"
+            },
+            "timer_ventilation_schedule_weekend": {
+                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (v\u00edkend)"
+            },
+            "timer_ventilation_schedule_monday": {
+                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (pond\u011bl\u00ed)"
+            },
+            "timer_ventilation_schedule_tuesday": {
+                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (\u00fater\u00fd)"
+            },
+            "timer_ventilation_schedule_wednesday": {
+                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (st\u0159eda)"
+            },
+            "timer_ventilation_schedule_thursday": {
+                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (\u010dtvrtek)"
+            },
+            "timer_ventilation_schedule_friday": {
+                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (p\u00e1tek)"
+            },
+            "timer_ventilation_schedule_saturday": {
+                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (sobota)"
+            },
+            "timer_ventilation_schedule_sunday": {
+                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (ned\u011ble)"
             }
         },
         "select": {

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -992,6 +992,36 @@
             },
             "timer_dhw_schedule_sunday": {
                 "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (ned\u011ble)"
+            },
+            "timer_heating_schedule_week": {
+                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (t\u00fdden)"
+            },
+            "timer_heating_schedule_weekday": {
+                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (pracovn\u00ed dny)"
+            },
+            "timer_heating_schedule_weekend": {
+                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (v\u00edkend)"
+            },
+            "timer_heating_schedule_monday": {
+                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (pond\u011bl\u00ed)"
+            },
+            "timer_heating_schedule_tuesday": {
+                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (\u00fater\u00fd)"
+            },
+            "timer_heating_schedule_wednesday": {
+                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (st\u0159eda)"
+            },
+            "timer_heating_schedule_thursday": {
+                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (\u010dtvrtek)"
+            },
+            "timer_heating_schedule_friday": {
+                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (p\u00e1tek)"
+            },
+            "timer_heating_schedule_saturday": {
+                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (sobota)"
+            },
+            "timer_heating_schedule_sunday": {
+                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (ned\u011ble)"
             }
         },
         "select": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -994,64 +994,64 @@
                 "name": "Warmwasser-Zeitschaltplan (Sonntag)"
             },
             "timer_heating_schedule_week": {
-                "name": "Heizung-Zeitschaltplan (Woche)"
+                "name": "Heizungs-Zeitschaltplan (Woche)"
             },
             "timer_heating_schedule_weekday": {
-                "name": "Heizung-Zeitschaltplan (Werktage)"
+                "name": "Heizungs-Zeitschaltplan (Werktage)"
             },
             "timer_heating_schedule_weekend": {
-                "name": "Heizung-Zeitschaltplan (Wochenende)"
+                "name": "Heizungs-Zeitschaltplan (Wochenende)"
             },
             "timer_heating_schedule_monday": {
-                "name": "Heizung-Zeitschaltplan (Montag)"
+                "name": "Heizungs-Zeitschaltplan (Montag)"
             },
             "timer_heating_schedule_tuesday": {
-                "name": "Heizung-Zeitschaltplan (Dienstag)"
+                "name": "Heizungs-Zeitschaltplan (Dienstag)"
             },
             "timer_heating_schedule_wednesday": {
-                "name": "Heizung-Zeitschaltplan (Mittwoch)"
+                "name": "Heizungs-Zeitschaltplan (Mittwoch)"
             },
             "timer_heating_schedule_thursday": {
-                "name": "Heizung-Zeitschaltplan (Donnerstag)"
+                "name": "Heizungs-Zeitschaltplan (Donnerstag)"
             },
             "timer_heating_schedule_friday": {
-                "name": "Heizung-Zeitschaltplan (Freitag)"
+                "name": "Heizungs-Zeitschaltplan (Freitag)"
             },
             "timer_heating_schedule_saturday": {
-                "name": "Heizung-Zeitschaltplan (Samstag)"
+                "name": "Heizungs-Zeitschaltplan (Samstag)"
             },
             "timer_heating_schedule_sunday": {
-                "name": "Heizung-Zeitschaltplan (Sonntag)"
+                "name": "Heizungs-Zeitschaltplan (Sonntag)"
             },
             "timer_ventilation_schedule_week": {
-                "name": "Lüftung-Zeitschaltplan (Woche)"
+                "name": "L\u00fcftungs-Zeitschaltplan (Woche)"
             },
             "timer_ventilation_schedule_weekday": {
-                "name": "Lüftung-Zeitschaltplan (Werktage)"
+                "name": "L\u00fcftungs-Zeitschaltplan (Werktage)"
             },
             "timer_ventilation_schedule_weekend": {
-                "name": "Lüftung-Zeitschaltplan (Wochenende)"
+                "name": "L\u00fcftungs-Zeitschaltplan (Wochenende)"
             },
             "timer_ventilation_schedule_monday": {
-                "name": "Lüftung-Zeitschaltplan (Montag)"
+                "name": "L\u00fcftungs-Zeitschaltplan (Montag)"
             },
             "timer_ventilation_schedule_tuesday": {
-                "name": "Lüftung-Zeitschaltplan (Dienstag)"
+                "name": "L\u00fcftungs-Zeitschaltplan (Dienstag)"
             },
             "timer_ventilation_schedule_wednesday": {
-                "name": "Lüftung-Zeitschaltplan (Mittwoch)"
+                "name": "L\u00fcftungs-Zeitschaltplan (Mittwoch)"
             },
             "timer_ventilation_schedule_thursday": {
-                "name": "Lüftung-Zeitschaltplan (Donnerstag)"
+                "name": "L\u00fcftungs-Zeitschaltplan (Donnerstag)"
             },
             "timer_ventilation_schedule_friday": {
-                "name": "Lüftung-Zeitschaltplan (Freitag)"
+                "name": "L\u00fcftungs-Zeitschaltplan (Freitag)"
             },
             "timer_ventilation_schedule_saturday": {
-                "name": "Lüftung-Zeitschaltplan (Samstag)"
+                "name": "L\u00fcftungs-Zeitschaltplan (Samstag)"
             },
             "timer_ventilation_schedule_sunday": {
-                "name": "Lüftung-Zeitschaltplan (Sonntag)"
+                "name": "L\u00fcftungs-Zeitschaltplan (Sonntag)"
             }
         },
         "select": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -1022,6 +1022,36 @@
             },
             "timer_heating_schedule_sunday": {
                 "name": "Heizung-Zeitschaltplan (Sonntag)"
+            },
+            "timer_ventilation_schedule_week": {
+                "name": "Lüftung-Zeitschaltplan (Woche)"
+            },
+            "timer_ventilation_schedule_weekday": {
+                "name": "Lüftung-Zeitschaltplan (Werktage)"
+            },
+            "timer_ventilation_schedule_weekend": {
+                "name": "Lüftung-Zeitschaltplan (Wochenende)"
+            },
+            "timer_ventilation_schedule_monday": {
+                "name": "Lüftung-Zeitschaltplan (Montag)"
+            },
+            "timer_ventilation_schedule_tuesday": {
+                "name": "Lüftung-Zeitschaltplan (Dienstag)"
+            },
+            "timer_ventilation_schedule_wednesday": {
+                "name": "Lüftung-Zeitschaltplan (Mittwoch)"
+            },
+            "timer_ventilation_schedule_thursday": {
+                "name": "Lüftung-Zeitschaltplan (Donnerstag)"
+            },
+            "timer_ventilation_schedule_friday": {
+                "name": "Lüftung-Zeitschaltplan (Freitag)"
+            },
+            "timer_ventilation_schedule_saturday": {
+                "name": "Lüftung-Zeitschaltplan (Samstag)"
+            },
+            "timer_ventilation_schedule_sunday": {
+                "name": "Lüftung-Zeitschaltplan (Sonntag)"
             }
         },
         "select": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -992,6 +992,36 @@
             },
             "timer_dhw_schedule_sunday": {
                 "name": "Warmwasser-Zeitschaltplan (Sonntag)"
+            },
+            "timer_heating_schedule_week": {
+                "name": "Heizung-Zeitschaltplan (Woche)"
+            },
+            "timer_heating_schedule_weekday": {
+                "name": "Heizung-Zeitschaltplan (Werktage)"
+            },
+            "timer_heating_schedule_weekend": {
+                "name": "Heizung-Zeitschaltplan (Wochenende)"
+            },
+            "timer_heating_schedule_monday": {
+                "name": "Heizung-Zeitschaltplan (Montag)"
+            },
+            "timer_heating_schedule_tuesday": {
+                "name": "Heizung-Zeitschaltplan (Dienstag)"
+            },
+            "timer_heating_schedule_wednesday": {
+                "name": "Heizung-Zeitschaltplan (Mittwoch)"
+            },
+            "timer_heating_schedule_thursday": {
+                "name": "Heizung-Zeitschaltplan (Donnerstag)"
+            },
+            "timer_heating_schedule_friday": {
+                "name": "Heizung-Zeitschaltplan (Freitag)"
+            },
+            "timer_heating_schedule_saturday": {
+                "name": "Heizung-Zeitschaltplan (Samstag)"
+            },
+            "timer_heating_schedule_sunday": {
+                "name": "Heizung-Zeitschaltplan (Sonntag)"
             }
         },
         "select": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -1085,6 +1085,22 @@
                     "daily": "Einzelne Tage"
                 }
             },
+            "timer_heating_program": {
+                "name": "Heizung Zeitprogramm",
+                "state": {
+                    "week": "Ganze Woche",
+                    "weekday_weekend": "Werktage + Wochenende",
+                    "daily": "Einzelne Tage"
+                }
+            },
+            "timer_ventilation_program": {
+                "name": "L\u00fcftung Zeitprogramm",
+                "state": {
+                    "week": "Ganze Woche",
+                    "weekday_weekend": "Werktage + Wochenende",
+                    "daily": "Einzelne Tage"
+                }
+            },
             "pv_mode_selector": {
                 "name": "PV Modus",
                 "state": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -992,6 +992,36 @@
             },
             "timer_dhw_schedule_sunday": {
                 "name": "DHW Timer Schedule (Sunday)"
+            },
+            "timer_heating_schedule_week": {
+                "name": "Heating Timer Schedule (Week)"
+            },
+            "timer_heating_schedule_weekday": {
+                "name": "Heating Timer Schedule (Weekdays)"
+            },
+            "timer_heating_schedule_weekend": {
+                "name": "Heating Timer Schedule (Weekend)"
+            },
+            "timer_heating_schedule_monday": {
+                "name": "Heating Timer Schedule (Monday)"
+            },
+            "timer_heating_schedule_tuesday": {
+                "name": "Heating Timer Schedule (Tuesday)"
+            },
+            "timer_heating_schedule_wednesday": {
+                "name": "Heating Timer Schedule (Wednesday)"
+            },
+            "timer_heating_schedule_thursday": {
+                "name": "Heating Timer Schedule (Thursday)"
+            },
+            "timer_heating_schedule_friday": {
+                "name": "Heating Timer Schedule (Friday)"
+            },
+            "timer_heating_schedule_saturday": {
+                "name": "Heating Timer Schedule (Saturday)"
+            },
+            "timer_heating_schedule_sunday": {
+                "name": "Heating Timer Schedule (Sunday)"
             }
         },
         "select": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -1022,6 +1022,36 @@
             },
             "timer_heating_schedule_sunday": {
                 "name": "Heating Timer Schedule (Sunday)"
+            },
+            "timer_ventilation_schedule_week": {
+                "name": "Ventilation Timer Schedule (Week)"
+            },
+            "timer_ventilation_schedule_weekday": {
+                "name": "Ventilation Timer Schedule (Weekdays)"
+            },
+            "timer_ventilation_schedule_weekend": {
+                "name": "Ventilation Timer Schedule (Weekend)"
+            },
+            "timer_ventilation_schedule_monday": {
+                "name": "Ventilation Timer Schedule (Monday)"
+            },
+            "timer_ventilation_schedule_tuesday": {
+                "name": "Ventilation Timer Schedule (Tuesday)"
+            },
+            "timer_ventilation_schedule_wednesday": {
+                "name": "Ventilation Timer Schedule (Wednesday)"
+            },
+            "timer_ventilation_schedule_thursday": {
+                "name": "Ventilation Timer Schedule (Thursday)"
+            },
+            "timer_ventilation_schedule_friday": {
+                "name": "Ventilation Timer Schedule (Friday)"
+            },
+            "timer_ventilation_schedule_saturday": {
+                "name": "Ventilation Timer Schedule (Saturday)"
+            },
+            "timer_ventilation_schedule_sunday": {
+                "name": "Ventilation Timer Schedule (Sunday)"
             }
         },
         "select": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -1085,6 +1085,22 @@
                     "daily": "Per day"
                 }
             },
+            "timer_heating_program": {
+                "name": "Heating timer program",
+                "state": {
+                    "week": "Whole week",
+                    "weekday_weekend": "Weekdays + weekend",
+                    "daily": "Per day"
+                }
+            },
+            "timer_ventilation_program": {
+                "name": "Ventilation timer program",
+                "state": {
+                    "week": "Whole week",
+                    "weekday_weekend": "Weekdays + weekend",
+                    "daily": "Per day"
+                }
+            },
             "pv_mode_selector": {
                 "name": "PV Mode",
                 "state": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -1085,6 +1085,22 @@
                     "daily": "Per dag"
                 }
             },
+            "timer_heating_program": {
+                "name": "Verwarming tijdprogramma",
+                "state": {
+                    "week": "Hele week",
+                    "weekday_weekend": "Werkdagen + weekend",
+                    "daily": "Per dag"
+                }
+            },
+            "timer_ventilation_program": {
+                "name": "Ventilatie tijdprogramma",
+                "state": {
+                    "week": "Hele week",
+                    "weekday_weekend": "Werkdagen + weekend",
+                    "daily": "Per dag"
+                }
+            },
             "pv_mode_selector": {
                 "name": "PV Mode",
                 "state": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -1022,6 +1022,36 @@
             },
             "timer_heating_schedule_sunday": {
                 "name": "Verwarming tijdschema (zondag)"
+            },
+            "timer_ventilation_schedule_week": {
+                "name": "Ventilatie tijdschema (week)"
+            },
+            "timer_ventilation_schedule_weekday": {
+                "name": "Ventilatie tijdschema (werkdagen)"
+            },
+            "timer_ventilation_schedule_weekend": {
+                "name": "Ventilatie tijdschema (weekend)"
+            },
+            "timer_ventilation_schedule_monday": {
+                "name": "Ventilatie tijdschema (maandag)"
+            },
+            "timer_ventilation_schedule_tuesday": {
+                "name": "Ventilatie tijdschema (dinsdag)"
+            },
+            "timer_ventilation_schedule_wednesday": {
+                "name": "Ventilatie tijdschema (woensdag)"
+            },
+            "timer_ventilation_schedule_thursday": {
+                "name": "Ventilatie tijdschema (donderdag)"
+            },
+            "timer_ventilation_schedule_friday": {
+                "name": "Ventilatie tijdschema (vrijdag)"
+            },
+            "timer_ventilation_schedule_saturday": {
+                "name": "Ventilatie tijdschema (zaterdag)"
+            },
+            "timer_ventilation_schedule_sunday": {
+                "name": "Ventilatie tijdschema (zondag)"
             }
         },
         "select": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -992,6 +992,36 @@
             },
             "timer_dhw_schedule_sunday": {
                 "name": "Warmwater tijdschema (zondag)"
+            },
+            "timer_heating_schedule_week": {
+                "name": "Verwarming tijdschema (week)"
+            },
+            "timer_heating_schedule_weekday": {
+                "name": "Verwarming tijdschema (werkdagen)"
+            },
+            "timer_heating_schedule_weekend": {
+                "name": "Verwarming tijdschema (weekend)"
+            },
+            "timer_heating_schedule_monday": {
+                "name": "Verwarming tijdschema (maandag)"
+            },
+            "timer_heating_schedule_tuesday": {
+                "name": "Verwarming tijdschema (dinsdag)"
+            },
+            "timer_heating_schedule_wednesday": {
+                "name": "Verwarming tijdschema (woensdag)"
+            },
+            "timer_heating_schedule_thursday": {
+                "name": "Verwarming tijdschema (donderdag)"
+            },
+            "timer_heating_schedule_friday": {
+                "name": "Verwarming tijdschema (vrijdag)"
+            },
+            "timer_heating_schedule_saturday": {
+                "name": "Verwarming tijdschema (zaterdag)"
+            },
+            "timer_heating_schedule_sunday": {
+                "name": "Verwarming tijdschema (zondag)"
             }
         },
         "select": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -992,6 +992,36 @@
             },
             "timer_dhw_schedule_sunday": {
                 "name": "Harmonogram czasowy ciep\u0142ej wody (niedziela)"
+            },
+            "timer_heating_schedule_week": {
+                "name": "Harmonogram czasowy ogrzewania (tydzie\u0144)"
+            },
+            "timer_heating_schedule_weekday": {
+                "name": "Harmonogram czasowy ogrzewania (dni robocze)"
+            },
+            "timer_heating_schedule_weekend": {
+                "name": "Harmonogram czasowy ogrzewania (weekend)"
+            },
+            "timer_heating_schedule_monday": {
+                "name": "Harmonogram czasowy ogrzewania (poniedzia\u0142ek)"
+            },
+            "timer_heating_schedule_tuesday": {
+                "name": "Harmonogram czasowy ogrzewania (wtorek)"
+            },
+            "timer_heating_schedule_wednesday": {
+                "name": "Harmonogram czasowy ogrzewania (\u015broda)"
+            },
+            "timer_heating_schedule_thursday": {
+                "name": "Harmonogram czasowy ogrzewania (czwartek)"
+            },
+            "timer_heating_schedule_friday": {
+                "name": "Harmonogram czasowy ogrzewania (pi\u0105tek)"
+            },
+            "timer_heating_schedule_saturday": {
+                "name": "Harmonogram czasowy ogrzewania (sobota)"
+            },
+            "timer_heating_schedule_sunday": {
+                "name": "Harmonogram czasowy ogrzewania (niedziela)"
             }
         },
         "select": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -1085,6 +1085,22 @@
                     "daily": "Poszczególne dni"
                 }
             },
+            "timer_heating_program": {
+                "name": "Program czasowy ogrzewania",
+                "state": {
+                    "week": "Cały tydzień",
+                    "weekday_weekend": "Dni robocze + weekend",
+                    "daily": "Poszczególne dni"
+                }
+            },
+            "timer_ventilation_program": {
+                "name": "Program czasowy wentylacji",
+                "state": {
+                    "week": "Cały tydzień",
+                    "weekday_weekend": "Dni robocze + weekend",
+                    "daily": "Poszczególne dni"
+                }
+            },
             "pv_mode_selector": {
                 "name": "Tryb PV",
                 "state": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -1022,6 +1022,36 @@
             },
             "timer_heating_schedule_sunday": {
                 "name": "Harmonogram czasowy ogrzewania (niedziela)"
+            },
+            "timer_ventilation_schedule_week": {
+                "name": "Harmonogram czasowy wentylacji (tydzie\u0144)"
+            },
+            "timer_ventilation_schedule_weekday": {
+                "name": "Harmonogram czasowy wentylacji (dni robocze)"
+            },
+            "timer_ventilation_schedule_weekend": {
+                "name": "Harmonogram czasowy wentylacji (weekend)"
+            },
+            "timer_ventilation_schedule_monday": {
+                "name": "Harmonogram czasowy wentylacji (poniedzia\u0142ek)"
+            },
+            "timer_ventilation_schedule_tuesday": {
+                "name": "Harmonogram czasowy wentylacji (wtorek)"
+            },
+            "timer_ventilation_schedule_wednesday": {
+                "name": "Harmonogram czasowy wentylacji (\u015broda)"
+            },
+            "timer_ventilation_schedule_thursday": {
+                "name": "Harmonogram czasowy wentylacji (czwartek)"
+            },
+            "timer_ventilation_schedule_friday": {
+                "name": "Harmonogram czasowy wentylacji (pi\u0105tek)"
+            },
+            "timer_ventilation_schedule_saturday": {
+                "name": "Harmonogram czasowy wentylacji (sobota)"
+            },
+            "timer_ventilation_schedule_sunday": {
+                "name": "Harmonogram czasowy wentylacji (niedziela)"
             }
         },
         "select": {

--- a/docs/superpowers/plans/2026-08-14-heating-ventilation-timer-schedules.md
+++ b/docs/superpowers/plans/2026-08-14-heating-ventilation-timer-schedules.md
@@ -1,0 +1,1159 @@
+# Heating and Ventilation Timer Schedules Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Roll the existing DHW timer-program entities out to the heating circuit and the ventilation module — 20 schedule text entities plus 2 program-mode selects.
+
+**Architecture:** The generic machinery already exists in `text.py` and is driven entirely by the `TIMER_SCHEDULE_ENTITIES` table in `timer_schedule_entities_predefined.py`. Two circuits get added to that table; ventilation needs a second parameter-name builder because its firmware names put the start/end index first. `text.py` itself changes only to make its "selector unreadable" bail per-circuit instead of per-pass, which only becomes wrong once more than one circuit exists. `lux_overrides.py` gains the datatype coverage for the ventilation parameter block, which sits outside the currently-covered 162-667 range.
+
+**Tech Stack:** Python 3.14, Home Assistant custom integration, `luxtronik` PyPI client library, pytest + pytest-homeassistant-custom-component, ruff, basedpyright.
+
+**Spec:** `docs/superpowers/specs/2026-08-14-heating-ventilation-timer-schedules-design.md`
+
+## Global Constraints
+
+- Use the `py314` conda env by full path for every Python command:
+  `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest`
+- **Never commit without explicit user approval** (repo rule in `CLAUDE.md`). The commit step in each task means: stage the listed files, show the message, ask, then commit.
+- Never scope `--cov` to a leaf submodule. Package root only:
+  `-m pytest --cov=custom_components.luxtronik2`
+- Branch is already created: `feat/timer-program-heating-ventilation`.
+- Commit format: `<type>(<scope>): <gitmoji> <description>`, lowercase imperative, no trailing period; body is a bullet list. End the message with
+  `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`.
+- Parameter-name prefixes are the upstream library's literal names and are **inconsistent between circuits on purpose**: heating `SuHkrW0` (digit zero) / `SuHkr25` / `SuHkrTG`; ventilation `SuLufWo` / `SuLuf25` / `SuLufTg`; DHW `SuBwWO` / `SuBw25` / `SuBwTG`. Copy them verbatim, never derive one from another.
+- All five translation files (`en`, `de`, `nl`, `cs`, `pl`) must stay in lockstep — `tests/test_translation_coverage.py` enforces it.
+- Before the final commit: `ruff check` clean, `ruff format --check` clean, `basedpyright` 0 errors, full test suite green, coverage not regressed.
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `custom_components/luxtronik2/lux_overrides.py` | Datatype coverage for the ventilation parameter block 895-955 | 1 |
+| `custom_components/luxtronik2/const.py` | New `SensorKey` and `LuxParameter` members | 2, 4, 5 |
+| `custom_components/luxtronik2/timer_schedule_entities_predefined.py` | Circuit table + the two parameter-name builders | 2, 4 |
+| `custom_components/luxtronik2/text.py` | Per-circuit bail in the active-block computation and the sync pass | 3 |
+| `custom_components/luxtronik2/select_entities_predefined.py` | The two program-mode select descriptions | 5 |
+| `custom_components/luxtronik2/translations/{en,de,nl,cs,pl}.json` | Entity names | 2, 4, 5 |
+| `tests/test_lux_overrides.py` | Datatype coverage assertions | 1 |
+| `tests/test_text.py` | Table integrity, name layouts, per-circuit bail | 2, 3, 4 |
+| `tests/test_select.py` | Program-select descriptions | 5 |
+
+---
+
+### Task 1: Ventilation datatype coverage
+
+The ventilation timer parameters live at 895-955, outside the 162-667 range the overrides currently cover, so today every ventilation time reads back as a raw seconds integer and the selector as a raw int.
+
+**Files:**
+- Modify: `custom_components/luxtronik2/lux_overrides.py:238-243`
+- Test: `tests/test_lux_overrides.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: after `update_Luxtronik_Parameters()`, parameter 895 is a `TimerProgram` instance (decodes to `"week"`/`"5+2"`/`"days"`) and 896-955 are `TimeOfDay` instances (decode to `"HH:MM"`). Tasks 2-5 assume this.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_lux_overrides.py`:
+
+```python
+class TestTimerScheduleDatatypeCoverage:
+    """Both timer-program parameter blocks must get their datatypes.
+
+    The heating/DHW/pool block is contiguous at 162-667, but the ventilation
+    block sits apart at 895-955 and was not covered at all, so every
+    ventilation time decoded as a raw seconds integer.
+    """
+
+    def _applied(self):
+        from luxtronik.parameters import Parameters
+
+        from custom_components.luxtronik2.lux_overrides import (
+            update_Luxtronik_Parameters,
+        )
+
+        update_Luxtronik_Parameters()
+        return Parameters.parameters
+
+    def test_ventilation_selector_is_a_timer_program(self):
+        from custom_components.luxtronik2.lux_overrides import TimerProgram
+
+        assert isinstance(self._applied()[895], TimerProgram)
+
+    def test_ventilation_times_are_time_of_day(self):
+        from custom_components.luxtronik2.lux_overrides import TimeOfDay
+
+        parameters = self._applied()
+        # First and last of both the start block (896-925) and the
+        # interleaved end block (926-955).
+        for number in (896, 925, 926, 955):
+            assert isinstance(parameters[number], TimeOfDay), number
+
+    def test_heating_block_is_still_covered(self):
+        from custom_components.luxtronik2.lux_overrides import (
+            TimeOfDay,
+            TimerProgram,
+        )
+
+        parameters = self._applied()
+        assert isinstance(parameters[222], TimerProgram)
+        for number in (223, 282):
+            assert isinstance(parameters[number], TimeOfDay), number
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_lux_overrides.py::TestTimerScheduleDatatypeCoverage -v`
+
+Expected: the two ventilation tests FAIL (895/896/955 are `Unknown`); `test_heating_block_is_still_covered` PASSES.
+
+- [ ] **Step 3: Extend the override ranges**
+
+In `update_Luxtronik_Parameters()`, replace the timer-program block:
+
+```python
+    # Timer program schedule parameters: mostly TimeOfDay entries, with a
+    # handful of TimerProgram mode selectors interspersed. 162-667 holds the
+    # heating, mixing, DHW, circulation-pump and pool circuits; the
+    # ventilation circuit sits apart at 895 (selector) and 896-955 (times).
+    timer_program_numbers = {222, 283, 344, 405, 506, 607, 895}
+    schedule_numbers = list(range(162, 668)) + list(range(895, 956))
+    time_of_day_numbers = [
+        n for n in schedule_numbers if n not in timer_program_numbers
+    ]
+    update_Luxtronik_Parameter_Classes(time_of_day_numbers, TimeOfDay)
+    update_Luxtronik_Parameter_Classes(list(timer_program_numbers), TimerProgram)
+```
+
+- [ ] **Step 4: Run the test again**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_lux_overrides.py -v`
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/luxtronik2/lux_overrides.py tests/test_lux_overrides.py
+```
+
+Message:
+
+```
+fix(lux_overrides): 🐛 decode the ventilation timer program block
+
+- extend the timer datatype overrides to 895-955, which sits outside the
+  162-667 range and so decoded as raw seconds
+- give selector 895 the TimerProgram datatype like the other six circuits
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+```
+
+---
+
+### Task 2: Heating circuit schedules
+
+**Files:**
+- Modify: `custom_components/luxtronik2/const.py:982` (after `TIMER_DHW_SCHEDULE_SUNDAY`)
+- Modify: `custom_components/luxtronik2/timer_schedule_entities_predefined.py`
+- Modify: `custom_components/luxtronik2/translations/{en,de,nl,cs,pl}.json`
+- Test: `tests/test_text.py`
+
+**Interfaces:**
+- Consumes: Task 1's datatype coverage (not strictly required to pass these tests).
+- Produces:
+  - `SK.TIMER_HEATING_SCHEDULE_{WEEK,WEEKDAY,WEEKEND,MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY,SATURDAY,SUNDAY}`
+  - `_row_names_row_slot(prefix: str, rows: int, col: int) -> tuple[tuple[str, str], ...]` — the existing `_row_names`, renamed
+  - `_TimerCircuit.name_builder: Callable[[str, int, int], tuple[tuple[str, str], ...]]`
+  - `TIMER_SCHEDULE_ENTITIES` grows from 10 to 20 entries
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_text.py`, extend `TestTimerScheduleTable`. Replace `test_ten_dhw_entities_generated` and `test_row_counts_are_five_for_dhw` with the versions below (the old ones assert totals that this task changes) and add the rest:
+
+```python
+    def test_entity_count(self):
+        assert len(TIMER_SCHEDULE_ENTITIES) == 20
+
+    def test_row_counts_per_circuit(self):
+        """DHW has 5 slots per day, the heating circuit only 3."""
+        by_key = {d.key: len(d.row_names) for d in TIMER_SCHEDULE_ENTITIES}
+        assert by_key[SK.TIMER_DHW_SCHEDULE_WEEK] == 5
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEK] == 3
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_SUNDAY] == 3
+
+    def test_heating_selector_and_device(self):
+        from custom_components.luxtronik2.const import DeviceKey
+
+        description = next(
+            d
+            for d in TIMER_SCHEDULE_ENTITIES
+            if d.key == SK.TIMER_HEATING_SCHEDULE_WEEK
+        )
+        assert description.mode_selector_name == "ID_Einst_SuHkr_akt"
+        assert description.device_key is DeviceKey.heating
+
+    def test_heating_row_names(self):
+        """Spot-checks against the real upstream names (222-282).
+
+        The heating prefixes are spelled `SuHkrW0` (digit zero) and `SuHkrTG`,
+        which differ from DHW's `SuBwWO`/`SuBwTG` - a copy-paste of the DHW
+        prefix would still generate plausible-looking names.
+        """
+        by_key = {d.key: d.row_names for d in TIMER_SCHEDULE_ENTITIES}
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEK][0] == (
+            "ID_Einst_SuHkrW0_zeit_0_0",
+            "ID_Einst_SuHkrW0_zeit_0_1",
+        )
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEKEND][0] == (
+            "ID_Einst_SuHkr25_zeit_0_2",
+            "ID_Einst_SuHkr25_zeit_0_3",
+        )
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_SUNDAY][2] == (
+            "ID_Einst_SuHkrTG_zeit_2_12",
+            "ID_Einst_SuHkrTG_zeit_2_13",
+        )
+
+    def test_heating_active_modes(self):
+        by_key = {d.key: d.active_mode for d in TIMER_SCHEDULE_ENTITIES}
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEK] == "week"
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEKDAY] == "5+2"
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEKEND] == "5+2"
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_MONDAY] == "days"
+```
+
+`test_names_exist_in_library` already covers every new name automatically — leave it as is.
+
+- [ ] **Step 2: Run them and confirm they fail**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_text.py::TestTimerScheduleTable -v`
+
+Expected: FAIL with `AttributeError: TIMER_HEATING_SCHEDULE_WEEK` on the new tests, and `assert 10 == 20` on `test_entity_count`.
+
+- [ ] **Step 3: Add the SensorKey members**
+
+In `const.py`, directly after `TIMER_DHW_SCHEDULE_SUNDAY = "timer_dhw_schedule_sunday"`:
+
+```python
+
+    TIMER_HEATING_SCHEDULE_WEEK = "timer_heating_schedule_week"
+    TIMER_HEATING_SCHEDULE_WEEKDAY = "timer_heating_schedule_weekday"
+    TIMER_HEATING_SCHEDULE_WEEKEND = "timer_heating_schedule_weekend"
+    TIMER_HEATING_SCHEDULE_MONDAY = "timer_heating_schedule_monday"
+    TIMER_HEATING_SCHEDULE_TUESDAY = "timer_heating_schedule_tuesday"
+    TIMER_HEATING_SCHEDULE_WEDNESDAY = "timer_heating_schedule_wednesday"
+    TIMER_HEATING_SCHEDULE_THURSDAY = "timer_heating_schedule_thursday"
+    TIMER_HEATING_SCHEDULE_FRIDAY = "timer_heating_schedule_friday"
+    TIMER_HEATING_SCHEDULE_SATURDAY = "timer_heating_schedule_saturday"
+    TIMER_HEATING_SCHEDULE_SUNDAY = "timer_heating_schedule_sunday"
+```
+
+- [ ] **Step 4: Make the name layout pluggable and add the heating circuit**
+
+In `timer_schedule_entities_predefined.py`:
+
+Add to the imports at the top:
+
+```python
+from collections.abc import Callable
+```
+
+Rename `_row_names` to `_row_names_row_slot` (body unchanged) and update its docstring:
+
+```python
+def _row_names_row_slot(prefix: str, rows: int, col: int) -> tuple[tuple[str, str], ...]:
+    """Build the (start_name, end_name) pairs for a `<row>_<slot>` block.
+
+    Matches the firmware's ``<prefix>_zeit_<row>_<slot>`` numbering, where
+    slot is ``2*col`` (start) / ``2*col + 1`` (end). Used by the DHW and
+    heating circuits.
+    """
+    return tuple(
+        (f"{prefix}_zeit_{row}_{2 * col}", f"{prefix}_zeit_{row}_{2 * col + 1}")
+        for row in range(rows)
+    )
+```
+
+Add a field to `_TimerCircuit`, after `per_day_prefix` and before `device_key`:
+
+```python
+    #: Builds the (start_name, end_name) pairs for one block. Circuits do not
+    #: share a single naming scheme, so the layout is per circuit -- see the
+    #: two `_row_names_*` functions. Deliberately has no default: a default
+    #: here would make it a class attribute and bind as a method on access.
+    name_builder: Callable[[str, int, int], tuple[tuple[str, str], ...]]
+```
+
+Give `_DHW_CIRCUIT` the new field:
+
+```python
+    name_builder=_row_names_row_slot,
+```
+
+Add the heating circuit and its day keys below `_DHW_WEEKDAYS`:
+
+```python
+_HEATING_CIRCUIT = _TimerCircuit(
+    mode_selector_name="ID_Einst_SuHkr_akt",
+    rows=3,
+    # `W0` ends in a digit zero and `TG` is uppercase: these are the upstream
+    # library's literal names and differ from the DHW spellings.
+    same_schedule_prefix="ID_Einst_SuHkrW0",
+    weekday_weekend_prefix="ID_Einst_SuHkr25",
+    per_day_prefix="ID_Einst_SuHkrTG",
+    name_builder=_row_names_row_slot,
+    device_key=DeviceKey.heating,
+)
+
+_HEATING_WEEKDAYS: tuple[tuple[SK, int], ...] = (
+    (SK.TIMER_HEATING_SCHEDULE_MONDAY, 0),
+    (SK.TIMER_HEATING_SCHEDULE_TUESDAY, 1),
+    (SK.TIMER_HEATING_SCHEDULE_WEDNESDAY, 2),
+    (SK.TIMER_HEATING_SCHEDULE_THURSDAY, 3),
+    (SK.TIMER_HEATING_SCHEDULE_FRIDAY, 4),
+    (SK.TIMER_HEATING_SCHEDULE_SATURDAY, 5),
+    (SK.TIMER_HEATING_SCHEDULE_SUNDAY, 6),
+)
+```
+
+In `_build_circuit_entities`, replace all four `_row_names(...)` calls with `circuit.name_builder(...)`, e.g.:
+
+```python
+            row_names=circuit.name_builder(circuit.same_schedule_prefix, circuit.rows, 0),
+```
+```python
+            row_names=circuit.name_builder(
+                circuit.weekday_weekend_prefix, circuit.rows, 0
+            ),
+```
+```python
+            row_names=circuit.name_builder(
+                circuit.weekday_weekend_prefix, circuit.rows, 1
+            ),
+```
+```python
+        row_names=circuit.name_builder(circuit.per_day_prefix, circuit.rows, day_index),
+```
+
+Extend the table at the bottom:
+
+```python
+TIMER_SCHEDULE_ENTITIES: list[LuxtronikTimerScheduleTextDescription] = (
+    _build_circuit_entities(
+        _DHW_CIRCUIT,
+        week_key=SK.TIMER_DHW_SCHEDULE_WEEK,
+        weekday_key=SK.TIMER_DHW_SCHEDULE_WEEKDAY,
+        weekend_key=SK.TIMER_DHW_SCHEDULE_WEEKEND,
+        day_keys=_DHW_WEEKDAYS,
+    )
+    + _build_circuit_entities(
+        _HEATING_CIRCUIT,
+        week_key=SK.TIMER_HEATING_SCHEDULE_WEEK,
+        weekday_key=SK.TIMER_HEATING_SCHEDULE_WEEKDAY,
+        weekend_key=SK.TIMER_HEATING_SCHEDULE_WEEKEND,
+        day_keys=_HEATING_WEEKDAYS,
+    )
+)
+```
+
+Finally update the module docstring — the DHW-only pilot is over:
+
+```python
+"""Predefined timer-program schedule text entities.
+
+Covers the DHW (Bw) and heating (Hkr) circuits. The remaining timer-program
+circuits (Mk1/Mk2/ZIP/Swb) follow the same pattern and need one
+`_TimerCircuit` instance plus translations each; see the
+"lux-timer-program-parameter-layout" memory for their selector/prefix values.
+"""
+```
+
+- [ ] **Step 5: Run the table tests**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_text.py -v`
+
+Expected: all PASS. If `test_names_exist_in_library` fails, a prefix is mistyped — compare against the upstream names, do not "fix" the test.
+
+- [ ] **Step 6: Add the translations**
+
+In each `translations/<lang>.json`, inside `entity.text`, after the existing `timer_dhw_schedule_sunday` entry, add 10 entries in the shape `"timer_heating_schedule_week": {"name": "..."},` using the names below. Match the file's existing indentation.
+
+`en.json`: Heating Timer Schedule (Week) / (Weekdays) / (Weekend) / (Monday) / (Tuesday) / (Wednesday) / (Thursday) / (Friday) / (Saturday) / (Sunday)
+
+`de.json`: Heizung-Zeitschaltplan (Woche) / (Werktage) / (Wochenende) / (Montag) / (Dienstag) / (Mittwoch) / (Donnerstag) / (Freitag) / (Samstag) / (Sonntag)
+
+`nl.json`: Verwarming tijdschema (week) / (werkdagen) / (weekend) / (maandag) / (dinsdag) / (woensdag) / (donderdag) / (vrijdag) / (zaterdag) / (zondag)
+
+`cs.json`: Časový plán vytápění (týden) / (pracovní dny) / (víkend) / (pondělí) / (úterý) / (středa) / (čtvrtek) / (pátek) / (sobota) / (neděle)
+
+`pl.json`: Harmonogram czasowy ogrzewania (tydzień) / (dni robocze) / (weekend) / (poniedziałek) / (wtorek) / (środa) / (czwartek) / (piątek) / (sobota) / (niedziela)
+
+The key order is `week, weekday, weekend, monday, tuesday, wednesday, thursday, friday, saturday, sunday`, matching the name order above.
+
+- [ ] **Step 7: Verify translation coverage**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_translation_coverage.py -v`
+
+Expected: all PASS. A failure names the missing key and locale exactly.
+
+- [ ] **Step 8: Lint, type-check and run the full suite**
+
+```bash
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff format custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff check custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m basedpyright --pythonpath "C:\Users\rhamm\anaconda3\envs\py314\python.exe" custom_components/luxtronik2
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest -q
+```
+
+Expected: ruff clean, basedpyright 0 errors, all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add custom_components/luxtronik2/const.py \
+        custom_components/luxtronik2/timer_schedule_entities_predefined.py \
+        custom_components/luxtronik2/translations/ \
+        tests/test_text.py
+```
+
+Message:
+
+```
+feat(text): ✨ add heating circuit timer schedule entities
+
+- add the 10 SuHkr schedule blocks (week, weekday/weekend, per day) on the
+  heating device, 3 slots per day
+- make the parameter-name layout pluggable per circuit, since not every
+  circuit uses the <prefix>_zeit_<row>_<slot> shape
+- add en/de/nl/cs/pl names for the new entities
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+```
+
+---
+
+### Task 3: Per-circuit bail on an unreadable selector
+
+`_active_schedule_descriptions` returns `None` for the entire pass as soon as any selector reads back `None`. With DHW alone that meant "this circuit is unreadable"; with two or more circuits it freezes all of them. Do this before adding ventilation, whose selector datatype is the one shipping on an unverified assumption.
+
+**Files:**
+- Modify: `custom_components/luxtronik2/text.py:51-93` (`_active_schedule_descriptions`) and `custom_components/luxtronik2/text.py:147-209` (`async_apply`)
+- Test: `tests/test_text.py`
+
+**Interfaces:**
+- Consumes: `SK.TIMER_HEATING_SCHEDULE_*` and the 20-entry `TIMER_SCHEDULE_ENTITIES` from Task 2.
+- Produces:
+  `_active_schedule_descriptions(coordinator, data) -> tuple[list[LuxtronikTimerScheduleTextDescription], set[str]] | None`
+  — the active blocks plus the `mode_selector_name`s that could not be read. `None` only when `data is None`.
+
+- [ ] **Step 1: Adapt the existing helper and write the failing tests**
+
+In `tests/test_text.py`, `TestActiveScheduleDescriptions`, change only the `_call` helper to unwrap the tuple:
+
+```python
+    def _call(self, parameters, *, entity_active=True):
+        from custom_components.luxtronik2.text import _active_schedule_descriptions
+
+        data = make_coordinator_data(parameters=parameters)
+        coord = _mock_coordinator(data)
+        coord.entity_active.return_value = entity_active
+        active, _unreadable = _active_schedule_descriptions(coord, data)
+        return [d.key for d in active]
+```
+
+Replace `test_undecodable_selector_yields_no_information` with the per-circuit version, and add the cross-circuit test:
+
+```python
+    def test_undecodable_selector_freezes_only_its_own_circuit(self):
+        """A present-but-unreadable selector must not read as "no program active".
+
+        `get_sensor_data` returns None both for an absent register and for a
+        register whose datatype could not decode the raw value
+        (`SelectionBase` returns None for an unrecognised code). The selector
+        is reported as unreadable so the sync leaves that circuit alone.
+        """
+        from custom_components.luxtronik2.text import _active_schedule_descriptions
+
+        data = make_coordinator_data(parameters={self._SELECTOR: None})
+        coord = _mock_coordinator(data)
+        active, unreadable = _active_schedule_descriptions(coord, data)
+        assert active == []
+        assert unreadable == {self._SELECTOR}
+
+    def test_one_unreadable_circuit_does_not_hide_another(self):
+        """The regression the second circuit makes possible.
+
+        Before this, any single unreadable selector returned "no information"
+        for the whole pass, freezing every circuit's entities.
+        """
+        from custom_components.luxtronik2.text import _active_schedule_descriptions
+
+        data = make_coordinator_data(
+            parameters={self._SELECTOR: None, "ID_Einst_SuHkr_akt": "week"}
+        )
+        coord = _mock_coordinator(data)
+        active, unreadable = _active_schedule_descriptions(coord, data)
+        assert [d.key for d in active] == [SK.TIMER_HEATING_SCHEDULE_WEEK]
+        assert unreadable == {self._SELECTOR}
+
+    def test_data_none_still_yields_no_information(self):
+        """No coordinator data at all is "unknown" for every circuit."""
+        from custom_components.luxtronik2.text import _active_schedule_descriptions
+
+        assert _active_schedule_descriptions(_mock_coordinator(), None) is None
+```
+
+Delete the now-superseded `test_data_none_yields_no_information` (replaced by the identical `test_data_none_still_yields_no_information` above) so it is not defined twice.
+
+Then add the sync-level test to `TestTimerScheduleSync`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_an_unreadable_circuit_is_frozen_while_others_still_sync(self):
+        """A frozen circuit keeps its live entities and registry entries.
+
+        The per-circuit skip is only safe if the sync also refuses to remove
+        and disable that circuit's blocks - otherwise it causes exactly the
+        teardown the whole-pass bail existed to prevent.
+        """
+        from custom_components.luxtronik2.text import LuxtronikTimerScheduleText
+
+        sync, coord, added = self._make_sync("week")
+        registry = self._registry({})
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            # Both circuits start in "week" mode.
+            coord.data = make_coordinator_data(
+                parameters={self._SELECTOR: "week", "ID_Einst_SuHkr_akt": "week"}
+            )
+            await sync.async_setup()
+            assert set(sync._entities) == {
+                SK.TIMER_DHW_SCHEDULE_WEEK,
+                SK.TIMER_HEATING_SCHEDULE_WEEK,
+            }
+
+            # DHW's selector glitches while heating switches program.
+            coord.data = make_coordinator_data(
+                parameters={self._SELECTOR: None, "ID_Einst_SuHkr_akt": "5+2"}
+            )
+            with patch.object(
+                LuxtronikTimerScheduleText, "async_remove", new=AsyncMock()
+            ) as remove:
+                await sync.async_apply()
+
+        # Only the heating week block was removed; the DHW one is untouched.
+        assert remove.await_count == 1
+        assert SK.TIMER_DHW_SCHEDULE_WEEK in sync._entities
+        assert SK.TIMER_HEATING_SCHEDULE_WEEK not in sync._entities
+        assert [e.entity_description.key for e in added[2:]] == [
+            SK.TIMER_HEATING_SCHEDULE_WEEKDAY,
+            SK.TIMER_HEATING_SCHEDULE_WEEKEND,
+        ]
+```
+
+- [ ] **Step 2: Run them and confirm they fail**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_text.py -v`
+
+Expected: FAIL — `TypeError: cannot unpack non-sequence` in `_call` and the new tests, since the helper still returns a bare list.
+
+- [ ] **Step 3: Make the helper report unreadable selectors**
+
+Replace `_active_schedule_descriptions` in `text.py`:
+
+```python
+def _active_schedule_descriptions(
+    coordinator: LuxtronikCoordinator,
+    data: LuxtronikCoordinatorData | None,
+) -> tuple[list[LuxtronikTimerScheduleTextDescription], set[str]] | None:
+    """Return the active schedule blocks and the unreadable selectors.
+
+    A block qualifies when its circuit's mode selector is present on this
+    controller and its value equals the block's `active_mode`. Every other
+    block is meaningless on the device, so no entity is created for it.
+
+    The second element holds the `mode_selector_name`s that could not be read
+    this poll. `get_sensor_data` returns ``None`` both for an absent register
+    and for a present one whose datatype could not decode the raw value
+    (``SelectionBase`` returns ``None`` for an unrecognised code), and
+    `key_exists` cannot tell the two apart for a parameter inside upstream's
+    defined index range. Reading a transient decode failure as "no program is
+    active" would tear down that circuit's schedule entities and disable their
+    registry entries until the next good poll, so the caller leaves those
+    circuits untouched instead. The failure is per circuit: an unreadable
+    selector on one circuit must not freeze the others.
+
+    Returns ``None`` -- "no information about anything this poll" -- only when
+    there is no coordinator data at all.
+    """
+    if data is None:
+        return None
+
+    descriptions: list[LuxtronikTimerScheduleTextDescription] = []
+    unreadable: set[str] = set()
+    for description in TIMER_SCHEDULE_ENTITIES:
+        if not coordinator.entity_active(description):
+            continue
+        selector_name = description.mode_selector_name
+        if selector_name in unreadable:
+            continue
+        selector_key = f"parameters.{selector_name}"
+        if not key_exists(data, selector_key):
+            continue
+        mode = get_sensor_data(data, selector_key)
+        if mode is None:
+            LOGGER.debug(
+                "Timer program selector %s could not be read this poll - "
+                "leaving its schedule entities untouched",
+                selector_key,
+            )
+            unreadable.add(selector_name)
+            continue
+        if mode != description.active_mode:
+            continue
+        descriptions.append(description)
+    return descriptions, unreadable
+```
+
+- [ ] **Step 4: Freeze those circuits in the sync pass**
+
+In `async_apply`, replace the block from `active = _active_schedule_descriptions(` through the `to_remove = [...]` assignment:
+
+```python
+            result = _active_schedule_descriptions(
+                self.coordinator, self.coordinator.data
+            )
+            if result is None:
+                # Nothing could be concluded this poll: do not add, remove or
+                # write anything.
+                return
+            active, unreadable = result
+            desired = {description.key: description for description in active}
+            # A circuit whose selector could not be read keeps whatever it
+            # has: its blocks are neither removed nor disabled, because we
+            # cannot tell which of them the device is actually running.
+            frozen = {
+                description.key
+                for description in TIMER_SCHEDULE_ENTITIES
+                if description.mode_selector_name in unreadable
+            }
+            to_add = [
+                description
+                for key, description in desired.items()
+                if key not in self._entities
+            ]
+            to_remove = [
+                (key, entity)
+                for key, entity in self._entities.items()
+                if key not in desired and key not in frozen
+            ]
+```
+
+and change the final disable call to spare the frozen keys:
+
+```python
+            self._disable_inactive(registry, set(desired) | frozen)
+```
+
+Update `async_apply`'s docstring to mention the freeze, and the class docstring line about "the registry entries of the other blocks are kept but disabled" to note the exception.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_text.py -v`
+
+Expected: all PASS, including the pre-existing `test_unreadable_selector_does_not_remove_or_disable_anything` — with every DHW key frozen there is nothing to add or remove, so the pass returns before touching the registry.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest -q`
+
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add custom_components/luxtronik2/text.py tests/test_text.py
+```
+
+Message:
+
+```
+fix(text): 🐛 freeze only the circuit whose selector is unreadable
+
+- report unreadable mode selectors per circuit instead of bailing out of the
+  whole sync pass, which froze every circuit's entities
+- keep a frozen circuit's blocks out of both the removal and the disable
+  pass, so its entities and registry entries survive the glitched read
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+```
+
+---
+
+### Task 4: Ventilation circuit schedules
+
+The ventilation firmware names put the start/end index **first**: `<prefix>_zeit_<0|1>_<row>_<2*col>`, so its start block (896-925) and end block (926-955) are interleaved rather than adjacent. This needs the second name builder.
+
+**Files:**
+- Modify: `custom_components/luxtronik2/const.py` (after the heating keys from Task 2)
+- Modify: `custom_components/luxtronik2/timer_schedule_entities_predefined.py`
+- Modify: `custom_components/luxtronik2/translations/{en,de,nl,cs,pl}.json`
+- Test: `tests/test_text.py`
+
+**Interfaces:**
+- Consumes: `_TimerCircuit.name_builder` and `_row_names_row_slot` from Task 2; the per-circuit bail from Task 3.
+- Produces:
+  - `SK.TIMER_VENTILATION_SCHEDULE_{WEEK,WEEKDAY,WEEKEND,MONDAY..SUNDAY}`
+  - `_row_names_block_row_col(prefix: str, rows: int, col: int) -> tuple[tuple[str, str], ...]`
+  - `TIMER_SCHEDULE_ENTITIES` grows from 20 to 30 entries
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_text.py`, update `test_entity_count` to `30` and add to `TestTimerScheduleTable`:
+
+```python
+    def test_ventilation_selector_and_device(self):
+        from custom_components.luxtronik2.const import DeviceKey
+
+        description = next(
+            d
+            for d in TIMER_SCHEDULE_ENTITIES
+            if d.key == SK.TIMER_VENTILATION_SCHEDULE_WEEK
+        )
+        assert description.mode_selector_name == "ID_Einst_SuLuf_akt"
+        assert description.device_key is DeviceKey.ventilation
+        assert len(description.row_names) == 3
+
+    def test_ventilation_row_names_use_the_leading_start_end_index(self):
+        """Ventilation names are `<prefix>_zeit_<0|1>_<row>_<2*col>`.
+
+        The start and end blocks are interleaved in the parameter numbering
+        (starts 896-925, ends 926-955), unlike every other circuit where the
+        end sits immediately after its start.
+        """
+        by_key = {d.key: d.row_names for d in TIMER_SCHEDULE_ENTITIES}
+        assert by_key[SK.TIMER_VENTILATION_SCHEDULE_WEEK][0] == (
+            "ID_Einst_SuLufWo_zeit_0_0_0",
+            "ID_Einst_SuLufWo_zeit_1_0_0",
+        )
+        assert by_key[SK.TIMER_VENTILATION_SCHEDULE_WEEKEND][2] == (
+            "ID_Einst_SuLuf25_zeit_0_2_2",
+            "ID_Einst_SuLuf25_zeit_1_2_2",
+        )
+        assert by_key[SK.TIMER_VENTILATION_SCHEDULE_WEDNESDAY][1] == (
+            "ID_Einst_SuLufTg_zeit_0_1_4",
+            "ID_Einst_SuLufTg_zeit_1_1_4",
+        )
+        assert by_key[SK.TIMER_VENTILATION_SCHEDULE_SUNDAY][2] == (
+            "ID_Einst_SuLufTg_zeit_0_2_12",
+            "ID_Einst_SuLufTg_zeit_1_2_12",
+        )
+```
+
+And add the device-gating test to `TestActiveScheduleDescriptions`:
+
+```python
+    def test_ventilation_blocks_are_skipped_without_a_ventilation_module(self):
+        """`entity_active` is False for the ventilation device on such a unit."""
+        from custom_components.luxtronik2.text import _active_schedule_descriptions
+        from custom_components.luxtronik2.const import DeviceKey
+
+        data = make_coordinator_data(
+            parameters={self._SELECTOR: "week", "ID_Einst_SuLuf_akt": "week"}
+        )
+        coord = _mock_coordinator(data)
+        coord.entity_active.side_effect = (
+            lambda description: description.device_key is not DeviceKey.ventilation
+        )
+        active, unreadable = _active_schedule_descriptions(coord, data)
+        keys = [d.key for d in active]
+        assert SK.TIMER_DHW_SCHEDULE_WEEK in keys
+        assert SK.TIMER_VENTILATION_SCHEDULE_WEEK not in keys
+        assert unreadable == set()
+```
+
+- [ ] **Step 2: Run them and confirm they fail**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_text.py::TestTimerScheduleTable -v`
+
+Expected: FAIL with `AttributeError: TIMER_VENTILATION_SCHEDULE_WEEK` and `assert 20 == 30`.
+
+- [ ] **Step 3: Add the SensorKey members**
+
+In `const.py`, after `TIMER_HEATING_SCHEDULE_SUNDAY`:
+
+```python
+
+    TIMER_VENTILATION_SCHEDULE_WEEK = "timer_ventilation_schedule_week"
+    TIMER_VENTILATION_SCHEDULE_WEEKDAY = "timer_ventilation_schedule_weekday"
+    TIMER_VENTILATION_SCHEDULE_WEEKEND = "timer_ventilation_schedule_weekend"
+    TIMER_VENTILATION_SCHEDULE_MONDAY = "timer_ventilation_schedule_monday"
+    TIMER_VENTILATION_SCHEDULE_TUESDAY = "timer_ventilation_schedule_tuesday"
+    TIMER_VENTILATION_SCHEDULE_WEDNESDAY = "timer_ventilation_schedule_wednesday"
+    TIMER_VENTILATION_SCHEDULE_THURSDAY = "timer_ventilation_schedule_thursday"
+    TIMER_VENTILATION_SCHEDULE_FRIDAY = "timer_ventilation_schedule_friday"
+    TIMER_VENTILATION_SCHEDULE_SATURDAY = "timer_ventilation_schedule_saturday"
+    TIMER_VENTILATION_SCHEDULE_SUNDAY = "timer_ventilation_schedule_sunday"
+```
+
+- [ ] **Step 4: Add the second name builder and the circuit**
+
+In `timer_schedule_entities_predefined.py`, after `_row_names_row_slot`:
+
+```python
+def _row_names_block_row_col(
+    prefix: str, rows: int, col: int
+) -> tuple[tuple[str, str], ...]:
+    """Build the (start_name, end_name) pairs for a `<0|1>_<row>_<col>` block.
+
+    The ventilation circuit names its slots ``<prefix>_zeit_<0|1>_<row>_<2*col>``
+    with the start/end index *first*, so its start times (896-925) and end
+    times (926-955) form two interleaved blocks rather than adjacent pairs.
+
+    Inferred from the parameter naming, not from a diagnostics dump: no unit
+    with a ventilation module has been sampled yet. If a dump ever shows the
+    leading index is not start/end, this function is the only thing to change.
+    """
+    return tuple(
+        (f"{prefix}_zeit_0_{row}_{2 * col}", f"{prefix}_zeit_1_{row}_{2 * col}")
+        for row in range(rows)
+    )
+```
+
+Then, after `_HEATING_WEEKDAYS`:
+
+```python
+_VENTILATION_CIRCUIT = _TimerCircuit(
+    mode_selector_name="ID_Einst_SuLuf_akt",
+    rows=3,
+    same_schedule_prefix="ID_Einst_SuLufWo",
+    weekday_weekend_prefix="ID_Einst_SuLuf25",
+    per_day_prefix="ID_Einst_SuLufTg",
+    name_builder=_row_names_block_row_col,
+    device_key=DeviceKey.ventilation,
+)
+
+_VENTILATION_WEEKDAYS: tuple[tuple[SK, int], ...] = (
+    (SK.TIMER_VENTILATION_SCHEDULE_MONDAY, 0),
+    (SK.TIMER_VENTILATION_SCHEDULE_TUESDAY, 1),
+    (SK.TIMER_VENTILATION_SCHEDULE_WEDNESDAY, 2),
+    (SK.TIMER_VENTILATION_SCHEDULE_THURSDAY, 3),
+    (SK.TIMER_VENTILATION_SCHEDULE_FRIDAY, 4),
+    (SK.TIMER_VENTILATION_SCHEDULE_SATURDAY, 5),
+    (SK.TIMER_VENTILATION_SCHEDULE_SUNDAY, 6),
+)
+```
+
+Extend the table:
+
+```python
+    + _build_circuit_entities(
+        _VENTILATION_CIRCUIT,
+        week_key=SK.TIMER_VENTILATION_SCHEDULE_WEEK,
+        weekday_key=SK.TIMER_VENTILATION_SCHEDULE_WEEKDAY,
+        weekend_key=SK.TIMER_VENTILATION_SCHEDULE_WEEKEND,
+        day_keys=_VENTILATION_WEEKDAYS,
+    )
+```
+
+Update the module docstring's first line to `Covers the DHW (Bw), heating (Hkr) and ventilation (Luf) circuits.`
+
+Also note in the `_VENTILATION_CIRCUIT` block that the selector's `TimerProgram` codes are assumed to match the other circuits:
+
+```python
+# The selector's week/5+2/days codes are assumed to match the other circuits;
+# see lux_overrides.update_Luxtronik_Parameters. Also inferred, not sampled.
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_text.py -v`
+
+Expected: all PASS. `test_names_exist_in_library` proves all 60 generated ventilation names resolve to real upstream parameters.
+
+- [ ] **Step 6: Add the translations**
+
+Same procedure as Task 2 Step 6, 10 more keys per file named `timer_ventilation_schedule_*`, placed after the heating ones:
+
+`en.json`: Ventilation Timer Schedule (Week) / (Weekdays) / (Weekend) / (Monday) / (Tuesday) / (Wednesday) / (Thursday) / (Friday) / (Saturday) / (Sunday)
+
+`de.json`: Lüftung-Zeitschaltplan (Woche) / (Werktage) / (Wochenende) / (Montag) / (Dienstag) / (Mittwoch) / (Donnerstag) / (Freitag) / (Samstag) / (Sonntag)
+
+`nl.json`: Ventilatie tijdschema (week) / (werkdagen) / (weekend) / (maandag) / (dinsdag) / (woensdag) / (donderdag) / (vrijdag) / (zaterdag) / (zondag)
+
+`cs.json`: Časový plán větrání (týden) / (pracovní dny) / (víkend) / (pondělí) / (úterý) / (středa) / (čtvrtek) / (pátek) / (sobota) / (neděle)
+
+`pl.json`: Harmonogram czasowy wentylacji (tydzień) / (dni robocze) / (weekend) / (poniedziałek) / (wtorek) / (środa) / (czwartek) / (piątek) / (sobota) / (niedziela)
+
+- [ ] **Step 7: Verify, lint and type-check**
+
+```bash
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_translation_coverage.py -v
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff format custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff check custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m basedpyright --pythonpath "C:\Users\rhamm\anaconda3\envs\py314\python.exe" custom_components/luxtronik2
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest -q
+```
+
+Expected: all clean and green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add custom_components/luxtronik2/const.py \
+        custom_components/luxtronik2/timer_schedule_entities_predefined.py \
+        custom_components/luxtronik2/translations/ \
+        tests/test_text.py
+```
+
+Message:
+
+```
+feat(text): ✨ add ventilation timer schedule entities
+
+- add the 10 SuLuf schedule blocks on the ventilation device, gated on the
+  coordinator's ventilation detection
+- add a second name builder for the ventilation layout, which puts the
+  start/end index first and interleaves the two blocks
+- add en/de/nl/cs/pl names for the new entities
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+```
+
+---
+
+### Task 5: Heating and ventilation program-mode selects
+
+Without these, the new schedules are visible but the user cannot switch which program is active — and which schedule entities exist at all is driven by exactly that selector.
+
+**Files:**
+- Modify: `custom_components/luxtronik2/const.py` (`SensorKey` and `LuxParameter`)
+- Modify: `custom_components/luxtronik2/select_entities_predefined.py:79-86` (after the DHW entry)
+- Modify: `custom_components/luxtronik2/translations/{en,de,nl,cs,pl}.json`
+- Test: `tests/test_select.py`
+
+**Interfaces:**
+- Consumes: nothing from Tasks 2-4 (independent), though it targets the same two selectors.
+- Produces: `SK.TIMER_HEATING_PROGRAM`, `SK.TIMER_VENTILATION_PROGRAM`, `LuxParameter.P0222_TIMER_PROGRAM_HEATING`, `LuxParameter.P0895_TIMER_PROGRAM_VENTILATION`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_select.py` (match the file's existing import style):
+
+```python
+class TestTimerProgramSelects:
+    """The program selector of every schedule-carrying circuit is settable."""
+
+    def _description(self, key):
+        from custom_components.luxtronik2.select_entities_predefined import (
+            SELECT_ENTITIES,
+        )
+
+        return next(d for d in SELECT_ENTITIES if d.key == key)
+
+    def test_heating_program_select(self):
+        from custom_components.luxtronik2.const import (
+            DeviceKey,
+            LuxParameter,
+            SensorKey,
+        )
+
+        description = self._description(SensorKey.TIMER_HEATING_PROGRAM)
+        assert description.luxtronik_key == LuxParameter.P0222_TIMER_PROGRAM_HEATING
+        assert description.device_key is DeviceKey.heating
+        assert description.raw_option_map == {
+            "week": "week",
+            "weekday_weekend": "5+2",
+            "daily": "days",
+        }
+
+    def test_ventilation_program_select(self):
+        from custom_components.luxtronik2.const import (
+            DeviceKey,
+            LuxParameter,
+            SensorKey,
+        )
+
+        description = self._description(SensorKey.TIMER_VENTILATION_PROGRAM)
+        assert description.luxtronik_key == LuxParameter.P0895_TIMER_PROGRAM_VENTILATION
+        assert description.device_key is DeviceKey.ventilation
+        assert description.options == ["week", "weekday_weekend", "daily"]
+
+    def test_parameter_strings_match_the_schedule_selectors(self):
+        """The select and the schedule entities must drive the same register.
+
+        A typo in either parameter string would silently give the user a
+        selector that writes somewhere else while the schedules keep reading
+        the real one.
+        """
+        from custom_components.luxtronik2.const import LuxParameter
+        from custom_components.luxtronik2.timer_schedule_entities_predefined import (
+            TIMER_SCHEDULE_ENTITIES,
+        )
+        from custom_components.luxtronik2.const import SensorKey
+
+        selectors = {
+            SensorKey.TIMER_HEATING_SCHEDULE_WEEK: (
+                LuxParameter.P0222_TIMER_PROGRAM_HEATING
+            ),
+            SensorKey.TIMER_VENTILATION_SCHEDULE_WEEK: (
+                LuxParameter.P0895_TIMER_PROGRAM_VENTILATION
+            ),
+        }
+        for schedule_key, parameter in selectors.items():
+            description = next(
+                d for d in TIMER_SCHEDULE_ENTITIES if d.key == schedule_key
+            )
+            assert parameter.value == f"parameters.{description.mode_selector_name}"
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_select.py::TestTimerProgramSelects -v`
+
+Expected: FAIL with `AttributeError: TIMER_HEATING_PROGRAM`.
+
+- [ ] **Step 3: Add the const members**
+
+In `const.py`, next to `TIMER_DHW_PROGRAM = "timer_dhw_program"`:
+
+```python
+    TIMER_HEATING_PROGRAM = "timer_heating_program"
+    TIMER_VENTILATION_PROGRAM = "timer_ventilation_program"
+```
+
+And in `LuxParameter`, next to `P0405_TIMER_PROGRAM_DHW` (keep the members in numeric order — 222 belongs before 405, 895 before `P0894_VENTILATION_MODE`'s neighbours; place each at its numeric position):
+
+```python
+    P0222_TIMER_PROGRAM_HEATING = "parameters.ID_Einst_SuHkr_akt"
+```
+```python
+    P0895_TIMER_PROGRAM_VENTILATION = "parameters.ID_Einst_SuLuf_akt"
+```
+
+- [ ] **Step 4: Add the select descriptions**
+
+In `select_entities_predefined.py`, directly after the `SK.TIMER_DHW_PROGRAM` entry:
+
+```python
+    LuxtronikSelectEntityDescription(
+        key=SK.TIMER_HEATING_PROGRAM,
+        device_key=DeviceKey.heating,
+        luxtronik_key=LuxParameter.P0222_TIMER_PROGRAM_HEATING,
+        entity_category=EntityCategory.CONFIG,
+        options=timer_program_options,
+        raw_option_map=TIMER_PROGRAM_RAW_OPTIONS,
+    ),
+    LuxtronikSelectEntityDescription(
+        key=SK.TIMER_VENTILATION_PROGRAM,
+        device_key=DeviceKey.ventilation,
+        luxtronik_key=LuxParameter.P0895_TIMER_PROGRAM_VENTILATION,
+        entity_category=EntityCategory.CONFIG,
+        options=timer_program_options,
+        raw_option_map=TIMER_PROGRAM_RAW_OPTIONS,
+    ),
+```
+
+- [ ] **Step 5: Run the test**
+
+Run: `"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_select.py -v`
+
+Expected: all PASS.
+
+- [ ] **Step 6: Add the translations**
+
+In each `translations/<lang>.json`, inside `entity.select`, after `timer_dhw_program`, add two entries with the same `name` + `state` shape. The three state keys are always `week`, `weekday_weekend`, `daily`, and their values are identical to the ones already on `timer_dhw_program` in that file — only the `name` differs:
+
+| lang | heating name | ventilation name |
+|---|---|---|
+| en | Heating timer program | Ventilation timer program |
+| de | Heizung Zeitprogramm | Lüftung Zeitprogramm |
+| nl | Verwarming tijdprogramma | Ventilatie tijdprogramma |
+| cs | Časový program vytápění | Časový program větrání |
+| pl | Program czasowy ogrzewania | Program czasowy wentylacji |
+
+For example, in `en.json`:
+
+```json
+    "timer_heating_program": {
+      "name": "Heating timer program",
+      "state": {
+        "week": "Whole week",
+        "weekday_weekend": "Weekdays + weekend",
+        "daily": "Per day"
+      }
+    },
+```
+
+`tests/test_translation_coverage.py` fails if any locale's `state` key set differs, so copy all three states into all ten new blocks.
+
+- [ ] **Step 7: Verify and commit**
+
+```bash
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest tests/test_translation_coverage.py tests/test_select.py -v
+```
+
+Then stage and commit:
+
+```bash
+git add custom_components/luxtronik2/const.py \
+        custom_components/luxtronik2/select_entities_predefined.py \
+        custom_components/luxtronik2/translations/ \
+        tests/test_select.py
+```
+
+Message:
+
+```
+feat(select): ✨ add heating and ventilation timer program selects
+
+- expose the SuHkr (222) and SuLuf (895) mode selectors, so the program
+  driving the new schedule entities can be switched from Home Assistant
+- reuse the DHW selector's week/5+2/days option mapping
+- add en/de/nl/cs/pl names and states
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+```
+
+---
+
+### Task 6: Final verification
+
+**Files:** none modified unless something fails.
+
+- [ ] **Step 1: Full pre-commit gate**
+
+```bash
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff format --check custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m ruff check custom_components/luxtronik2 tests
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m basedpyright --pythonpath "C:\Users\rhamm\anaconda3\envs\py314\python.exe" custom_components/luxtronik2
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m codespell custom_components/luxtronik2 tests
+```
+
+Expected: all clean, basedpyright 0 errors. Note that German entity names contain `ü`/`ö` — if codespell flags a translated word, add it to the existing ignore configuration rather than changing the translation.
+
+- [ ] **Step 2: Full suite with coverage**
+
+```bash
+"C:\Users\rhamm\anaconda3\envs\py314\python.exe" -m pytest --cov=custom_components.luxtronik2 --cov-report=term-missing -q
+```
+
+Expected: all tests pass, total coverage no lower than on `main`. Never scope `--cov` to a submodule (see Global Constraints).
+
+- [ ] **Step 3: Report**
+
+Summarise for the user: 30 schedule text entities across 3 circuits, 2 new selects, the two shipped-unverified ventilation assumptions and where to correct them, and the exact test/lint/coverage numbers observed. Do not claim anything that was not run.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Every spec section maps to a task — circuit table → 2 & 4; parameter-name layouts → 2 (`_row_names_row_slot`) & 4 (`_row_names_block_row_col`); unverified assumptions → comments in 4 and the datatype override in 1; program mode selects → 5; `lux_overrides.py` → 1; `const.py` → 2, 4, 5; `select_entities_predefined.py` → 5; translations → 2, 4, 5; per-circuit bail → 3; every testing bullet → the corresponding task's test step plus Task 6 for the coverage requirement.
+
+**Placeholders:** none — every code step carries the actual code, and every translation string is spelled out.
+
+**Type consistency:** `_row_names_row_slot` and `_row_names_block_row_col` share the signature `(str, int, int) -> tuple[tuple[str, str], ...]` declared on `_TimerCircuit.name_builder`. `_active_schedule_descriptions` returns `tuple[list[...], set[str]] | None` in Task 3 and is consumed with that shape in Tasks 3 and 4. Sensor and parameter key names are identical everywhere they appear.

--- a/docs/superpowers/specs/2026-08-14-heating-ventilation-timer-schedules-design.md
+++ b/docs/superpowers/specs/2026-08-14-heating-ventilation-timer-schedules-design.md
@@ -1,0 +1,170 @@
+# Heating and ventilation timer-program schedules
+
+Date: 2026-08-14
+
+## Goal
+
+Extend the existing timer-program schedule text entities — today wired up for
+the DHW circuit only — to the heating circuit and the ventilation module.
+
+The DHW implementation was built as a deliberate pilot (see the module
+docstring of `timer_schedule_entities_predefined.py`). This spec rolls it out
+to two more circuits and fixes the one behaviour that only becomes wrong once
+more than one circuit exists.
+
+Out of scope: the mixing circuits (`SuMk1` 283, `SuMk2` 344), the circulation
+pump (`SuZIP` 506), the pool (`SuSwb` 607), and the combined `SuAll` block
+(162-221). They follow the same pattern and can be added later at the cost of
+one `_TimerCircuit` instance plus translations each.
+
+## Circuits
+
+| | Heating | Ventilation |
+|---|---|---|
+| Mode selector | `ID_Einst_SuHkr_akt` (222) | `ID_Einst_SuLuf_akt` (895) |
+| Rows per day | 3 | 3 |
+| Week prefix | `ID_Einst_SuHkrW0` | `ID_Einst_SuLufWo` |
+| Weekday/weekend prefix | `ID_Einst_SuHkr25` | `ID_Einst_SuLuf25` |
+| Per-day prefix | `ID_Einst_SuHkrTG` | `ID_Einst_SuLufTg` |
+| Parameter range | 223-282 | 896-955 |
+| Device | `DeviceKey.heating` | `DeviceKey.ventilation` |
+
+The prefix spellings are the upstream library's literal parameter names and are
+inconsistent between circuits on purpose: heating uses `W0` with a **digit
+zero** and uppercase `TG`, ventilation uses `Wo`/`Tg`, DHW uses `WO`/`TG`.
+They must be copied verbatim, never derived.
+
+Device gating is already generic: `coordinator.device_key_active` returns
+`True` unconditionally for `DeviceKey.heating` and defers to `has_ventilation`
+for `DeviceKey.ventilation`, and `_active_schedule_descriptions` already calls
+`entity_active`. No coordinator change is needed.
+
+Each circuit yields 10 entities: week, weekday, weekend, and one per weekday
+Monday-Sunday. 20 new entities in total.
+
+## Parameter-name layouts
+
+The two circuits do **not** share a naming scheme.
+
+Heating (same as DHW), `<prefix>_zeit_<row>_<slot>`:
+
+```
+slot = 2 * col      -> start time
+slot = 2 * col + 1  -> end time
+col  = 0            for the week block
+col  = 0 | 1        for weekday | weekend
+col  = 0..6         for Monday..Sunday
+```
+
+Ventilation, `<prefix>_zeit_<0|1>_<row>_<2*col>`:
+
+```
+leading index 0 -> start time, 1 -> end time
+middle index    -> row (0..2)
+trailing index  -> 2 * col, same col meaning as above
+```
+
+The start and end blocks are interleaved in the parameter numbering rather
+than adjacent: `SuLufWo` starts live at 896-898 and their ends at 926-928;
+`SuLufTg` starts at 905-925, ends at 935-955. Nothing in the integration
+depends on the numbering — only on the names — but the split is why the
+per-prefix number ranges overlap when listed.
+
+## Unverified assumptions
+
+Both are inferred from the naming pattern, not from a diagnostics dump, and
+are shipped as such by explicit decision. Each gets a code comment saying so.
+
+1. `ID_Einst_SuLuf_akt` (895) uses the same `TimerProgram` codes as the other
+   selectors: `0 = week`, `1 = 5+2`, `2 = days`.
+2. In the ventilation names, the leading index is start(0)/end(1).
+
+If a dump later contradicts either, the correction is local: the datatype
+override for 895, or the ventilation name builder.
+
+## Changes
+
+### `lux_overrides.py`
+
+The timer datatype overrides currently cover 162-667 only, so every
+ventilation time parameter is still `Unknown` and would surface as raw
+seconds. Extend them:
+
+- add `895` to `timer_program_numbers` (gets `TimerProgram`)
+- add `range(896, 956)` to the `TimeOfDay` number list
+
+Heating needs nothing here; 222 and 223-282 are already covered.
+
+### `timer_schedule_entities_predefined.py`
+
+`_row_names` hardcodes the heating/DHW layout. Give `_TimerCircuit` a
+`name_builder` field holding one of two functions with the signature
+`(prefix, rows, col) -> tuple[tuple[str, str], ...]`:
+
+- `_row_names_row_slot` — the existing body, used by DHW and heating
+- `_row_names_block_row_col` — the ventilation layout
+
+`_build_circuit_entities` calls `circuit.name_builder(...)` instead of
+`_row_names(...)` and is otherwise unchanged, as is
+`LuxtronikTimerScheduleTextDescription`.
+
+Add `_HEATING_CIRCUIT` and `_VENTILATION_CIRCUIT` instances plus their
+weekday key tuples, and extend `TIMER_SCHEDULE_ENTITIES` with their built
+entities. Update the module docstring: the pilot is over, and what remains
+unrolled is the mixing/ZIP/pool set.
+
+### `const.py`
+
+20 new `SensorKey` members following the existing DHW naming:
+`TIMER_HEATING_SCHEDULE_{WEEK,WEEKDAY,WEEKEND,MONDAY..SUNDAY}` and
+`TIMER_VENTILATION_SCHEDULE_{...}`, with string values matching the member
+name in lowercase.
+
+### `translations/{en,de,nl,cs,pl}.json`
+
+20 keys each under `entity.text`, mirroring the DHW wording, e.g.
+`"Heating Timer Schedule (Monday)"` / `"Heizung-Zeitschaltplan (Montag)"` /
+`"Verwarming tijdschema (maandag)"`. All five files stay in lockstep.
+
+### `text.py` — per-circuit bail
+
+`_active_schedule_descriptions` returns `None` for the entire pass as soon as
+any selector it consults reads back `None`, which suppresses the add/remove
+pass for every circuit at once. With DHW alone that was equivalent to "this
+circuit is unreadable". With three circuits it is not: an undecodable
+ventilation selector — precisely the assumption shipped unverified above —
+would freeze the heating and DHW entities too.
+
+Make the bail per-circuit: collect the `mode_selector_name`s that failed to
+read this poll and skip only the descriptions belonging to them, computing the
+other circuits' active blocks normally. The whole-pass `None` return stays for
+`data is None`, which genuinely carries no information about any circuit.
+
+Nothing else in `text.py` changes: the registry enable/disable sync, the write
+batching in `async_set_value`, and the `available` property are all already
+keyed per description via `mode_selector_name`.
+
+## Testing
+
+Extends `tests/test_text.py`. All existing DHW tests must pass unchanged.
+
+- **Name generation, heating**: `_row_names_row_slot` output spot-checked
+  against real upstream names, e.g. week row 0 -> `ID_Einst_SuHkrW0_zeit_0_0`
+  / `..._zeit_0_1`; per-day row 2, Sunday end -> `ID_Einst_SuHkrTG_zeit_2_13`.
+- **Name generation, ventilation**: e.g. week row 0 ->
+  `ID_Einst_SuLufWo_zeit_0_0_0` / `ID_Einst_SuLufWo_zeit_1_0_0`; per-day row 1,
+  Wednesday end -> `ID_Einst_SuLufTg_zeit_1_1_4`.
+- **Every generated name exists upstream**: assert that each name in every
+  description's `row_names` resolves to a defined parameter, which catches a
+  mistyped prefix (`W0` vs `WO`) for all three circuits at once.
+- **Device gating**: with `has_ventilation` False, no ventilation description
+  is returned by `_active_schedule_descriptions`; with it True and the
+  selector reading `week`, exactly the ventilation week block appears.
+- **Per-circuit bail**: with the ventilation selector unreadable and the DHW
+  and heating selectors reading `week`, the pass still returns both of their
+  week blocks and no ventilation block — the regression this rollout forces.
+- **Datatype overrides**: after `update_Luxtronik_Parameters()`, parameter 895
+  is `TimerProgram` and 896/955 are `TimeOfDay`.
+
+Coverage must not regress; run the full suite with `--cov` scoped at the
+package root.

--- a/docs/superpowers/specs/2026-08-14-heating-ventilation-timer-schedules-design.md
+++ b/docs/superpowers/specs/2026-08-14-heating-ventilation-timer-schedules-design.md
@@ -39,8 +39,28 @@ Device gating is already generic: `coordinator.device_key_active` returns
 for `DeviceKey.ventilation`, and `_active_schedule_descriptions` already calls
 `entity_active`. No coordinator change is needed.
 
-Each circuit yields 10 entities: week, weekday, weekend, and one per weekday
-Monday-Sunday. 20 new entities in total.
+Each circuit yields 10 text entities: week, weekday, weekend, and one per
+weekday Monday-Sunday. 20 new text entities in total.
+
+## Program mode selects
+
+DHW also exposes its mode selector as a select entity (`SK.TIMER_DHW_PROGRAM`
+-> `LuxParameter.P0405_TIMER_PROGRAM_DHW` in `select_entities_predefined.py`).
+Without the equivalents, a user can see the new schedules but cannot switch
+which program is active from Home Assistant - and which schedule entities
+exist at all is driven by exactly that selector. So both circuits get one too:
+
+| | Heating | Ventilation |
+|---|---|---|
+| Sensor key | `SK.TIMER_HEATING_PROGRAM` | `SK.TIMER_VENTILATION_PROGRAM` |
+| Lux parameter | `P0222_TIMER_PROGRAM_HEATING` | `P0895_TIMER_PROGRAM_VENTILATION` |
+| Device | `DeviceKey.heating` | `DeviceKey.ventilation` |
+
+Both reuse the existing `timer_program_options` /
+`TIMER_PROGRAM_RAW_OPTIONS` mapping (`week` / `weekday_weekend` -> `"5+2"` /
+`daily` -> `"days"`) and `EntityCategory.CONFIG`, exactly like the DHW one.
+They need the same `name` + `state` translation shape as
+`entity.select.timer_dhw_program` in all five languages.
 
 ## Parameter-name layouts
 
@@ -118,13 +138,26 @@ unrolled is the mixing/ZIP/pool set.
 20 new `SensorKey` members following the existing DHW naming:
 `TIMER_HEATING_SCHEDULE_{WEEK,WEEKDAY,WEEKEND,MONDAY..SUNDAY}` and
 `TIMER_VENTILATION_SCHEDULE_{...}`, with string values matching the member
-name in lowercase.
+name in lowercase, plus `TIMER_HEATING_PROGRAM` and
+`TIMER_VENTILATION_PROGRAM`.
+
+Two new `LuxParameter` members alongside `P0405_TIMER_PROGRAM_DHW`:
+`P0222_TIMER_PROGRAM_HEATING = "parameters.ID_Einst_SuHkr_akt"` and
+`P0895_TIMER_PROGRAM_VENTILATION = "parameters.ID_Einst_SuLuf_akt"`.
+
+### `select_entities_predefined.py`
+
+Two `LuxtronikSelectEntityDescription` entries appended to `SELECT_ENTITIES`,
+copying the `SK.TIMER_DHW_PROGRAM` entry's shape with the keys, parameters and
+devices from the table above.
 
 ### `translations/{en,de,nl,cs,pl}.json`
 
 20 keys each under `entity.text`, mirroring the DHW wording, e.g.
 `"Heating Timer Schedule (Monday)"` / `"Heizung-Zeitschaltplan (Montag)"` /
-`"Verwarming tijdschema (maandag)"`. All five files stay in lockstep.
+`"Verwarming tijdschema (maandag)"`, and 2 keys each under `entity.select`
+with the same `name` + `state` shape as `timer_dhw_program`. All five files
+stay in lockstep.
 
 ### `text.py` — per-circuit bail
 
@@ -135,18 +168,34 @@ circuit is unreadable". With three circuits it is not: an undecodable
 ventilation selector — precisely the assumption shipped unverified above —
 would freeze the heating and DHW entities too.
 
-Make the bail per-circuit: collect the `mode_selector_name`s that failed to
-read this poll and skip only the descriptions belonging to them, computing the
-other circuits' active blocks normally. The whole-pass `None` return stays for
-`data is None`, which genuinely carries no information about any circuit.
+Make the bail per-circuit. `_active_schedule_descriptions` returns
+`tuple[list[description], set[str]] | None`: the active blocks, plus the
+`mode_selector_name`s that could not be read this poll. `None` stays reserved
+for `data is None`, which genuinely carries no information about any circuit.
 
-Nothing else in `text.py` changes: the registry enable/disable sync, the write
-batching in `async_set_value`, and the `available` property are all already
-keyed per description via `mode_selector_name`.
+"Skipping" an unreadable circuit means more than leaving it out of the active
+list — its live entities must also survive. `async_apply` derives the frozen
+keys (every description whose selector is unreadable) and excludes them from
+both `to_remove` and the `_disable_inactive` pass, so an unreadable circuit is
+left exactly as it is while the others are synced normally. Without that, the
+per-circuit skip would cause the very teardown the whole-pass bail exists to
+prevent.
+
+Nothing else in `text.py` changes: `_enable_active`, the write batching in
+`async_set_value`, and the `available` property already work per description.
+An entity of an unreadable circuit reports unavailable (its selector reads
+`None`, which never equals `active_mode`) while keeping its registry entry and
+history — which is the intended behaviour.
+
+This changes the helper's return type, so the private `_call` helper in
+`TestActiveScheduleDescriptions` unwraps the tuple; its assertions and every
+other existing DHW test stay as they are.
 
 ## Testing
 
-Extends `tests/test_text.py`. All existing DHW tests must pass unchanged.
+Extends `tests/test_text.py`. All existing DHW tests keep their assertions;
+the only edit permitted to them is unwrapping the new tuple return in the
+`TestActiveScheduleDescriptions._call` helper.
 
 - **Name generation, heating**: `_row_names_row_slot` output spot-checked
   against real upstream names, e.g. week row 0 -> `ID_Einst_SuHkrW0_zeit_0_0`
@@ -160,11 +209,18 @@ Extends `tests/test_text.py`. All existing DHW tests must pass unchanged.
 - **Device gating**: with `has_ventilation` False, no ventilation description
   is returned by `_active_schedule_descriptions`; with it True and the
   selector reading `week`, exactly the ventilation week block appears.
-- **Per-circuit bail**: with the ventilation selector unreadable and the DHW
-  and heating selectors reading `week`, the pass still returns both of their
-  week blocks and no ventilation block — the regression this rollout forces.
+- **Per-circuit bail**: with one circuit's selector unreadable and the others
+  reading `week`, the pass still returns the readable circuits' week blocks
+  and reports the unreadable selector in the second element of the tuple.
+- **Frozen circuit is left alone**: a live entity of a circuit whose selector
+  turns unreadable is neither removed from the state machine nor written to
+  the registry, while a second, readable circuit still swaps its blocks in the
+  same pass.
 - **Datatype overrides**: after `update_Luxtronik_Parameters()`, parameter 895
   is `TimerProgram` and 896/955 are `TimeOfDay`.
+- **Program selects** (`tests/test_select.py`): the two new descriptions are
+  present in `SELECT_ENTITIES` with the expected `luxtronik_key`, device and
+  `raw_option_map`, so a wrong parameter string is caught at CI time.
 
 Coverage must not regress; run the full suite with `--cov` scoped at the
 package root.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -388,6 +388,75 @@ class TestDeviceKeyActive:
         coord = _make_coordinator(calculations={})
         assert coord.device_key_active(DeviceKey.ventilation) is False
 
+    def test_ventilation_stays_active_once_detected(self):
+        """The detection latches on, because the evidence is a live reading.
+
+        A supply-air channel genuinely passing through 0.0 or 5.0 C - while
+        the exhaust channel sits on the unwired 5.0 sentinel - makes both
+        channels look absent for that poll. Without the latch the device
+        would disappear and come back, and `text.py` (the only per-poll
+        caller of `entity_active`) would tear its schedule entities down and
+        rebuild them each time.
+        """
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_Temp_Lueftung_Zuluft": 17.4,
+                "ID_WEB_Temp_Lueftung_Abluft": 5.0,
+            }
+        )
+        assert coord.device_key_active(DeviceKey.ventilation) is True
+
+        # The supply air drifts down onto a sentinel: both channels now look
+        # absent, but the module has not gone anywhere.
+        coord.data = make_coordinator_data(
+            calculations={
+                "ID_WEB_Temp_Lueftung_Zuluft": 5.0,
+                "ID_WEB_Temp_Lueftung_Abluft": 5.0,
+            }
+        )
+        assert coord.device_key_active(DeviceKey.ventilation) is True
+
+    def test_ventilation_detected_on_a_later_poll(self):
+        """A first poll landing on a sentinel must not be final.
+
+        This is why the gate latches on rather than being evaluated once at
+        setup: a restart during a cold spell would otherwise hide the module
+        for the whole session.
+        """
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_Temp_Lueftung_Zuluft": 0.0,
+                "ID_WEB_Temp_Lueftung_Abluft": 0.0,
+            }
+        )
+        assert coord.device_key_active(DeviceKey.ventilation) is False
+
+        coord.data = make_coordinator_data(
+            calculations={
+                "ID_WEB_Temp_Lueftung_Zuluft": 17.4,
+                "ID_WEB_Temp_Lueftung_Abluft": 0.0,
+            }
+        )
+        assert coord.device_key_active(DeviceKey.ventilation) is True
+
+    def test_ventilation_latch_is_per_coordinator(self):
+        """The latch lives in memory, so a fresh entry re-detects."""
+        detected = _make_coordinator(
+            calculations={
+                "ID_WEB_Temp_Lueftung_Zuluft": 17.4,
+                "ID_WEB_Temp_Lueftung_Abluft": 21.2,
+            }
+        )
+        assert detected.device_key_active(DeviceKey.ventilation) is True
+
+        fresh = _make_coordinator(
+            calculations={
+                "ID_WEB_Temp_Lueftung_Zuluft": 0.0,
+                "ID_WEB_Temp_Lueftung_Abluft": 0.0,
+            }
+        )
+        assert fresh.device_key_active(DeviceKey.ventilation) is False
+
     def test_unknown_device_key_raises(self):
         coord = _make_coordinator()
         with pytest.raises(NotImplementedError):

--- a/tests/test_lux_overrides.py
+++ b/tests/test_lux_overrides.py
@@ -198,8 +198,21 @@ class TestTimeOfDay:
         assert self.TimeOfDay.from_heatpump(6 * 3600) == "06:00"
         assert self.TimeOfDay.from_heatpump(22 * 3600 + 30 * 60) == "22:30"
 
-    def test_from_heatpump_includes_seconds_when_nonzero(self):
-        assert self.TimeOfDay.from_heatpump(6 * 3600 + 15) == "06:00:15"
+    def test_from_heatpump_drops_seconds(self):
+        """The controller can only set whole minutes, so seconds are noise.
+
+        Rendering them would also widen the value past what the schedule
+        text entities allow: `_attr_native_max` there budgets 11 characters
+        per "HH:MM-HH:MM" pair.
+        """
+        assert self.TimeOfDay.from_heatpump(6 * 3600 + 15) == "06:00"
+        assert self.TimeOfDay.from_heatpump(6 * 3600 + 59) == "06:00"
+        assert self.TimeOfDay.from_heatpump(59) == "00:00"
+
+    def test_from_heatpump_is_always_five_characters(self):
+        """The invariant `_attr_native_max` in text.py is sized against."""
+        for raw in range(0, 24 * 3600, 617):
+            assert len(self.TimeOfDay.from_heatpump(raw)) == 5
 
     def test_from_heatpump_non_int_returns_none(self):
         assert self.TimeOfDay.from_heatpump("06:00") is None

--- a/tests/test_lux_overrides.py
+++ b/tests/test_lux_overrides.py
@@ -417,3 +417,47 @@ class TestUnknownSelectionCodeWarning:
         lux_overrides.warn_on_unknown_selection_codes()
         HeatpumpCode("ID_WEB_Code_WP_akt").from_heatpump(9999)
         assert caplog.text.count("9999") == 1
+
+
+class TestTimerScheduleDatatypeCoverage:
+    """Both timer-program parameter blocks must get their datatypes.
+
+    The heating/DHW/pool block is contiguous at 162-667, but the ventilation
+    block sits apart at 895-955 and was not covered at all, so every
+    ventilation time decoded as a raw seconds integer.
+    """
+
+    def _applied(self):
+        from luxtronik.parameters import Parameters
+
+        from custom_components.luxtronik2.lux_overrides import (
+            update_Luxtronik_Parameters,
+        )
+
+        update_Luxtronik_Parameters()
+        return Parameters.parameters
+
+    def test_ventilation_selector_is_a_timer_program(self):
+        from custom_components.luxtronik2.lux_overrides import TimerProgram
+
+        assert isinstance(self._applied()[895], TimerProgram)
+
+    def test_ventilation_times_are_time_of_day(self):
+        from custom_components.luxtronik2.lux_overrides import TimeOfDay
+
+        parameters = self._applied()
+        # First and last of both the start block (896-925) and the
+        # interleaved end block (926-955).
+        for number in (896, 925, 926, 955):
+            assert isinstance(parameters[number], TimeOfDay), number
+
+    def test_heating_block_is_still_covered(self):
+        from custom_components.luxtronik2.lux_overrides import (
+            TimeOfDay,
+            TimerProgram,
+        )
+
+        parameters = self._applied()
+        assert isinstance(parameters[222], TimerProgram)
+        for number in (223, 282):
+            assert isinstance(parameters[number], TimeOfDay), number

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -263,3 +263,60 @@ class TestRawOptionMap:
         entity._handle_coordinator_update()
         assert entity._attr_options == ["automatic", "off"]
         assert entity._attr_current_option == "automatic"
+
+
+# ===========================================================================
+# Heating and ventilation timer program selects
+# ===========================================================================
+
+
+class TestTimerProgramSelects:
+    """The program selector of every schedule-carrying circuit is settable."""
+
+    def _description(self, key):
+        from custom_components.luxtronik2.select_entities_predefined import (
+            SELECT_ENTITIES,
+        )
+
+        return next(d for d in SELECT_ENTITIES if d.key == key)
+
+    def test_heating_program_select(self):
+        description = self._description(SensorKey.TIMER_HEATING_PROGRAM)
+        assert description.luxtronik_key == LuxParameter.P0222_TIMER_PROGRAM_HEATING
+        assert description.device_key is DeviceKey.heating
+        assert description.raw_option_map == {
+            "week": "week",
+            "weekday_weekend": "5+2",
+            "daily": "days",
+        }
+
+    def test_ventilation_program_select(self):
+        description = self._description(SensorKey.TIMER_VENTILATION_PROGRAM)
+        assert description.luxtronik_key == LuxParameter.P0895_TIMER_PROGRAM_VENTILATION
+        assert description.device_key is DeviceKey.ventilation
+        assert description.options == ["week", "weekday_weekend", "daily"]
+
+    def test_parameter_strings_match_the_schedule_selectors(self):
+        """The select and the schedule entities must drive the same register.
+
+        A typo in either parameter string would silently give the user a
+        selector that writes somewhere else while the schedules keep reading
+        the real one.
+        """
+        from custom_components.luxtronik2.timer_schedule_entities_predefined import (
+            TIMER_SCHEDULE_ENTITIES,
+        )
+
+        selectors = {
+            SensorKey.TIMER_HEATING_SCHEDULE_WEEK: (
+                LuxParameter.P0222_TIMER_PROGRAM_HEATING
+            ),
+            SensorKey.TIMER_VENTILATION_SCHEDULE_WEEK: (
+                LuxParameter.P0895_TIMER_PROGRAM_VENTILATION
+            ),
+        }
+        for schedule_key, parameter in selectors.items():
+            description = next(
+                d for d in TIMER_SCHEDULE_ENTITIES if d.key == schedule_key
+            )
+            assert parameter.value == f"parameters.{description.mode_selector_name}"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
 import pytest
@@ -245,6 +245,32 @@ class TestRawOptionMap:
         entity, coord = self._make_selector("week")
         await entity.async_select_option("weekday_weekend")
         coord.async_write.assert_awaited_once_with("ID_Einst_SUBW_akt2", "5+2")
+
+    def test_an_unrecognised_raw_value_is_warned_about_once(self):
+        """The coordinator polls constantly; one bad code must not spam the log.
+
+        The ventilation timer program's code mapping (parameter 895) is an
+        inference, so a controller whose codes differ would otherwise emit
+        one WARNING per poll forever. The first occurrence still warns, and
+        a second, different bad value warns again.
+        """
+        entity, coord = self._make_selector("week")
+        with patch("custom_components.luxtronik2.select.LOGGER") as logger:
+            coord.data = make_coordinator_data(
+                parameters={"ID_Einst_SUBW_akt2": "nonsense"}
+            )
+            entity._handle_coordinator_update()
+            entity._handle_coordinator_update()
+            entity._handle_coordinator_update()
+            assert logger.warning.call_count == 1
+
+            coord.data = make_coordinator_data(
+                parameters={"ID_Einst_SUBW_akt2": "other-nonsense"}
+            )
+            entity._handle_coordinator_update()
+            assert logger.warning.call_count == 2
+        # State is untouched by an unrecognised value, as before.
+        assert entity._attr_current_option is None
 
     def test_existing_selectors_keep_working_without_a_map(self):
         from custom_components.luxtronik2.select import LuxtronikModeSelector

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -94,12 +94,15 @@ class TestTimerScheduleTable:
 
         assert not problems, "\n".join(problems)
 
-    def test_ten_dhw_entities_generated(self):
-        assert len(TIMER_SCHEDULE_ENTITIES) == 10
+    def test_entity_count(self):
+        assert len(TIMER_SCHEDULE_ENTITIES) == 20
 
-    def test_row_counts_are_five_for_dhw(self):
-        for description in TIMER_SCHEDULE_ENTITIES:
-            assert len(description.row_names) == 5
+    def test_row_counts_per_circuit(self):
+        """DHW has 5 slots per day, the heating circuit only 3."""
+        by_key = {d.key: len(d.row_names) for d in TIMER_SCHEDULE_ENTITIES}
+        assert by_key[SK.TIMER_DHW_SCHEDULE_WEEK] == 5
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEK] == 3
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_SUNDAY] == 3
 
     def test_active_modes(self):
         by_key = {d.key: d.active_mode for d in TIMER_SCHEDULE_ENTITIES}
@@ -108,6 +111,45 @@ class TestTimerScheduleTable:
         assert by_key[SK.TIMER_DHW_SCHEDULE_WEEKEND] == "5+2"
         assert by_key[SK.TIMER_DHW_SCHEDULE_MONDAY] == "days"
         assert by_key[SK.TIMER_DHW_SCHEDULE_SUNDAY] == "days"
+
+    def test_heating_selector_and_device(self):
+        from custom_components.luxtronik2.const import DeviceKey
+
+        description = next(
+            d
+            for d in TIMER_SCHEDULE_ENTITIES
+            if d.key == SK.TIMER_HEATING_SCHEDULE_WEEK
+        )
+        assert description.mode_selector_name == "ID_Einst_SuHkr_akt"
+        assert description.device_key is DeviceKey.heating
+
+    def test_heating_row_names(self):
+        """Spot-checks against the real upstream names (222-282).
+
+        The heating prefixes are spelled `SuHkrW0` (digit zero) and `SuHkrTG`,
+        which differ from DHW's `SuBwWO`/`SuBwTG` - a copy-paste of the DHW
+        prefix would still generate plausible-looking names.
+        """
+        by_key = {d.key: d.row_names for d in TIMER_SCHEDULE_ENTITIES}
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEK][0] == (
+            "ID_Einst_SuHkrW0_zeit_0_0",
+            "ID_Einst_SuHkrW0_zeit_0_1",
+        )
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEKEND][0] == (
+            "ID_Einst_SuHkr25_zeit_0_2",
+            "ID_Einst_SuHkr25_zeit_0_3",
+        )
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_SUNDAY][2] == (
+            "ID_Einst_SuHkrTG_zeit_2_12",
+            "ID_Einst_SuHkrTG_zeit_2_13",
+        )
+
+    def test_heating_active_modes(self):
+        by_key = {d.key: d.active_mode for d in TIMER_SCHEDULE_ENTITIES}
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEK] == "week"
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEKDAY] == "5+2"
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEKEND] == "5+2"
+        assert by_key[SK.TIMER_HEATING_SCHEDULE_MONDAY] == "days"
 
 
 # ===========================================================================

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -95,7 +95,7 @@ class TestTimerScheduleTable:
         assert not problems, "\n".join(problems)
 
     def test_entity_count(self):
-        assert len(TIMER_SCHEDULE_ENTITIES) == 20
+        assert len(TIMER_SCHEDULE_ENTITIES) == 30
 
     def test_row_counts_per_circuit(self):
         """DHW has 5 slots per day, the heating circuit only 3."""
@@ -150,6 +150,43 @@ class TestTimerScheduleTable:
         assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEKDAY] == "5+2"
         assert by_key[SK.TIMER_HEATING_SCHEDULE_WEEKEND] == "5+2"
         assert by_key[SK.TIMER_HEATING_SCHEDULE_MONDAY] == "days"
+
+    def test_ventilation_selector_and_device(self):
+        from custom_components.luxtronik2.const import DeviceKey
+
+        description = next(
+            d
+            for d in TIMER_SCHEDULE_ENTITIES
+            if d.key == SK.TIMER_VENTILATION_SCHEDULE_WEEK
+        )
+        assert description.mode_selector_name == "ID_Einst_SuLuf_akt"
+        assert description.device_key is DeviceKey.ventilation
+        assert len(description.row_names) == 3
+
+    def test_ventilation_row_names_use_the_leading_start_end_index(self):
+        """Ventilation names are `<prefix>_zeit_<0|1>_<row>_<2*col>`.
+
+        The start and end blocks are interleaved in the parameter numbering
+        (starts 896-925, ends 926-955), unlike every other circuit where the
+        end sits immediately after its start.
+        """
+        by_key = {d.key: d.row_names for d in TIMER_SCHEDULE_ENTITIES}
+        assert by_key[SK.TIMER_VENTILATION_SCHEDULE_WEEK][0] == (
+            "ID_Einst_SuLufWo_zeit_0_0_0",
+            "ID_Einst_SuLufWo_zeit_1_0_0",
+        )
+        assert by_key[SK.TIMER_VENTILATION_SCHEDULE_WEEKEND][2] == (
+            "ID_Einst_SuLuf25_zeit_0_2_2",
+            "ID_Einst_SuLuf25_zeit_1_2_2",
+        )
+        assert by_key[SK.TIMER_VENTILATION_SCHEDULE_WEDNESDAY][1] == (
+            "ID_Einst_SuLufTg_zeit_0_1_4",
+            "ID_Einst_SuLufTg_zeit_1_1_4",
+        )
+        assert by_key[SK.TIMER_VENTILATION_SCHEDULE_SUNDAY][2] == (
+            "ID_Einst_SuLufTg_zeit_0_2_12",
+            "ID_Einst_SuLufTg_zeit_1_2_12",
+        )
 
 
 # ===========================================================================
@@ -427,6 +464,24 @@ class TestActiveScheduleDescriptions:
         active, unreadable = _active_schedule_descriptions(coord, data)
         assert [d.key for d in active] == [SK.TIMER_HEATING_SCHEDULE_WEEK]
         assert unreadable == {self._SELECTOR}
+
+    def test_ventilation_blocks_are_skipped_without_a_ventilation_module(self):
+        """`entity_active` is False for the ventilation device on such a unit."""
+        from custom_components.luxtronik2.const import DeviceKey
+        from custom_components.luxtronik2.text import _active_schedule_descriptions
+
+        data = make_coordinator_data(
+            parameters={self._SELECTOR: "week", "ID_Einst_SuLuf_akt": "week"}
+        )
+        coord = _mock_coordinator(data)
+        coord.entity_active.side_effect = lambda description: (
+            description.device_key is not DeviceKey.ventilation
+        )
+        active, unreadable = _active_schedule_descriptions(coord, data)
+        keys = [d.key for d in active]
+        assert SK.TIMER_DHW_SCHEDULE_WEEK in keys
+        assert SK.TIMER_VENTILATION_SCHEDULE_WEEK not in keys
+        assert unreadable == set()
 
     def test_data_none_still_yields_no_information(self):
         """No coordinator data at all is "unknown" for every circuit."""

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,4 +1,4 @@
-"""Tests for the DHW timer-program schedule text entities."""
+"""Tests for the DHW, heating and ventilation timer-program schedule text entities."""
 
 from __future__ import annotations
 
@@ -281,6 +281,22 @@ class TestLuxtronikTimerScheduleText:
         data = make_coordinator_data(parameters={start0: "00:00", end0: "00:00"})
         entity._handle_coordinator_update(data)
         assert entity._attr_native_value == ""
+
+    def test_a_fully_populated_block_lands_exactly_on_native_max(self):
+        """`_attr_native_max` must fit the widest value the block can render.
+
+        Every pair is 11 characters because `TimeOfDay` always renders
+        "HH:MM" (it drops the seconds a non-minute-aligned register would
+        otherwise carry) - this is the consumer side of that invariant.
+        """
+        longest = max(TIMER_SCHEDULE_ENTITIES, key=lambda d: len(d.row_names))
+        entity, _, description = self._make_entity(key=longest.key)
+        parameters = {}
+        for start_name, end_name in description.row_names:
+            parameters[start_name] = "06:00"
+            parameters[end_name] = "22:00"
+        entity._handle_coordinator_update(make_coordinator_data(parameters=parameters))
+        assert len(entity._attr_native_value) == entity._attr_native_max
 
     def test_handle_coordinator_update_none_data(self):
         entity, coord, _ = self._make_entity()
@@ -758,49 +774,45 @@ class TestTimerScheduleSync:
         assert list(sync._entities) == [SK.TIMER_DHW_SCHEDULE_WEEK]
 
     @pytest.mark.asyncio
-    async def test_unreadable_selector_does_not_remove_or_disable_anything(self):
-        """A glitched selector read must be a no-op, not a full teardown.
-
-        Regression test: treating an undecodable selector value as "no
-        program active" removed every live schedule entity and wrote
-        `disabled_by = INTEGRATION` on all 10 registry entries, with the next
-        good poll re-adding and re-enabling them - entity churn, registry
-        writes and a recorder gap caused by one transient read.
-        """
-        from custom_components.luxtronik2.text import LuxtronikTimerScheduleText
-
-        sync, coord, _added = self._make_sync("week")
-        registry = self._registry({})
-        with (
-            patch(
-                "custom_components.luxtronik2.text.er.async_get", return_value=registry
-            ),
-            patch("homeassistant.helpers.frame.report_usage"),
-        ):
-            await sync.async_setup()
-            registry.async_update_entity.reset_mock()
-            coord.data = make_coordinator_data(parameters={self._SELECTOR: None})
-            with patch.object(
-                LuxtronikTimerScheduleText, "async_remove", new=AsyncMock()
-            ) as remove:
-                await sync.async_apply()
-
-        remove.assert_not_awaited()
-        registry.async_update_entity.assert_not_called()
-        assert list(sync._entities) == [SK.TIMER_DHW_SCHEDULE_WEEK]
-
-    @pytest.mark.asyncio
     async def test_an_unreadable_circuit_is_frozen_while_others_still_sync(self):
         """A frozen circuit keeps its live entities and registry entries.
 
+        Regression test: treating an undecodable selector value as "no
+        program active" removed every live schedule entity of that circuit
+        and wrote `disabled_by = INTEGRATION` on its registry entries, with
+        the next good poll re-adding and re-enabling them - entity churn,
+        registry writes and a recorder gap caused by one transient read.
+
         The per-circuit skip is only safe if the sync also refuses to remove
         and disable that circuit's blocks - otherwise it causes exactly the
-        teardown the whole-pass bail existed to prevent.
+        teardown the whole-pass bail existed to prevent. Real registry ids
+        are seeded for both circuits (not an empty registry) so that a
+        regression which drops the freeze from the `_disable_inactive` call
+        has an actual row to wrongly write `disabled_by` to - an empty
+        registry would make `async_get_entity_id` return `None` for the
+        frozen circuit and the assertions below would pass for the wrong
+        reason.
         """
-        from custom_components.luxtronik2.text import LuxtronikTimerScheduleText
+        from custom_components.luxtronik2.text import (
+            LuxtronikTimerScheduleText,
+            _timer_schedule_unique_id,
+        )
 
         sync, coord, added = self._make_sync("week")
-        registry = self._registry({})
+        entry = _mock_entry()
+        dhw_week = next(
+            d for d in TIMER_SCHEDULE_ENTITIES if d.key == SK.TIMER_DHW_SCHEDULE_WEEK
+        )
+        dhw_week_id = _timer_schedule_unique_id(entry, dhw_week)
+        heating_week = next(
+            d
+            for d in TIMER_SCHEDULE_ENTITIES
+            if d.key == SK.TIMER_HEATING_SCHEDULE_WEEK
+        )
+        heating_week_id = _timer_schedule_unique_id(entry, heating_week)
+        registry = self._registry(
+            {dhw_week_id: self._entry(), heating_week_id: self._entry()}
+        )
         with (
             patch(
                 "custom_components.luxtronik2.text.er.async_get", return_value=registry
@@ -816,6 +828,7 @@ class TestTimerScheduleSync:
                 SK.TIMER_DHW_SCHEDULE_WEEK,
                 SK.TIMER_HEATING_SCHEDULE_WEEK,
             }
+            registry.async_update_entity.reset_mock()
 
             # DHW's selector glitches while heating switches program.
             coord.data = make_coordinator_data(
@@ -834,6 +847,14 @@ class TestTimerScheduleSync:
             SK.TIMER_HEATING_SCHEDULE_WEEKDAY,
             SK.TIMER_HEATING_SCHEDULE_WEEKEND,
         ]
+        # The heating circuit's now-inactive week entry got disabled...
+        registry.async_update_entity.assert_any_call(
+            heating_week_id, disabled_by=RegistryEntryDisabler.INTEGRATION
+        )
+        # ...but the frozen DHW circuit's registry entry was never touched by
+        # any call, in either position.
+        for call in registry.async_update_entity.call_args_list:
+            assert call.args[0] != dhw_week_id
 
     @pytest.mark.asyncio
     async def test_removal_of_an_entity_that_never_reached_the_platform(self):

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -371,7 +371,8 @@ class TestActiveScheduleDescriptions:
         data = make_coordinator_data(parameters=parameters)
         coord = _mock_coordinator(data)
         coord.entity_active.return_value = entity_active
-        return [d.key for d in _active_schedule_descriptions(coord, data)]
+        active, _unreadable = _active_schedule_descriptions(coord, data)
+        return [d.key for d in active]
 
     def test_week_mode_yields_only_the_week_block(self):
         assert self._call({self._SELECTOR: "week"}) == [SK.TIMER_DHW_SCHEDULE_WEEK]
@@ -392,29 +393,46 @@ class TestActiveScheduleDescriptions:
         """A selector that this controller does not have is a real answer: no blocks."""
         assert self._call({}) == []
 
-    def test_data_none_yields_no_information(self):
-        """No coordinator data at all is "unknown", not "no program active"."""
-        from custom_components.luxtronik2.text import _active_schedule_descriptions
+    def test_inactive_entity_yields_nothing(self):
+        assert self._call({self._SELECTOR: "week"}, entity_active=False) == []
 
-        assert _active_schedule_descriptions(_mock_coordinator(), None) is None
-
-    def test_undecodable_selector_yields_no_information(self):
+    def test_undecodable_selector_freezes_only_its_own_circuit(self):
         """A present-but-unreadable selector must not read as "no program active".
 
         `get_sensor_data` returns None both for an absent register and for a
-        register whose datatype could not decode the raw value this poll
-        (`SelectionBase` returns None for an unrecognised code). Treating the
-        latter as "nothing is active" would drop all 10 entities and disable
-        all 10 registry entries on a single glitched read.
+        register whose datatype could not decode the raw value
+        (`SelectionBase` returns None for an unrecognised code). The selector
+        is reported as unreadable so the sync leaves that circuit alone.
         """
         from custom_components.luxtronik2.text import _active_schedule_descriptions
 
         data = make_coordinator_data(parameters={self._SELECTOR: None})
         coord = _mock_coordinator(data)
-        assert _active_schedule_descriptions(coord, data) is None
+        active, unreadable = _active_schedule_descriptions(coord, data)
+        assert active == []
+        assert unreadable == {self._SELECTOR}
 
-    def test_inactive_entity_yields_nothing(self):
-        assert self._call({self._SELECTOR: "week"}, entity_active=False) == []
+    def test_one_unreadable_circuit_does_not_hide_another(self):
+        """The regression the second circuit makes possible.
+
+        Before this, any single unreadable selector returned "no information"
+        for the whole pass, freezing every circuit's entities.
+        """
+        from custom_components.luxtronik2.text import _active_schedule_descriptions
+
+        data = make_coordinator_data(
+            parameters={self._SELECTOR: None, "ID_Einst_SuHkr_akt": "week"}
+        )
+        coord = _mock_coordinator(data)
+        active, unreadable = _active_schedule_descriptions(coord, data)
+        assert [d.key for d in active] == [SK.TIMER_HEATING_SCHEDULE_WEEK]
+        assert unreadable == {self._SELECTOR}
+
+    def test_data_none_still_yields_no_information(self):
+        """No coordinator data at all is "unknown" for every circuit."""
+        from custom_components.luxtronik2.text import _active_schedule_descriptions
+
+        assert _active_schedule_descriptions(_mock_coordinator(), None) is None
 
 
 # ===========================================================================
@@ -715,6 +733,52 @@ class TestTimerScheduleSync:
         remove.assert_not_awaited()
         registry.async_update_entity.assert_not_called()
         assert list(sync._entities) == [SK.TIMER_DHW_SCHEDULE_WEEK]
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_circuit_is_frozen_while_others_still_sync(self):
+        """A frozen circuit keeps its live entities and registry entries.
+
+        The per-circuit skip is only safe if the sync also refuses to remove
+        and disable that circuit's blocks - otherwise it causes exactly the
+        teardown the whole-pass bail existed to prevent.
+        """
+        from custom_components.luxtronik2.text import LuxtronikTimerScheduleText
+
+        sync, coord, added = self._make_sync("week")
+        registry = self._registry({})
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            # Both circuits start in "week" mode.
+            coord.data = make_coordinator_data(
+                parameters={self._SELECTOR: "week", "ID_Einst_SuHkr_akt": "week"}
+            )
+            await sync.async_setup()
+            assert set(sync._entities) == {
+                SK.TIMER_DHW_SCHEDULE_WEEK,
+                SK.TIMER_HEATING_SCHEDULE_WEEK,
+            }
+
+            # DHW's selector glitches while heating switches program.
+            coord.data = make_coordinator_data(
+                parameters={self._SELECTOR: None, "ID_Einst_SuHkr_akt": "5+2"}
+            )
+            with patch.object(
+                LuxtronikTimerScheduleText, "async_remove", new=AsyncMock()
+            ) as remove:
+                await sync.async_apply()
+
+        # Only the heating week block was removed; the DHW one is untouched.
+        assert remove.await_count == 1
+        assert SK.TIMER_DHW_SCHEDULE_WEEK in sync._entities
+        assert SK.TIMER_HEATING_SCHEDULE_WEEK not in sync._entities
+        assert [e.entity_description.key for e in added[2:]] == [
+            SK.TIMER_HEATING_SCHEDULE_WEEKDAY,
+            SK.TIMER_HEATING_SCHEDULE_WEEKEND,
+        ]
 
     @pytest.mark.asyncio
     async def test_removal_of_an_entity_that_never_reached_the_platform(self):


### PR DESCRIPTION
## 🎯 Goal

Rolls the existing timer-program machinery — until now wired up for domestic hot water only — out to the **heating circuit** and the **ventilation module**.

Each circuit gains 10 schedule entities (week, weekdays, weekend, and one per day) plus a `select` for choosing the active program. Without that select you could see the new schedules but not switch between them from Home Assistant — and that selector is exactly what decides which schedule entities exist at all.

Out of scope: the mixing circuits (Mk1/Mk2), circulation pump (ZIP) and pool (Swb). They follow the same pattern and cost one `_TimerCircuit` plus translations each, later.

## 📦 What is added

| | Heating | Ventilation |
|---|---|---|
| Mode selector | `ID_Einst_SuHkr_akt` (222) | `ID_Einst_SuLuf_akt` (895) |
| Rows per day | 3 | 3 |
| Parameter range | 223-282 | 896-955 |
| Device | `DeviceKey.heating` | `DeviceKey.ventilation` |

- **20 new `text` entities** and **2 new `select` entities**, with translations in en/de/nl/cs/pl.
- **`lux_overrides`**: the ventilation block (895-955) sat outside the existing 162-667 range and decoded as raw seconds. 895 now gets `TimerProgram` and 896-955 get `TimeOfDay`.

## ⚠️ Two deliberately unverified assumptions

Both are inferred from the naming pattern rather than from a diagnostics dump, and are documented as such in the spec and in code comments:

1. Parameter 895 uses the same codes as the other selectors (`0 = week`, `1 = 5+2`, `2 = days`).
2. In the ventilation parameter names, the leading index is start(0)/end(1).

If either is wrong, the correction is local: the datatype override for 895, or the ventilation name builder. So that a wrong assumption cannot log forever, `LuxtronikModeSelector` now warns **once per distinct unrecognised raw value** instead of on every poll.

The two circuits do not share a naming scheme: heating uses `<prefix>_zeit_<row>_<slot>` (like DHW), ventilation uses `<prefix>_zeit_<0|1>_<row>_<2*col>` with the start and end blocks interleaved in the numbering (896-925 / 926-955).

## 🐛 Fixes included

- **`has_ventilation` now latches on.** Detection reads two air temperatures and treats `0.0` / `5.0` / `75.0` as sentinels. A supply-air channel genuinely passing through 0 or 5 °C — while the exhaust channel sits on an unwired 5.0 — made the module vanish for that poll. Since `text.py` is the only per-poll caller of `entity_active`, that tore the schedule entities down and wrote `disabled_by`, and the recovery then scheduled a config-entry reload. Once detected, the module now stays for the lifetime of the config entry. Not persisted: a restart re-detects, which also clears the latch if a module is genuinely removed.
- **`TimeOfDay` always renders `HH:MM`.** The controller can only set whole minutes, so seconds in a register are an artefact — and rendering them pushed the value past `_attr_native_max` (11 characters per `HH:MM-HH:MM` pair). Display only: `to_heatpump` still accepts seconds and an untouched row is never written back, so the raw value on the device is left as it is.

## 🧪 Tests

989 tests green, 99% coverage. Beyond the new entities: every generated parameter name must resolve in the library (catching a mistyped prefix such as `W0` vs `WO` for all three circuits at once), the latch transitions, the log-once threshold, and the `HH:MM` invariant asserted from both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
