### PR TITLE
refactor(const,model): 🔥 drop the unusable FirmwareVersionMinor enum

### DIFF
--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -157,15 +157,6 @@ class DeviceKey(StrEnum):
     ventilation = "ventilation"
 
 
-class FirmwareVersionMinor(Enum):
-    """Firmware minor versions."""
-
-    minor_80 = 80
-    minor_88 = 88
-    minor_89 = 89
-    minor_90 = 90
-
-
 LUXTRONIK_HA_SIGNAL_UPDATE_ENTITY = "luxtronik_entry_update"
 
 MIN_TIME_BETWEEN_UPDATES: Final = timedelta(seconds=10)

--- a/custom_components/luxtronik2/model.py
+++ b/custom_components/luxtronik2/model.py
@@ -32,7 +32,6 @@ from packaging.version import Version
 
 from .const import (
     DeviceKey,
-    # FirmwareVersionMinor,
     LuxCalculation,
     LuxOperationMode,
     LuxParameter,
@@ -81,6 +80,17 @@ class LuxtronikEntityDescription(EntityDescription, frozen_or_thawed=True):
     visibility: LuxVisibility | LuxParameter = LuxVisibility.UNSET
     visibility_formula: str | None = None
     entity_active_formula: str | None = None
+    # All four are compared against a Version with `<` / `>`, so they must be
+    # Version instances - a bare int or an Enum member raises TypeError at
+    # entity setup, because Version.__lt__ returns NotImplemented and neither
+    # int nor Enum defines the reflected operator against it.
+    #
+    # The `_minor` pair carries <minor>.<patch> (V3.90.1 -> Version("90.1")),
+    # which is why a whole-number type cannot express the thresholds actually
+    # in use - see water_heater.py, where 88.2 and 88.3 split the DHW target
+    # parameter pair. Prefer testing whether the register is present at all
+    # (`.value is None`) over any version gate; reserve these for registers
+    # present on both sides of a change whose *meaning* moves.
     min_firmware_version_minor: Version | None = None
     max_firmware_version_minor: Version | None = None
     min_firmware_version: Version | None = None

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -538,7 +538,6 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         entity_registry_enabled_default=False,
         native_precision=0,
-        # min_firmware_version_minor=FirmwareVersionMinor.minor_90,
     ),
     # endregion Main heatpump
     # region Heating
@@ -669,7 +668,6 @@ SENSORS: list[descr] = [
         # 0.01 kWh raw unit, applied by the Energy2 datatype this parameter is
         # registered with in lux_overrides - hence no factor. Scale measured
         # against the heat-quantity calculations in #734.
-        # min_firmware_version_minor=FirmwareVersionMinor.minor_89,
     ),
     descr(
         key=SensorKey.FLOW_OUT_TEMPERATURE_EXTERNAL,
@@ -741,7 +739,6 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         native_precision=2,
         # 0.01 kWh raw unit, applied by the Energy2 datatype (see 1136 above).
-        # min_firmware_version_minor=FirmwareVersionMinor.minor_89,
     ),
     descr(
         key=SensorKey.SOLAR_COLLECTOR_TEMPERATURE,
@@ -796,7 +793,6 @@ SENSORS: list[descr] = [
         # 0.01 kWh raw unit, applied by the Energy2 datatype (see 1136 above).
         # This one reads 0.0 on every unit examined in #734, so its scale
         # follows its two siblings by analogy and is not itself measured.
-        # min_firmware_version_minor=FirmwareVersionMinor.minor_88,
     ),
     # endregion Cooling
 ]

