### PR TITLE
fix(sensor,coordinator,model): 🐛 scale the aux heater energy counters by controller series

### DIFF
--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -517,6 +517,19 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
             return Version("0")
 
     @property
+    def firmware_series(self) -> int:
+        """Return the controller series, which is the firmware major version.
+
+        The major digit identifies the controller generation - V2.x is a
+        Luxtronik 2.0, V3.x a 2.1 - and never advances on a firmware update,
+        so it is a hardware fact rather than a version threshold. Only use it
+        where a register's *meaning* differs between generations; whether a
+        register exists is decided by reading it, not by this.
+        """
+        rel = self.firmware_package_version.release
+        return rel[0] if rel else 0
+
+    @property
     def firmware_version_minor(self) -> Version:
         """Return firmware 'minor' version as <minor>.<patch>.
         Example:

--- a/custom_components/luxtronik2/model.py
+++ b/custom_components/luxtronik2/model.py
@@ -113,6 +113,18 @@ class LuxtronikSensorDescription(  # type: ignore  # pyright: ignore[reportIncom
     platform = Platform.SENSOR
     factor: float | None = None
     native_precision: int | None = None
+    factor_by_firmware_series: dict[int, float] | None = None
+    """Per-controller-generation override of `factor`, keyed by firmware major.
+
+    For the few registers whose *unit* differs between controller
+    generations rather than their presence - see the auxiliary heater energy
+    counters, 0.1 kWh on a series-3 controller and 0.01 kWh on a series-2 one
+    (#752). A series absent from the mapping falls back to `factor`.
+
+    This cannot live in the datatype the register is registered with: the
+    library overrides are applied once per process, while one process can
+    serve two config entries whose heat pumps are different generations.
+    """
 
 
 class LuxtronikIndexSensorDescription(  # type: ignore  # pyright: ignore[reportIncompatibleVariableOverride]

--- a/custom_components/luxtronik2/sensor.py
+++ b/custom_components/luxtronik2/sensor.py
@@ -203,6 +203,22 @@ class LuxtronikSensorEntity(LuxtronikEntity[LuxtronikSensorDescription], SensorE
         self.entity_id = ENTITY_ID_FORMAT.format(f"{prefix}_{description.key}")
         self._attr_unique_id = self.entity_id
 
+    @property
+    def _value_factor(self) -> float:
+        """Factor to apply to the decoded register value.
+
+        Normally the description's own `factor`, unless it declares a
+        different one for this controller generation - a handful of registers
+        hold the same quantity in a different unit per generation (#752).
+        """
+        descr = self.entity_description
+        by_series = descr.factor_by_firmware_series
+        if by_series is not None:
+            factor = by_series.get(self.coordinator.firmware_series)
+            if factor is not None:
+                return factor
+        return descr.factor or 1
+
     @callback
     def _handle_coordinator_update(
         self, data: LuxtronikCoordinatorData | None = None
@@ -219,7 +235,7 @@ class LuxtronikSensorEntity(LuxtronikEntity[LuxtronikSensorDescription], SensorE
         elif self.entity_description.key == SensorKey.ERROR_REASON:
             self._attr_native_value = value
         elif isinstance(value, float | int):
-            factor = self.entity_description.factor or 1
+            factor = self._value_factor
             precision = self.entity_description.native_precision
             value = float(value) * factor
             if precision is not None:
@@ -535,7 +551,7 @@ class LuxtronikSumSensorEntity(LuxtronikSensorEntity):
             self._attr_native_value = None
         else:
             self._attr_available = True
-            total = sum(summands) * (descr.factor or 1)
+            total = sum(summands) * self._value_factor
             if descr.native_precision is not None:
                 total = round(total, descr.native_precision)
             self._attr_native_value = total

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -41,6 +41,37 @@ from .model import (
 
 # endregion Imports
 
+# What one count of the auxiliary heater's heat counters (parameters 1059 and
+# 1140) is worth, per controller generation, on top of the /10 the Energy
+# datatype they are registered with in lux_overrides already applies.
+#
+# Series 3 - 0.1 kWh per count, so nothing further. Measured, not read off a
+#   unit note: energy divided by the aux heater's run time must equal the
+#   rated element power in parameter 1025, which it does on five units
+#   (MSW4-16, MSW2-6S, MSW2-9S, LW SEC 2; V3.79 through V3.92.3) at this
+#   scale and puts them all at an impossible 0.89 kW element without it.
+#   #490 applied the further /10 to everyone on one unverified display
+#   comparison; #625 measured it away again.
+# Series 2 - 0.01 kWh per count. An LD9 on V2.88.3 read 147140 counts against
+#   1471.4 kWh on the controller's own web page, and the one earlier report
+#   needing /100 also ran V2.88.3 (#752). Every unit behind the series-3
+#   figure above is a series 3, so that sample could not have shown this.
+#   It also puts 1059 back in line with the rest of its register family:
+#   parameters 852/854/878/879, the other ID_Waermemenge_* counters, are
+#   0.01 kWh on both generations (checked against calculations 151/152, which
+#   are 0.1 kWh, on 21 diagnostics dumps). Series 3 is where 1059 leaves it.
+# Series 1 - assumed to match series 2, never measured: there is no V1.x
+#   diagnostics dump in the corpus at all. A controller line that used 0.01 kWh
+#   on series 1, kept it on series 2 and changed to 0.1 on series 3 is a
+#   plausible history; one that used 0.1, switched to 0.01, then switched back
+#   is not. It also keeps series 1 inside the ID_Waermemenge_* family above.
+#   Still an assumption, and the one to revisit first - tracked in #752.
+#
+# Listed exhaustively rather than as a single series-2 exception so that every
+# generation states its scale where it can be checked. A generation missing
+# from the mapping falls back to the description's own `factor`.
+AUX_HEATER_ENERGY_FACTOR_BY_SERIES: dict[int, float] = {1: 0.1, 2: 0.1, 3: 1}
+
 SENSORS_STATUS: list[descr] = [
     descr(
         key=SensorKey.STATUS,
@@ -314,28 +345,9 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         entity_active_formula="!= 0.0",
         visibility=LV.V0324_ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER,
-        # Raw register unit is 0.1 kWh on a series-3 controller, applied by
-        # the Energy datatype this parameter is registered with in
-        # lux_overrides - hence no plain factor. #490 scaled it by a further
-        # /10 based on a single unverified display comparison; measured
-        # against the rated element power (parameter 1025) on five units,
-        # that reported a tenth of the real energy. #625.
-        #
-        # Series-2 controllers count the same register in 0.01 kWh, which is
-        # the further /10 below: an LD9 on V2.88.3 read 147140 counts against
-        # 1471.4 kWh on its own web page, and the one other unit that ever
-        # needed /100 also ran V2.88.3 (#752). Every unit measured onto /10
-        # in #625 is a series 3 - that sample could not have shown this.
-        #
-        # It also makes 1059 consistent with the rest of its register family
-        # on a series-2 controller: parameters 852/854/878/879, the other
-        # ID_Waermemenge_* counters, are 0.01 kWh on every unit seen of
-        # either series (verified against calculations 151/152, which are
-        # 0.1 kWh, on 21 dumps). Series 3 is where 1059 leaves that family.
-        #
-        # No series-1 controller has been compared, so those keep the
-        # series-3 scale until one is.
-        factor_by_firmware_series={2: 0.1},
+        # Register unit differs by controller generation - see
+        # AUX_HEATER_ENERGY_FACTOR_BY_SERIES for the measurements behind each.
+        factor_by_firmware_series=AUX_HEATER_ENERGY_FACTOR_BY_SERIES,
         native_precision=1,
     ),
     descr(
@@ -346,13 +358,11 @@ SENSORS: list[descr] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         entity_active_formula="!= 0.0",
-        # 0.1 kWh raw unit, applied by the Energy datatype (see 1059 above),
-        # and the same 0.01 kWh unit on a series-2 controller. That last part
-        # is by analogy rather than by measurement - it is the same physical
-        # element on the same controller as 1059, and no series-2 unit has
-        # been seen with 1140 counting yet - but leaving it out would make a
-        # unit's total change scale mid-handover.
-        factor_by_firmware_series={2: 0.1},
+        # Shares 1059's scale, by analogy rather than by measurement: it is
+        # the same physical element on the same controller, and no series-2
+        # unit has been seen with 1140 counting yet. Giving it its own scale
+        # would make a unit's total jump at the handover between the two.
+        factor_by_firmware_series=AUX_HEATER_ENERGY_FACTOR_BY_SERIES,
         native_precision=1,
         # Despite the name this is not the second heat generator (ZWE2) - it
         # counts the same element as 1059, which stops advancing once this
@@ -863,9 +873,8 @@ SENSORS_SUM: list[sum_descr] = [
         # cannot be selected in the energy dashboard, which is the main thing
         # a lifetime kWh counter is for.
         #
-        # Both summands share the series-2 unit, so one factor covers the
-        # total - see the two descriptions above (#752).
-        factor_by_firmware_series={2: 0.1},
+        # Both summands share one scale, so the same mapping covers the total.
+        factor_by_firmware_series=AUX_HEATER_ENERGY_FACTOR_BY_SERIES,
         native_precision=1,
     ),
 ]

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -314,11 +314,28 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         entity_active_formula="!= 0.0",
         visibility=LV.V0324_ADDITIONAL_HEAT_GENERATOR_AMOUNT_COUNTER,
-        # Raw register unit is 0.1 kWh, applied by the Energy datatype this
-        # parameter is registered with in lux_overrides - hence no factor.
-        # #490 scaled it by a further /10 based on a single unverified display
-        # comparison; measured against the rated element power (parameter
-        # 1025) on five units, that reported a tenth of the real energy. #625.
+        # Raw register unit is 0.1 kWh on a series-3 controller, applied by
+        # the Energy datatype this parameter is registered with in
+        # lux_overrides - hence no plain factor. #490 scaled it by a further
+        # /10 based on a single unverified display comparison; measured
+        # against the rated element power (parameter 1025) on five units,
+        # that reported a tenth of the real energy. #625.
+        #
+        # Series-2 controllers count the same register in 0.01 kWh, which is
+        # the further /10 below: an LD9 on V2.88.3 read 147140 counts against
+        # 1471.4 kWh on its own web page, and the one other unit that ever
+        # needed /100 also ran V2.88.3 (#752). Every unit measured onto /10
+        # in #625 is a series 3 - that sample could not have shown this.
+        #
+        # It also makes 1059 consistent with the rest of its register family
+        # on a series-2 controller: parameters 852/854/878/879, the other
+        # ID_Waermemenge_* counters, are 0.01 kWh on every unit seen of
+        # either series (verified against calculations 151/152, which are
+        # 0.1 kWh, on 21 dumps). Series 3 is where 1059 leaves that family.
+        #
+        # No series-1 controller has been compared, so those keep the
+        # series-3 scale until one is.
+        factor_by_firmware_series={2: 0.1},
         native_precision=1,
     ),
     descr(
@@ -329,7 +346,13 @@ SENSORS: list[descr] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         entity_active_formula="!= 0.0",
-        # 0.1 kWh raw unit, applied by the Energy datatype (see 1059 above).
+        # 0.1 kWh raw unit, applied by the Energy datatype (see 1059 above),
+        # and the same 0.01 kWh unit on a series-2 controller. That last part
+        # is by analogy rather than by measurement - it is the same physical
+        # element on the same controller as 1059, and no series-2 unit has
+        # been seen with 1140 counting yet - but leaving it out would make a
+        # unit's total change scale mid-handover.
+        factor_by_firmware_series={2: 0.1},
         native_precision=1,
         # Despite the name this is not the second heat generator (ZWE2) - it
         # counts the same element as 1059, which stops advancing once this
@@ -839,6 +862,10 @@ SENSORS_SUM: list[sum_descr] = [
         # Deliberately not EntityCategory.DIAGNOSTIC: diagnostic entities
         # cannot be selected in the energy dashboard, which is the main thing
         # a lifetime kWh counter is for.
+        #
+        # Both summands share the series-2 unit, so one factor covers the
+        # total - see the two descriptions above (#752).
+        factor_by_firmware_series={2: 0.1},
         native_precision=1,
     ),
 ]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -222,6 +222,19 @@ class TestCoordinatorProperties:
         minor = coord.firmware_version_minor
         assert minor == Version("90.0")
 
+    def test_firmware_series(self):
+        coord = _make_coordinator(calculations={"ID_WEB_SoftStand": "V3.90.1"})
+        assert coord.firmware_series == 3
+
+    def test_firmware_series_of_a_luxtronik_2_0(self):
+        """The generation that counts aux heater energy in 0.01 kWh (#752)."""
+        coord = _make_coordinator(calculations={"ID_WEB_SoftStand": "V2.88.3"})
+        assert coord.firmware_series == 2
+
+    def test_firmware_series_unparseable(self):
+        coord = _make_coordinator(calculations={"ID_WEB_SoftStand": "invalid"})
+        assert coord.firmware_series == 0
+
     def test_serial_number(self):
         coord = _make_coordinator(
             parameters={

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -61,7 +61,7 @@ def _mock_entry():
     return entry
 
 
-def _mock_coordinator(data=None, *, last_update_success=True):
+def _mock_coordinator(data=None, *, last_update_success=True, firmware_series=3):
     if data is None:
         data = make_coordinator_data()
     coord = MagicMock()
@@ -70,6 +70,7 @@ def _mock_coordinator(data=None, *, last_update_success=True):
     coord.entity_active.return_value = True
     coord.entity_visible.return_value = True
     coord.get_device.return_value = MagicMock()
+    coord.firmware_series = firmware_series
     return coord
 
 
@@ -85,10 +86,10 @@ def _patch_entity(entity):
 # ===========================================================================
 
 
-def _make_sensor(description=None, data=None):
+def _make_sensor(description=None, data=None, *, firmware_series=3):
     hass = MagicMock()
     entry = _mock_entry()
-    coord = _mock_coordinator(data)
+    coord = _mock_coordinator(data, firmware_series=firmware_series)
     if description is None:
         description = LuxtronikSensorDescription(
             key=SensorKey.FLOW_OUT_TEMPERATURE,
@@ -916,24 +917,30 @@ class TestEnergyInputScaling:
 
 
 class TestAuxHeaterAmountScaling:
-    """Parameters 1059 and 1140 both count auxiliary-heater heat in 0.1 kWh
-    units, so the Energy datatype they are registered with is the whole
-    conversion and neither description carries a `factor`.
+    """Parameters 1059 and 1140 count auxiliary-heater heat in 0.1 kWh units
+    on a series-3 controller, so the Energy datatype they are registered with
+    is the whole conversion there, and in 0.01 kWh units on a series-2 one,
+    where the description supplies a further /10.
 
-    The scale is pinned by physics rather than by upstream's unit note:
-    energy divided by the aux heater's run time must equal its rated power
-    (parameter 1025). The values below are real readings from user
+    The series-3 scale is pinned by physics rather than by upstream's unit
+    note: energy divided by the aux heater's run time must equal its rated
+    power (parameter 1025). The values below are real readings from user
     diagnostics in #625 - 37539 counts over 420.03 hours of ZWE1 run time on
     a unit whose rated element is 9.0 kW, giving 8.94 kW at 0.1 kWh per count
     and 0.89 kW if a further /10 is applied on top, as #490 did.
+
+    The series-2 scale comes from #752, where an LD9 on V2.88.3 read 147140
+    counts against 1471.4 kWh on the controller's own web page.
     """
 
-    def _converted_value(self, sensor_key: SensorKey, raw_value: int) -> float:
+    def _converted_value(
+        self, sensor_key: SensorKey, raw_value: int, *, firmware_series: int = 3
+    ) -> float:
         description, datatype = _energy_input_case(sensor_key)
         converted = datatype.from_heatpump(raw_value)
         group, sensor_id = description.luxtronik_key.split(".", 1)
         data = make_coordinator_data(**{group: {sensor_id: converted}})
-        entity = _make_sensor(description, data)
+        entity = _make_sensor(description, data, firmware_series=firmware_series)
         entity._handle_coordinator_update(data)
         return entity._attr_native_value
 
@@ -958,3 +965,30 @@ class TestAuxHeaterAmountScaling:
             SensorKey.ADDITIONAL_HEAT_GENERATOR_ENERGY_P1059, 37539
         )
         assert 8.0 <= kwh / 420.03 <= 9.5
+
+    def test_p1059_takes_a_further_tenth_on_series_2(self):
+        """The reading from #752: 147140 counts is 1471.4 kWh on that LD9."""
+        value = self._converted_value(
+            SensorKey.ADDITIONAL_HEAT_GENERATOR_ENERGY_P1059,
+            147140,
+            firmware_series=2,
+        )
+        assert value == 1471.4
+
+    def test_p1140_takes_a_further_tenth_on_series_2(self):
+        """1140 follows 1059 by analogy - same element, same controller."""
+        value = self._converted_value(
+            SensorKey.ADDITIONAL_HEAT_GENERATOR_ENERGY_P1140,
+            8410,
+            firmware_series=2,
+        )
+        assert value == 84.1
+
+    def test_series_3_is_unaffected_by_the_series_2_rule(self):
+        """The same register on a series-3 unit keeps the measured /10."""
+        value = self._converted_value(
+            SensorKey.ADDITIONAL_HEAT_GENERATOR_ENERGY_P1059,
+            147140,
+            firmware_series=3,
+        )
+        assert value == 14714.0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -984,6 +984,24 @@ class TestAuxHeaterAmountScaling:
         )
         assert value == 84.1
 
+    def test_series_1_follows_series_2(self):
+        """Assumed, not measured - no V1.x unit has ever been compared. A line
+        that went 0.01 -> 0.01 -> 0.1 across generations is plausible; one that
+        went 0.1 -> 0.01 -> 0.1 is not. The mapping states it outright so the
+        assumption is visible rather than arriving through a fallback (#752).
+        """
+        description, _ = _energy_input_case(
+            SensorKey.ADDITIONAL_HEAT_GENERATOR_ENERGY_P1059
+        )
+        assert description.factor_by_firmware_series is not None
+        assert set(description.factor_by_firmware_series) == {1, 2, 3}
+        value = self._converted_value(
+            SensorKey.ADDITIONAL_HEAT_GENERATOR_ENERGY_P1059,
+            147140,
+            firmware_series=1,
+        )
+        assert value == 1471.4
+
     def test_series_3_is_unaffected_by_the_series_2_rule(self):
         """The same register on a series-3 unit keeps the measured /10."""
         value = self._converted_value(

--- a/tests/test_sum_sensor.py
+++ b/tests/test_sum_sensor.py
@@ -47,13 +47,14 @@ def _mock_entry():
     return entry
 
 
-def _mock_coordinator(data):
+def _mock_coordinator(data, *, firmware_series=3):
     coord = MagicMock()
     coord.data = data
     coord.last_update_success = True
     coord.entity_active.return_value = True
     coord.entity_visible.return_value = True
     coord.get_device.return_value = MagicMock()
+    coord.firmware_series = firmware_series
     return coord
 
 
@@ -69,10 +70,10 @@ def _aux_energy_description() -> LuxtronikSumSensorDescription:
     )
 
 
-def _make_entity(data, description=None):
+def _make_entity(data, description=None, *, firmware_series=3):
     hass = MagicMock()
     entry = _mock_entry()
-    coord = _mock_coordinator(data)
+    coord = _mock_coordinator(data, firmware_series=firmware_series)
     description = description or _aux_energy_description()
     entity = LuxtronikSumSensorEntity(
         hass, entry, coord, description, DeviceKey.heatpump
@@ -140,6 +141,33 @@ class TestSumSensorHandleCoordinatorUpdate:
         entity = _make_entity(data, descr)
         entity._handle_coordinator_update(data)
         assert entity._attr_native_value == 7.0
+
+    def test_series_2_takes_a_further_tenth(self):
+        """Both summands are 0.01 kWh registers on a series-2 controller, so
+        the total carries the same /10 the individual sensors do (#752). The
+        decoded values here are the Energy datatype's own /10 already applied
+        to 147140 and 8410 counts.
+        """
+        descr = next(
+            d
+            for d in SENSORS_SUM
+            if d.key == SensorKey.ADDITIONAL_HEAT_GENERATOR_ENERGY
+        )
+        data = make_coordinator_data(parameters={_P1059: 14714.0, _P1140: 841.0})
+        entity = _make_entity(data, descr, firmware_series=2)
+        entity._handle_coordinator_update(data)
+        assert entity._attr_native_value == 1555.5
+
+    def test_series_3_total_is_unscaled(self):
+        descr = next(
+            d
+            for d in SENSORS_SUM
+            if d.key == SensorKey.ADDITIONAL_HEAT_GENERATOR_ENERGY
+        )
+        data = make_coordinator_data(parameters={_P1059: 14714.0, _P1140: 841.0})
+        entity = _make_entity(data, descr, firmware_series=3)
+        entity._handle_coordinator_update(data)
+        assert entity._attr_native_value == 15555.0
 
     def test_no_write_without_data(self):
         entity = _make_entity(make_coordinator_data(parameters={_P1059: 1.0}))

--- a/tests/test_sum_sensor.py
+++ b/tests/test_sum_sensor.py
@@ -25,7 +25,10 @@ from custom_components.luxtronik2.const import (
 )
 from custom_components.luxtronik2.model import LuxtronikSumSensorDescription
 from custom_components.luxtronik2.sensor import LuxtronikSumSensorEntity
-from custom_components.luxtronik2.sensor_entities_predefined import SENSORS_SUM
+from custom_components.luxtronik2.sensor_entities_predefined import (
+    SENSORS,
+    SENSORS_SUM,
+)
 
 _ENTRY_DATA = {
     CONF_HOST: "192.168.1.100",
@@ -190,6 +193,29 @@ class TestAuxHeaterEnergyTotalDescription:
             LP.P1140_SECOND_HEAT_GENERATOR_AMOUNT_COUNTER,
         )
         assert descr.native_unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR
+
+    def test_total_scales_exactly_like_its_summands(self):
+        """A total on a different scale from the registers it adds up would
+        be wrong on every series-2 unit, so all three share one mapping.
+        """
+        total = next(
+            d
+            for d in SENSORS_SUM
+            if d.key == SensorKey.ADDITIONAL_HEAT_GENERATOR_ENERGY
+        )
+        summands = [
+            d
+            for d in SENSORS
+            if d.key
+            in (
+                SensorKey.ADDITIONAL_HEAT_GENERATOR_ENERGY_P1059,
+                SensorKey.ADDITIONAL_HEAT_GENERATOR_ENERGY_P1140,
+            )
+        ]
+        assert len(summands) == 2
+        for summand in summands:
+            assert summand.factor_by_firmware_series == total.factor_by_firmware_series
+            assert summand.factor == total.factor
 
     def test_is_selectable_in_the_energy_dashboard(self):
         """Diagnostic entities cannot be added there, so it must not be one."""


### PR DESCRIPTION
## 🐛 Problem

Since 2026.08.12, *Additional heat generator energy* reads **10× too high** on some units. Reported in #752: an LD9 on V2.88.3 shows 14714.0 kWh in Home Assistant against **1471.4 kWh** on the controller's own web page.

That release corrected the same sensor for everyone else (#625, #735/#736), where the counter had been 10× too *low*. Both reports are right: the register's unit differs between controller generations.

## 🔍 Evidence

| generation | unit per count | how established |
|---|---|---|
| Series 3 (V3.x) | 0.1 kWh | energy ÷ ZWE run-time = rated element power (parameter 1025) on five units — MSW4-16, MSW2-6S, MSW2-9S, LW SEC 2, V3.79→V3.92.3 (#625) |
| Series 2 (V2.x) | 0.01 kWh | raw 147140 against a displayed 1471.4 kWh, dump and screenshot taken at the same moment; an earlier report needing /100 also ran V2.88.3 (#752) |
| Series 1 (V1.x) | 0.01 kWh | **assumed**, never measured — see below |

Why the existing diagnostics corpus could not have caught this: of ~50 dumps, only five units carry the energy counter, the run-time counter *and* a rated power at once, and **all five are series 3**. The single series-2 dump has parameter 1025 = 0. The #625 conclusion was sound but drawn from one generation and generalised to all.

Supporting: on a series-2 controller this puts 1059 back in line with its own register family — parameters 852/854/878/879 are 0.01 kWh on both generations (verified against calculations 151/152 across 21 dumps, and against the controller display on the #752 unit). Series 3 is where 1059 leaves that family.

## 🔧 Approach

- `LuxtronikCoordinator.firmware_series` — the firmware major digit identifies the controller generation and never advances on a firmware update, so it is a hardware fact rather than a version threshold.
- `LuxtronikSensorDescription.factor_by_firmware_series` — a per-generation override of `factor`, resolved per entity at update time. This cannot live in the datatype: `lux_overrides` is applied once per process, while one process can serve two config entries whose heat pumps are different generations.
- `AUX_HEATER_ENERGY_FACTOR_BY_SERIES = {1: 0.1, 2: 0.1, 3: 1}`, shared by 1059, 1140 and their total, with the per-generation evidence in one place. A total on a different scale from the registers it sums would be wrong on every series-2 unit, so a test pins the three together.
- The entity keys are untouched, so existing history and `unique_id`s are preserved.

## ⚠️ Assumptions, stated deliberately

- **Series 1** follows series 2. There is no V1.x diagnostics dump anywhere in the corpus. A line that counted in 0.01 kWh on series 1 and 2 and changed on series 3 is a plausible history; 0.1 → 0.01 → 0.1 is not. Listed explicitly rather than left to a fallback so it is visible and easy to flip — @McGismo (LWC407 / V1.88.3) has been asked for a reading in #752.
- **Parameter 1140** shares 1059's scale by analogy: same physical element, same controller, and no series-2 unit has yet been seen with 1140 counting. Giving it its own scale would make a unit's total jump at the handover.

## 🧪 Verification

- 1013 tests pass, coverage unchanged at 99 %
- `ruff check`, `ruff format --check`, `basedpyright` (0 errors), `codespell` all clean
- New tests cover both scales for 1059/1140, the total under each generation, the explicit series-1 entry, and `firmware_series` parsing

## 📌 Note for affected users

Anyone on a series-2 controller will see the value drop 10× when this lands. That step, and the one from 2026.08.12, can be repaired together under **Developer tools → Statistics**.

## 🔗 Issue

Reported in #752 — deliberately **not** closing it on merge. The series-1 scale in this PR is an assumption, and #752 is where the confirming readings from a V1.x controller (and a second series-2 unit) are expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
