### PR TITLE
feat(sensor,const,lux_overrides): ✨ expose the pool heat and energy counters

### DIFF
--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -118,6 +118,7 @@ WRITABLE_PARAMETER_PREFIXES: Final = (
     "HEAT_ENERGY_INPUT",
     "DHW_ENERGY_INPUT",
     "COOLING_ENERGY_INPUT",
+    "POOL_ENERGY_INPUT",
     "SECOND_HEAT_GENERATOR_AMOUNT_COUNTER",
     "POWER_LIMIT_SWITCH",
     "THERMAL_POWER_LIMIT_SWITCH",
@@ -516,7 +517,7 @@ class LuxParameter(StrEnum):
     )
     P1136_HEAT_ENERGY_INPUT = "parameters.HEAT_ENERGY_INPUT"
     P1137_DHW_ENERGY_INPUT = "parameters.DHW_ENERGY_INPUT"
-    # ? P1138_SWIMMING_POOL_ENERGY_INPUT: Final = "parameters.Unknown_Parameter_1138" -->
+    P1138_POOL_ENERGY_INPUT = "parameters.POOL_ENERGY_INPUT"
     P1139_COOLING_ENERGY_INPUT = "parameters.COOLING_ENERGY_INPUT"
     P1140_SECOND_HEAT_GENERATOR_AMOUNT_COUNTER = (
         "parameters.SECOND_HEAT_GENERATOR_AMOUNT_COUNTER"
@@ -631,6 +632,7 @@ class LuxCalculation(StrEnum):
     C0146_APPROVAL_COOLING = "calculations.ID_WEB_FreigabKuehl"
     C0151_HEAT_AMOUNT_HEATING = "calculations.ID_WEB_WMZ_Heizung"
     C0152_DHW_HEAT_AMOUNT = "calculations.ID_WEB_WMZ_Brauchwasser"
+    C0153_POOL_HEAT_AMOUNT = "calculations.ID_WEB_WMZ_Schwimmbad"
     C0154_HEAT_AMOUNT_COUNTER = "calculations.ID_WEB_WMZ_Seit"  # 25668.9
     C0155_HEAT_AMOUNT_FLOW_RATE = "calculations.ID_WEB_WMZ_Durchfluss"
     C0156_ANALOG_OUT1 = "calculations.ID_WEB_AnalogOut1"
@@ -826,6 +828,8 @@ class SensorKey(StrEnum):
     HEAT_ENERGY_INPUT = "heat_energy_input"
     DHW_ENERGY_INPUT = "dhw_energy_input"
     COOLING_ENERGY_INPUT = "cooling_energy_input"
+    POOL_HEAT_AMOUNT = "pool_heat_amount"
+    POOL_ENERGY_INPUT = "pool_energy_input"
     COP_HEATING = "cop_heating"
     COP_DHW = "cop_dhw"
     DHW_TEMPERATURE = "dhw_temperature"

--- a/custom_components/luxtronik2/lux_overrides.py
+++ b/custom_components/luxtronik2/lux_overrides.py
@@ -189,10 +189,18 @@ parameters_to_add_update = {
     # totals put the same upper bound under 2 at /10 on six further units.
     # Upstream's "kWh/10" note claims /10 for these and is simply wrong here;
     # it also sits on 1059 and calculations 151/152/154, which need /10.
-    # 1139 has read 0.0 on every unit seen so far, so it follows its two
+    # 1139 has read 0.0 on every unit seen so far, so it follows its three
     # siblings by analogy rather than by measurement.
+    #
+    # #752 confirmed the scale directly for the first time: on an LD9 whose
+    # controller page was photographed at the moment of the dump, 1136 read
+    # 543197 against a displayed 5431.9 kWh and 1137 read 222335 against
+    # 2223.3 kWh. The same unit identified 1138 as the pool counter - 113191
+    # against a displayed 1131.9 kWh - which had sat unregistered because a
+    # unit without a pool reads 0.0 there.
     1136: Energy2("HEAT_ENERGY_INPUT", False),
     1137: Energy2("DHW_ENERGY_INPUT", False),
+    1138: Energy2("POOL_ENERGY_INPUT", False),
     1139: Energy2("COOLING_ENERGY_INPUT", False),
     # Auxiliary-heater heat counters, both in 0.1 kWh units, so Energy's own
     # /10 is the whole conversion and their descriptions carry no factor. The

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -797,9 +797,52 @@ SENSORS: list[descr] = [
         native_precision=2,
         # 0.01 kWh raw unit, applied by the Energy2 datatype (see 1136 above).
         # This one reads 0.0 on every unit examined in #734, so its scale
-        # follows its two siblings by analogy and is not itself measured.
+        # follows its three siblings by analogy and is not itself measured.
     ),
     # endregion Cooling
+    # region Pool
+    #
+    # The controller reports pool heat and pool energy the same way it reports
+    # them for heating and DHW, but neither half was ever exposed: a unit
+    # without a pool reads 0.0 in both registers, and no diagnostics dump from
+    # a unit with one had been examined until #752.
+    descr(
+        key=SensorKey.POOL_HEAT_AMOUNT,
+        luxtronik_key=LC.C0153_POOL_HEAT_AMOUNT,
+        device_key=DeviceKey.heatpump,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        native_precision=1,
+        # 0.1 kWh, like its siblings 151 and 152 - the library's Energy
+        # datatype is the whole conversion. Confirmed on the #752 unit, whose
+        # controller page read 4364.1 kWh at the moment of the dump.
+        entity_active_formula="!= 0.0",
+    ),
+    descr(
+        key=SensorKey.POOL_ENERGY_INPUT,
+        luxtronik_key=LP.P1138_POOL_ENERGY_INPUT,
+        # There is no pool device, so this sits on the heat pump itself
+        # alongside the other whole-unit counters.
+        device_key=DeviceKey.heatpump,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        native_precision=2,
+        # 0.01 kWh raw unit, applied by the Energy2 datatype (see 1136 above),
+        # measured on the unit in #752: 113191 counts against 1131.9 kWh on
+        # the controller's own page, read at the same moment.
+        #
+        # Deliberately not gated on ID_Visi_Schwimmbad: that flag reads 0 on
+        # the very unit whose pool counter is populated, so it would hide the
+        # sensor from exactly the installations that have one. A machine
+        # without a pool reads 0.0 here, which is also why the register went
+        # unidentified for so long.
+        entity_active_formula="!= 0.0",
+    ),
+    # endregion Pool
 ]
 
 # region COP (instantaneous, no external meter)

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -875,6 +875,9 @@
             "heat_amount_heating": {
                 "name": "Mno\u017estv\u00ed tepla pro topen\u00ed"
             },
+            "pool_heat_amount": {
+                "name": "Množství tepla pro bazén"
+            },
             "heat_amount_flow_rate": {
                 "name": "Mno\u017estv\u00ed tepla"
             },
@@ -904,6 +907,9 @@
             },
             "cooling_energy_input": {
                 "name": "Spot\u0159ebovan\u00e1 energie pro chlazen\u00ed"
+            },
+            "pool_energy_input": {
+                "name": "Spotřebovaná energie pro bazén"
             },
             "room_thermostat_temperature": {
                 "name": "Teplota termostatu m\u00edstnosti"

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -872,6 +872,9 @@
             "heat_amount_heating": {
                 "name": "Z\u00e4hler W\u00e4rmemenge Heizung"
             },
+            "pool_heat_amount": {
+                "name": "Zähler Wärmemenge Schwimmbad"
+            },
             "heat_amount_flow_rate": {
                 "name": "Z\u00e4hler W\u00e4rmemenge Durchfluss"
             },
@@ -919,6 +922,9 @@
             },
             "cooling_energy_input": {
                 "name": "Eingesetzte Energie K\u00fchlung"
+            },
+            "pool_energy_input": {
+                "name": "Eingesetzte Energie Schwimmbad"
             },
             "additional_heat_generator_energy_p1140": {
                 "name": "Zus\u00e4tzlicher W\u00e4rmeerzeuger W\u00e4rmemenge (Firmware ab x.88)"

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -875,6 +875,9 @@
             "heat_amount_heating": {
                 "name": "Heating heat amount"
             },
+            "pool_heat_amount": {
+                "name": "Pool heat amount"
+            },
             "heat_amount_flow_rate": {
                 "name": "Heating heat amount flow rate"
             },
@@ -904,6 +907,9 @@
             },
             "cooling_energy_input": {
                 "name": "Energy input"
+            },
+            "pool_energy_input": {
+                "name": "Energy input pool"
             },
             "room_thermostat_temperature": {
                 "name": "Room thermostat"

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -869,6 +869,9 @@
             "heat_amount_heating": {
                 "name": "Meter warmtehoeveelheid verwarming"
             },
+            "pool_heat_amount": {
+                "name": "Meter warmtehoeveelheid zwembad"
+            },
             "heat_amount_flow_rate": {
                 "name": "Meter warmtehoeveelheidsstroom"
             },
@@ -916,6 +919,9 @@
             },
             "cooling_energy_input": {
                 "name": "Gebruikte energie koeling"
+            },
+            "pool_energy_input": {
+                "name": "Gebruikte energie zwembad"
             },
             "current_power_consumption": {
                 "name": "Stroomverbruik"

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -869,6 +869,9 @@
             "heat_amount_heating": {
                 "name": "Ilo\u015b\u0107 ciep\u0142a grzewczego"
             },
+            "pool_heat_amount": {
+                "name": "Ilość ciepła basenu"
+            },
             "heat_amount_flow_rate": {
                 "name": "Nat\u0119\u017cenie przep\u0142ywu ilo\u015bci ciep\u0142a grzewczego"
             },
@@ -904,6 +907,9 @@
             },
             "cooling_energy_input": {
                 "name": "Energia zu\u017cyta na ch\u0142odzenie"
+            },
+            "pool_energy_input": {
+                "name": "Energia zużyta na basen"
             },
             "current_power_consumption": {
                 "name": "Pob\u00f3r mocy"

--- a/tests/test_lux_overrides.py
+++ b/tests/test_lux_overrides.py
@@ -344,7 +344,7 @@ class TestUpstreamMaxDefinedIndex:
         assert key_exists(data, f"parameters.{short.parameters[1125].name}") is True
 
     def test_every_override_only_parameter_sits_above_the_range(self):
-        """The 13 indices that exist only because of lux_overrides are exactly the
+        """The 14 indices that exist only because of lux_overrides are exactly the
         ones the absence rule must be able to reach."""
         upstream_max = lux_overrides.UPSTREAM_MAX_DEFINED_INDEX[CONF_PARAMETERS]
         override_only = {
@@ -355,6 +355,7 @@ class TestUpstreamMaxDefinedIndex:
         assert override_only == {
             1136,
             1137,
+            1138,
             1139,
             1140,
             1146,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -891,6 +891,13 @@ class TestEnergyInputScaling:
     def test_cooling_energy_input_scaling(self):
         self._assert_raw_converts_to(SensorKey.COOLING_ENERGY_INPUT, 12345, 123.45)
 
+    def test_pool_energy_input_scaling(self):
+        """The only reading of 1138 there is: the #752 unit showed 113191
+        counts against 1131.9 kWh on the controller's own page, which is what
+        identified the register in the first place.
+        """
+        self._assert_raw_converts_to(SensorKey.POOL_ENERGY_INPUT, 113191, 1131.91)
+
     def _converted_value(self, sensor_key: SensorKey, raw_value: int) -> float:
         description, datatype = _energy_input_case(sensor_key)
         converted = datatype.from_heatpump(raw_value)


### PR DESCRIPTION
## ✨ What

Adds the two pool counters the controller has always shown next to the heating and DHW figures, but which the integration never exposed:

| entity | register | example reading |
|---|---|---|
| `pool_heat_amount` | calculation 153 `ID_WEB_WMZ_Schwimmbad` | 4364.1 kWh |
| `pool_energy_input` | parameter 1138 | 1131.9 kWh |

Both were verified against a controller web page photographed at the same moment as the diagnostics dump it is compared with (#752): 1138 read 113191 counts against a displayed 1131.9 kWh, and calculation 153 read 4364.1 against 4364.1.

## 🔍 Why they were missing

Parameter 1138 sat in `const.py` as a commented-out `# ? P1138_SWIMMING_POOL_ENERGY_INPUT` guess, and calculation 153 was not defined at all. A heat pump without a pool reads **0.0** in both registers, and until #752 no diagnostics dump from a unit *with* a pool had been examined — so there was nothing to identify them from. The pool was the only circuit missing on both the output and the input side.

## 🔧 Details

- 1138 is registered with `Energy2` (0.01 kWh), matching its siblings 1136/1137/1139. The same dump also confirms those two against a display for the first time — 1136 → 5431.9 kWh, 1137 → 2223.3 kWh — which #734 had established by regression only.
- Calculation 153 needs no conversion beyond the library's `Energy` datatype, like calculations 151 and 152.
- Both carry `entity_active_formula="!= 0.0"`, so a unit without a pool does not gain two permanently empty entities.
- **Deliberately not gated on `ID_Visi_Schwimmbad`**: that visibility flag reads 0 on the very unit whose pool counters are populated, so gating on it would hide the sensors from exactly the installations that have a pool.
- Both sit on the heat pump device — there is no pool device — and are named in all five translations.

## 🧪 Verification

- 1004 tests pass, coverage unchanged at 99 %
- `ruff check`, `ruff format --check`, `basedpyright` (0 errors), `codespell` all clean
- New test pins 1138's scale to the reading that identified it; the override-inventory test in `test_lux_overrides.py` was updated from 13 to 14 indices, having caught the new parameter as designed

## 🔗 Related

Discovered while investigating #752, but independent of it — this branch is based on `main` and touches no scaling logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