--- a/custom_components/luxtronik2/switch_entities_predefined.py
+++ b/custom_components/luxtronik2/switch_entities_predefined.py
@@ -45,14 +45,12 @@ SWITCHES: list[LuxtronikSwitchDescription] = [
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
         visibility=LV.V0357_ELECTRICAL_POWER_LIMITATION_SWITCH,
-        # min_firmware_version_minor=FirmwareVersionMinor.minor_90,
     ),
     LuxtronikSwitchDescription(
         key=SensorKey.THERMAL_POWER_LIMITATION_SWITCH,
         luxtronik_key=LP.P1175_THERMAL_POWER_LIMIT_SWITCH,
         entity_category=EntityCategory.CONFIG,
         entity_registry_enabled_default=False,
-        # min_firmware_version_minor=FirmwareVersionMinor.minor_90,
     ),
     # LuxtronikSwitchDescription(
     #     luxtronik_key=LP.P0870_AMOUNT_COUNTER_ACTIVE,

--- a/tests/test_predefined_entities.py
+++ b/tests/test_predefined_entities.py
@@ -2,13 +2,55 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+import importlib
+import pkgutil
+
+from packaging.version import Version
+
+import custom_components.luxtronik2 as luxtronik2
 from custom_components.luxtronik2.binary_sensor_entities_predefined import (
     BINARY_SENSORS,
 )
 from custom_components.luxtronik2.date_entities_predefined import CALENDAR_ENTITIES
+from custom_components.luxtronik2.model import LuxtronikEntityDescription
 from custom_components.luxtronik2.number_entities_predefined import NUMBER_SENSORS
 from custom_components.luxtronik2.sensor_entities_predefined import SENSORS
 from custom_components.luxtronik2.switch_entities_predefined import SWITCHES
+
+
+def _is_luxtronik_description(item: object) -> bool:
+    """Whether item is one of our entity descriptions.
+
+    Deliberately not isinstance(): HA's `frozen_or_thawed=True` metaclass
+    builds distinct frozen and thawed class objects, so the
+    LuxtronikEntityDescription appearing in a description's MRO is a
+    different object from the imported one and isinstance is always False.
+    Matching on the MRO by name sidesteps that.
+    """
+    return any(
+        base.__name__ == LuxtronikEntityDescription.__name__
+        for base in type(item).__mro__
+    )
+
+
+def _all_descriptions() -> Iterator[LuxtronikEntityDescription]:
+    """Yield every entity description defined anywhere in the package.
+
+    Descriptions live in the *_entities_predefined modules for most
+    platforms, but water_heater and climate declare theirs inline, so this
+    walks every module rather than a fixed list of imports.
+    """
+    for module_info in pkgutil.iter_modules(luxtronik2.__path__):
+        module = importlib.import_module(f"{luxtronik2.__name__}.{module_info.name}")
+        for attr_name in dir(module):
+            if attr_name.startswith("__"):
+                continue
+            value = getattr(module, attr_name)
+            if isinstance(value, (list, tuple)):
+                for item in value:
+                    if _is_luxtronik_description(item):
+                        yield item
 
 
 class TestBinarySensorPredefined:
@@ -63,3 +105,49 @@ class TestDatePredefined:
         for d in CALENDAR_ENTITIES:
             assert d.key is not None
             assert d.luxtronik_key is not None
+
+
+class TestFirmwareVersionFields:
+    """Every firmware gate must hold a Version, on every platform.
+
+    The four firmware fields are compared against a Version with `<` / `>`.
+    A bare int or an Enum member raises TypeError at entity setup, because
+    Version.__lt__ returns NotImplemented and neither int nor Enum defines
+    the reflected operator against it - so the failure surfaces as entities
+    silently missing from a user's installation, not as a test failure.
+
+    This walks every description the package defines rather than a
+    hand-listed set, so a new platform or a new predefined list is covered
+    the moment it exists.
+    """
+
+    FIELDS = (
+        "min_firmware_version",
+        "max_firmware_version",
+        "min_firmware_version_minor",
+        "max_firmware_version_minor",
+    )
+
+    def test_all_descriptions_use_version_or_none(self):
+        descriptions = list(_all_descriptions())
+        # Guard the guard: an import that silently yielded nothing would
+        # make every assertion below vacuous.
+        assert len(descriptions) > 100
+
+        offenders = [
+            (type(descr).__name__, descr.key, name, repr(value))
+            for descr in descriptions
+            for name in self.FIELDS
+            if not isinstance(
+                (value := getattr(descr, name, None)), (Version, type(None))
+            )
+        ]
+        assert offenders == []
+
+    def test_at_least_one_gate_is_actually_in_use(self):
+        """Otherwise the check above passes trivially forever."""
+        assert any(
+            getattr(descr, name, None) is not None
+            for descr in _all_descriptions()
+            for name in self.FIELDS
+        )


### PR DESCRIPTION
## 🔎 What was wrong

`FirmwareVersionMinor` was dead code that modelled a **crashing** idiom.

It was referenced nowhere active — only in six commented-out lines of the form:

```python
# min_firmware_version_minor=FirmwareVersionMinor.minor_90,
```

Uncommenting one raises `TypeError` at entity setup. The four firmware fields are compared against a `Version` with `<` / `>`, and `Version.__lt__` returns `NotImplemented` against an `Enum` member, which defines no reflected operator against it:

```
'<' not supported between instances of 'Version' and 'FirmwareVersionMinor'
```

Since the failure happens during `entity_active()`, it would surface as entities silently missing from a user's installation — not as a test failure.

## 🛠️ What this does

**Removes the enum** rather than teaching the comparison to accept it. It cannot express the thresholds actually in use: `water_heater.py` needs `88.2` and `88.3` to split the DHW target parameter pair, and a whole-number enum has no way to say that. Keeping it would mean maintaining a conversion path for an abstraction with no users that is strictly less expressive than the alternative.

**Deletes all six commented gates** — on the energy sensors (`P1136`, `P1137`, `P1139`, `C0268`) and the power limitation switches (`P1158`, `P1175`). Every one is an *existence* question, and `key_exists` already answers those per unit since #740. All six registers sit above `UPSTREAM_MAX_DEFINED_INDEX`, so `_register_returned` compares the index against the block length the controller actually returned:

| register | 1126-parameter unit | 1200-parameter unit |
|---|---|---|
| P1136 / P1137 / P1139 | not created | created |
| P1158 / P1175 | not created | created |

Uncommenting those lines would have re-added a firmware threshold for a problem already solved correctly, and one that gets the answer right on firmware nobody has a dump from.

**Documents the `Version` requirement** on the four fields in `model.py`, along with the preference for testing register presence over any version gate — reserving these for registers present on *both* sides of a change whose meaning moves.

**Adds a guard test** that walks every description the package defines rather than a hand-listed set, so a new platform or predefined list is covered the moment it exists.

## ✅ No behaviour change

The only live firmware gates are the two DHW water heater descriptions, which already use `Version` and are untouched. Verified that exactly one stays active either side of the split:

| firmware | minor | active `domestic_water` entities |
|---|---|---|
| V3.79.0 | 79.0 | 1 |
| V3.88.2 | 88.2 | 1 |
| V3.88.3 | 88.3 | 1 |
| V3.92.1 | 92.1 | 1 |
| V1.88.1 / V2.92.0 | 88.1 / 92.0 | 1 |

No gap where zero exist, no overlap where both do.

## 🧪 Verification

```
991 passed
ruff check           All checks passed!
ruff format --check  59 files already formatted
basedpyright         0 errors, 0 warnings, 0 notes
codespell            clean
```

99% coverage, no regression.

Two notes on the guard test, both worth keeping in mind for anything similar:

- Its "guard the guard" assertion (`len(descriptions) > 100`) fired on the first run and caught a real flaw in the walker: `isinstance` against `LuxtronikEntityDescription` is **always False**, because HA's `frozen_or_thawed=True` metaclass builds distinct frozen and thawed class objects — the one in a description's MRO is not the one you imported. It now matches on the MRO by name. Without that assertion the test would have passed vacuously forever.
- It was then mutation-tested: injecting an `Enum` member into a real description makes it fail and name the offender.

## 📌 Merge order

Touches `const.py` and `model.py`, which #748 also modifies — different regions, so no conflict is expected, but merging #748 first is the cleaner order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
