### PR TITLE
fix(common,sensor,binary_sensor): 🐛 read the smartgrid sg2 input from its per-generation terminal

### DIFF
--- a/custom_components/luxtronik2/binary_sensor.py
+++ b/custom_components/luxtronik2/binary_sensor.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
 from .binary_sensor_entities_predefined import BINARY_SENSORS
-from .common import get_sensor_data, key_exists
+from .common import get_sensor_data, key_exists, read_smart_grid_inputs
 from .const import CONF_HA_SENSOR_PREFIX, LOGGER, DeviceKey, SensorKey
 from .coordinator import LuxtronikCoordinator, LuxtronikCoordinatorData
 from .model import LuxtronikBinarySensorEntityDescription
@@ -92,7 +92,13 @@ class LuxtronikBinarySensorEntity(  # type: ignore  # pyright: ignore[reportInco
             return
 
         descr = self.entity_description
-        state = get_sensor_data(data, descr.luxtronik_key.value)
+        if descr.key == SensorKey.EVU2:
+            # SG2 is not wired to the HZIO input on every controller
+            # generation, so derive it the same way the SmartGrid status
+            # sensor does - the two must never disagree (#669).
+            _, state = read_smart_grid_inputs(data)
+        else:
+            state = get_sensor_data(data, descr.luxtronik_key.value)
         self._attr_is_on = self.compute_is_on(state)
 
         super()._handle_coordinator_update()

--- a/custom_components/luxtronik2/common.py
+++ b/custom_components/luxtronik2/common.py
@@ -29,6 +29,11 @@ from .model import LuxtronikCoordinatorData
 
 # endregion Imports
 
+# Rail of the room station's +/-5 K adjuster. Mains voltage on that terminal
+# pins the reading to one end or the other, which is how an SG2 contact shows
+# up there on a Luxtronik 2.0 controller (#669).
+SMART_GRID_RFV_RAIL = 5.0
+
 
 def _register_returned(group_data: Any, group: str, index: int) -> bool:
     """Did the controller actually return this register in its last read?
@@ -149,6 +154,75 @@ def get_sensor_data(
         if raw_value
         else normalize_sensor_value(value, coordinator, luxtronik_key)
     )
+
+
+def _as_bool(value: Any) -> bool:
+    """Coerce a Luxtronik input register to a bool (True/1/"true"/"True")."""
+    return value in [True, 1, "1", "true", "True"]
+
+
+def smart_grid_enabled(coordinator: LuxtronikCoordinatorData) -> bool:
+    """Is SmartGrid switched on at the controller?
+
+    P1030 holds a mode rather than a flag: 0 is off, but the variant selected
+    when it is on is not always 1 - the Luxtronik 2.0 unit in #669 reports 3.
+    So this must not be coerced through a boolean-ish comparison.
+    """
+    value = get_sensor_data(coordinator, LP.P1030_SMART_GRID_SWITCH)
+    return bool(value) and value not in [False, 0, "0", "false", "False"]
+
+
+def read_smart_grid_inputs(
+    coordinator: LuxtronikCoordinatorData,
+) -> tuple[bool, bool]:
+    """Read the EVU1/EVU2 inputs of the SmartGrid state table.
+
+    The SG contacts are wired to different terminals per controller
+    generation (see the "Klemmenplan Smart Grid" in the part-2 manuals):
+    Luxtronik 2.1 and HMD2 put SG2 on a dedicated input reported through the
+    HZIO board, but Luxtronik 2.0 puts it on the RFV room station terminal,
+    where the HZIO register stays 0 forever and the status sensor sticks on
+    evu_locked / reduced_operation (#669).
+
+    That wiring identifies itself in the data, so no firmware gate is needed.
+    It requires SmartGrid to be switched on at all - with it off the terminal
+    is not an SG contact by definition - no room station to be configured,
+    since otherwise the terminal is taken, and an RFV reading at one of the
+    adjuster's rails, which a real station never parks at. Every unit in the
+    diagnostics corpus without a station reads exactly 0.0; the only exception
+    was the SG2-wired 2.0 unit in #669, whose reading flipped +5.0 / -5.0 with
+    the contact.
+
+    The rail test is a band rather than an exact match: the register may not be
+    clamped at the rail on every unit, so reading slightly past it must still
+    count. It is bounded above because a signed Celsius register can also
+    report something implausible, and treating that as SG2 would move a 2.1
+    unit onto this branch and invert its EVU1 as well.
+
+    On 2.0 the EVU terminal carries SG1 itself, and there "released" means the
+    SG1 row of the table is 0, so EVU1 is inverted along with it.
+    """
+    evu1 = _as_bool(get_sensor_data(coordinator, LC.C0031_EVU_UNLOCKED))
+    rfv = get_sensor_data(coordinator, LC.C0023_ROOM_STATION_RFV)
+    room_station = get_sensor_data(coordinator, LP.P0033_ROOM_THERMOSTAT_TYPE)
+
+    rfv_value: float | None = None
+    if rfv is not None and room_station is not None and smart_grid_enabled(coordinator):
+        try:
+            if int(room_station) == 0:
+                rfv_value = float(rfv)
+        except (TypeError, ValueError):
+            # Both registers are Unknown/Celsius datatypes, so a firmware that
+            # reports something unparsable must fall back, not raise.
+            rfv_value = None
+
+    if rfv_value is not None and SMART_GRID_RFV_RAIL <= abs(rfv_value) <= (
+        SMART_GRID_RFV_RAIL * 2
+    ):
+        LOGGER.debug("SmartGrid SG2 read from the RFV terminal (%s)", rfv_value)
+        return not evu1, rfv_value < 0
+
+    return evu1, _as_bool(get_sensor_data(coordinator, LC.C0185_EVU2))
 
 
 def _derive_operation_mode(value: Any, coordinator: LuxtronikCoordinatorData) -> Any:

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -575,6 +575,10 @@ class LuxCalculation(StrEnum):
     C0021_FLOW_IN_CIRCUIT1_TARGET_TEMPERATURE = "calculations.ID_WEB_Sollwert_TVL_MK1"
     C0022_FLOW_IN_CIRCUIT2_TARGET_TEMPERATURE = "calculations.ID_WEB_Sollwert_TVL_MK2"
     C0023_FLOW_IN_CIRCUIT3_TARGET_TEMPERATURE = "calculations.ID_WEB_Sollwert_TVL_MK3"
+    # Room station (Raumfernversteller) adjuster, +/-5 K. Doubles as the
+    # SmartGrid SG2 input on Luxtronik 2.0 controllers, where the reading
+    # flips between the two rails with the contact, see #669.
+    C0023_ROOM_STATION_RFV = "calculations.ID_WEB_Temperatur_RFV"
     C0024_HEAT_SOURCE_OUTPUT_TEMPERATURE = "calculations.ID_WEB_Temperatur_TWA"
     C0026_SOLAR_COLLECTOR_TEMPERATURE = "calculations.ID_WEB_Temperatur_TSK"
     C0027_SOLAR_BUFFER_TEMPERATURE = "calculations.ID_WEB_Temperatur_TSS"

--- a/custom_components/luxtronik2/sensor.py
+++ b/custom_components/luxtronik2/sensor.py
@@ -16,7 +16,13 @@ from homeassistant.helpers.translation import async_get_cached_translations
 
 from . import LuxtronikConfigEntry
 from .base import LuxtronikEntity
-from .common import get_sensor_data, key_exists, state_as_number_or_none
+from .common import (
+    get_sensor_data,
+    key_exists,
+    read_smart_grid_inputs,
+    smart_grid_enabled,
+    state_as_number_or_none,
+)
 from .const import (
     CONF_HA_SENSOR_CURRENT_POWER_CONSUMPTION,
     CONF_HA_SENSOR_PREFIX,
@@ -101,7 +107,10 @@ async def async_setup_entry(
                     # Check if firmware supports the Luxtronik Parameter/Calculation key
                     key_exists(coordinator.data, description.luxtronik_key)
                     or (
-                        # For SmartGrid status sensor, check if required parameters exist
+                        # For SmartGrid status sensor, check if required parameters exist.
+                        # EVU2 may be read from another register than C0185 at
+                        # runtime (#669), but every controller defines C0185,
+                        # so this stays a valid presence check.
                         description.key == SensorKey.SMART_GRID_STATUS
                         and (
                             key_exists(coordinator.data, LP.P1030_SMART_GRID_SWITCH)
@@ -350,24 +359,16 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity):
 
     def _update_smart_grid_status(self) -> None:
         """Calculate and update SmartGrid status based on EVU and EVU2 inputs."""
-        from .const import LuxParameter as LP
-
-        # Check if SmartGrid is enabled (P1030)
-        smartgrid_enabled = self._get_value(LP.P1030_SMART_GRID_SWITCH)
-
-        # If SmartGrid is disabled, set sensor to unavailable
-        if not smartgrid_enabled or smartgrid_enabled in [False, 0, "false", "False"]:
+        # If SmartGrid is disabled (P1030), set sensor to unavailable
+        if not smart_grid_enabled(self.coordinator.data):
             self._smart_grid_available = False
             self._attr_native_value = None
         else:
             self._smart_grid_available = True
 
-            evu = self._get_value(LC.C0031_EVU_UNLOCKED)
-            evu2 = self._get_value(LC.C0185_EVU2)
-
-            # Convert to boolean (handle True/False/1/0/"true"/"false")
-            evu_on = evu in [True, 1, "true", "True"]
-            evu2_on = evu2 in [True, 1, "true", "True"]
+            # Which terminal carries SG1/SG2 depends on the controller
+            # generation, so the inputs are derived rather than read (#669).
+            evu_on, evu2_on = read_smart_grid_inputs(self.coordinator.data)
 
             # Determine SmartGrid status based on EVU and EVU2 inputs
             # EVU=0, EVU2=0 → Status 2 (reduced operation)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -13,6 +13,7 @@ from custom_components.luxtronik2.common import (
     get_sensor_data,
     key_exists,
     normalize_sensor_value,
+    read_smart_grid_inputs,
     state_as_number_or_none,
 )
 from custom_components.luxtronik2.const import (
@@ -153,6 +154,120 @@ class TestRegisterPresence:
         )
         assert key_exists(data, "calculations.upstream_a") is True
         assert key_exists(data, "calculations.added_b") is False
+
+
+# ===========================================================================
+# read_smart_grid_inputs
+# ===========================================================================
+
+
+def _sg_data(evu_in=True, hzio_evu2=0, rfv=0.0, rfv_type=0, smart_grid=1):
+    return make_coordinator_data(
+        calculations={
+            "ID_WEB_EVUin": evu_in,
+            "ID_WEB_HZIO_EVU2": hzio_evu2,
+            "ID_WEB_Temperatur_RFV": rfv,
+        },
+        parameters={
+            "ID_Einst_RFVEinb_akt": rfv_type,
+            "ID_Einst_SmartGrid": smart_grid,
+        },
+    )
+
+
+class TestReadSmartGridInputs:
+    """SG1/SG2 land on different terminals per controller generation (#669)."""
+
+    def test_hzio_wiring_reads_the_registers_verbatim(self):
+        """The 2.1 / HMD2 case: EVU2 from calc 185, EVU1 from calc 31."""
+        assert read_smart_grid_inputs(_sg_data(evu_in=True, hzio_evu2=1)) == (
+            True,
+            True,
+        )
+        assert read_smart_grid_inputs(_sg_data(evu_in=False, hzio_evu2=1)) == (
+            False,
+            True,
+        )
+        assert read_smart_grid_inputs(_sg_data(evu_in=True, hzio_evu2=0)) == (
+            True,
+            False,
+        )
+        assert read_smart_grid_inputs(_sg_data(evu_in=False, hzio_evu2=0)) == (
+            False,
+            False,
+        )
+
+    def test_rfv_wiring_reads_evu2_from_the_rfv_sign(self):
+        """Luxtronik 2.0: SG2 sits on the room station terminal, EVU1 inverted.
+
+        Both rows are taken from the two diagnostics dumps in #669, together
+        with the state the controller display showed for each.
+        """
+        # SG2 on -> display state 3 -> EVU1=0, EVU2=1
+        assert read_smart_grid_inputs(_sg_data(evu_in=True, rfv=-5.0)) == (False, True)
+        # SG2 off -> display state 2 -> EVU1=0, EVU2=0
+        assert read_smart_grid_inputs(_sg_data(evu_in=True, rfv=5.0)) == (False, False)
+
+    def test_rfv_wiring_inverts_evu1(self):
+        """On 2.0 the EVU terminal is SG1 itself, so released == EVU1 off."""
+        assert read_smart_grid_inputs(_sg_data(evu_in=False, rfv=-5.0)) == (True, True)
+
+    def test_room_station_configured_keeps_hzio(self):
+        """A real room station owns the terminal, so it can never be SG2.
+
+        Every unit in the diagnostics corpus with a station reads -2.0..0.0.
+        """
+        assert read_smart_grid_inputs(
+            _sg_data(evu_in=True, hzio_evu2=1, rfv=-2.0, rfv_type=4)
+        ) == (True, True)
+
+    def test_idle_rfv_input_keeps_hzio(self):
+        """The common case: no station, nothing wired, RFV reads exactly 0.0."""
+        assert read_smart_grid_inputs(
+            _sg_data(evu_in=True, hzio_evu2=1, rfv=0.0, rfv_type=0)
+        ) == (True, True)
+
+    def test_missing_registers_fall_back_to_hzio(self):
+        """Firmware without RFV registers must keep the pre-#669 behaviour."""
+        data = make_coordinator_data(
+            calculations={"ID_WEB_EVUin": True, "ID_WEB_HZIO_EVU2": 1},
+            parameters={"ID_Einst_SmartGrid": 1},
+        )
+        assert read_smart_grid_inputs(data) == (True, True)
+
+    def test_smart_grid_off_keeps_hzio(self):
+        """With SG disabled the terminal is not an SG contact by definition.
+
+        Without this the heuristic would run on every install in the fleet,
+        including the majority that never enabled SmartGrid.
+        """
+        assert read_smart_grid_inputs(
+            _sg_data(evu_in=True, hzio_evu2=1, rfv=-5.0, smart_grid=0)
+        ) == (True, True)
+
+    def test_smart_grid_mode_value_is_enabled(self):
+        """P1030 holds a mode, not a flag - the #669 unit reports 3, not 1."""
+        assert read_smart_grid_inputs(
+            _sg_data(evu_in=True, rfv=-5.0, smart_grid=3)
+        ) == (False, True)
+
+    def test_implausible_rfv_reading_keeps_hzio(self):
+        """A signed Celsius register can report garbage; only the rails count.
+
+        Without a ceiling such a reading would move a 2.1 unit onto the 2.0
+        branch, which also inverts its EVU1.
+        """
+        for rfv in (3276.7, -100.0):
+            assert read_smart_grid_inputs(
+                _sg_data(evu_in=True, hzio_evu2=1, rfv=rfv)
+            ) == (True, True)
+
+    def test_unreadable_room_station_setting_keeps_hzio(self):
+        """P33 is an Unknown-datatype register, so do not trust its type."""
+        for rfv_type in (None, "unknown"):
+            assert read_smart_grid_inputs(
+                _sg_data(evu_in=True, hzio_evu2=1, rfv=-5.0, rfv_type=rfv_type)
+            ) == (True, True)
 
 
 # ===========================================================================

--- a/tests/test_entity_platforms.py
+++ b/tests/test_entity_platforms.py
@@ -275,6 +275,69 @@ class TestLuxtronikBinarySensorEntity:
         coord.data = None
         entity._handle_coordinator_update(None)
 
+    def _make_evu2_sensor(self):
+        from custom_components.luxtronik2.binary_sensor import (
+            LuxtronikBinarySensorEntity,
+        )
+
+        desc = LuxtronikBinarySensorEntityDescription(
+            key=SK.EVU2,
+            luxtronik_key=LC.C0185_EVU2,
+            device_key=DeviceKey.heatpump,
+        )
+        coord = _mock_coordinator(make_coordinator_data())
+        entry = _mock_entry()
+
+        with patch("homeassistant.helpers.frame.report_usage"):
+            entity = LuxtronikBinarySensorEntity(
+                MagicMock(), entry, coord, desc, DeviceKey.heatpump
+            )
+        _patch_entity_hass(entity)
+        return entity
+
+    def _evu2_data(self, hzio_evu2=0, rfv=0.0, rfv_type=0, smart_grid=1):
+        return make_coordinator_data(
+            calculations={
+                "ID_WEB_EVUin": True,
+                "ID_WEB_HZIO_EVU2": hzio_evu2,
+                "ID_WEB_Temperatur_RFV": rfv,
+            },
+            parameters={
+                "ID_Einst_RFVEinb_akt": rfv_type,
+                "ID_Einst_SmartGrid": smart_grid,
+            },
+        )
+
+    def test_evu2_follows_hzio_register(self):
+        entity = self._make_evu2_sensor()
+        entity._handle_coordinator_update(self._evu2_data(hzio_evu2=1))
+        assert entity._attr_is_on is True
+        entity._handle_coordinator_update(self._evu2_data(hzio_evu2=0))
+        assert entity._attr_is_on is False
+
+    def test_evu2_follows_rfv_sign_on_2_0_wiring(self):
+        """Must agree with the SmartGrid status sensor on a 2.0 unit (#669)."""
+        entity = self._make_evu2_sensor()
+        entity._handle_coordinator_update(self._evu2_data(rfv=-5.0))
+        assert entity._attr_is_on is True
+        entity._handle_coordinator_update(self._evu2_data(rfv=5.0))
+        assert entity._attr_is_on is False
+
+    def test_evu2_ignores_a_configured_room_station(self):
+        entity = self._make_evu2_sensor()
+        entity._handle_coordinator_update(
+            self._evu2_data(hzio_evu2=1, rfv=-5.0, rfv_type=4)
+        )
+        assert entity._attr_is_on is True
+
+    def test_evu2_ignores_rfv_when_smart_grid_is_off(self):
+        """The heuristic must not run on installs that never enabled SG."""
+        entity = self._make_evu2_sensor()
+        entity._handle_coordinator_update(
+            self._evu2_data(hzio_evu2=0, rfv=-5.0, smart_grid=0)
+        )
+        assert entity._attr_is_on is False
+
 
 # ===========================================================================
 # async_setup_entry — number
@@ -640,19 +703,21 @@ class TestLuxtronikSensorEntity:
 
 
 class TestSmartGridSensor:
-    def _make_smart_grid(self, evu=0, evu2=0, sg_enabled=1):
+    def _make_smart_grid(self, evu=0, evu2=0, sg_enabled=1, rfv=0.0, rfv_type=0):
         from custom_components.luxtronik2.sensor import LuxtronikStatusSensorEntity
 
         data = make_coordinator_data(
             calculations={
                 "ID_WEB_EVUin": evu,
                 "ID_WEB_HZIO_EVU2": evu2,
+                "ID_WEB_Temperatur_RFV": rfv,
                 "ID_WEB_WP_BZ_akt": "heating",
                 "ID_WEB_VD1out": 1,
                 "ID_WEB_ZW1out": 0,
             },
             parameters={
                 "ID_Einst_SmartGrid": sg_enabled,
+                "ID_Einst_RFVEinb_akt": rfv_type,
             },
         )
         coord = _mock_coordinator(data)
@@ -703,6 +768,30 @@ class TestSmartGridSensor:
         entity._handle_coordinator_update()
         assert entity.available is False
         assert entity._attr_native_value is None
+
+    def test_smart_grid_rfv_wiring_normal(self):
+        """Luxtronik 2.0 with SG2 on the RFV terminal, display state 3 (#669)."""
+        from custom_components.luxtronik2.const import LuxSmartGridStatus
+
+        entity, _ = self._make_smart_grid(evu=1, evu2=0, rfv=-5.0)
+        entity._handle_coordinator_update()
+        assert entity._attr_native_value == LuxSmartGridStatus.normal
+
+    def test_smart_grid_rfv_wiring_reduced(self):
+        """Same unit with SG2 open, display state 2 (#669)."""
+        from custom_components.luxtronik2.const import LuxSmartGridStatus
+
+        entity, _ = self._make_smart_grid(evu=1, evu2=0, rfv=5.0)
+        entity._handle_coordinator_update()
+        assert entity._attr_native_value == LuxSmartGridStatus.reduced
+
+    def test_smart_grid_room_station_still_uses_hzio(self):
+        """A configured room station never doubles as SG2."""
+        from custom_components.luxtronik2.const import LuxSmartGridStatus
+
+        entity, _ = self._make_smart_grid(evu=1, evu2=0, rfv=-5.0, rfv_type=4)
+        entity._handle_coordinator_update()
+        assert entity._attr_native_value == LuxSmartGridStatus.locked
 
 
 # ===========================================================================


### PR DESCRIPTION
## 🐛 Problem

On a Luxtronik **2.0** controller the `smart_grid_status` sensor is permanently stuck on `evu_locked` / `reduced_operation`, no matter what the SG contacts do — while the controller's own display switches states correctly (#669).

Both of those states are EVU2=0 rows, so the integration was reading EVU2 as 0 unconditionally. It reads it from `calc 185 ID_WEB_HZIO_EVU2`, which is fed by the **HZIO I/O board**.

## 🔍 Root cause

**The SG contacts are wired to a different terminal per controller generation.** From the "Klemmenplan Smart Grid" in the manufacturer's part-2 manuals:

| Generation | SG1 | SG2 |
|---|---|---|
| Luxtronik 2.0 ([83055300hDE](https://assets.alpha-innotec.com/baarchiv/83055300hDE_Lux_20_Teil_2.pdf) p33) | `EVU` | **`RFV`** (room station, terminal -X4) |
| Luxtronik 2.1 (83055400gDE p33-34) | IN5 / IN3 | IN6 / IN4 |
| HMD2 (83055600dDE p30-31) | IN3 | IN4 |

So on a 2.0 unit SG2 never reaches the HZIO register — it lands on the RFV room-station input. The two diagnostics dumps attached to the issue confirm it (firmware `V1.90.0`, `RFVEinb = 0`, `HZIO_EVU2 = 0` in both):

| reported | `ID_WEB_Temperatur_RFV` | EVU2 | display |
|---|---|---|---|
| SG2 off | `+5.0` | 0 | 2 |
| SG2 on | `−5.0` | 1 | 3 |

±5.0 are the rails of the RFV ±5 K adjuster — mains voltage on that terminal pins the reading there.

There is a second half to it. On 2.0 the EVU terminal carries **SG1 itself**, and that terminal is the utility-block input, where closed means "not blocked". The state table's `EVU1` column counts *blocking* as 1, so on this generation it is the logical inverse of `calc 31 ID_WEB_EVUin`. Both dumps show it: `EVUin` is `True` while both displayed states (2 and 3) are EVU1=0 rows.

Credit to @rottama, whose note in #500 about older firmware using the RFV input as `EVU2In` when no HZIO board is present turns out to be exactly right — it needed a Luxtronik 2.0 unit to show up. @siedi tested this on @Zaschii's V3.92.3 and correctly found nothing: the fallback is generation-specific and lives on the older hardware.

## ✅ Fix

`common.read_smart_grid_inputs()` derives the `(EVU1, EVU2)` pair of the state table, and **both** the status sensor and the `evu2` binary sensor consume it — so the two entities cannot disagree.

The 2.0 wiring is detected **from the data, not from the firmware version**. All three must hold:

1. SmartGrid is switched on (`P1030 != 0`) — with it off the terminal is not an SG contact by definition;
2. no room station is configured (`ID_Einst_RFVEinb_akt == 0`) — otherwise the terminal is taken;
3. the RFV reading sits in the band of the adjuster's rails (`5.0 <= abs(RFV) <= 10.0`).

Validated against a corpus of ~45 diagnostics dumps from earlier issues: **every** unit with `RFVEinb == 0` reads RFV exactly `0.0`, and units with a station configured read `-2.0…0.0` — never the rails. The only exception is the SG2-wired 2.0 unit in #669. So no existing user's entities change behaviour.

The band is deliberate on both ends. `>=` at the low end because the register may not be clamped at the rail on every unit, so reading slightly past it must still count; bounded above because a signed Celsius register can also report something implausible, and treating that as SG2 would move a 2.1 unit onto this branch and invert its EVU1 as well.

The four-state EVU1/EVU2 → status table is **unchanged** — it is identical across all three manuals, and the reporter's states fit it once the inputs are read correctly. `P1030` handling is now shared through `common.smart_grid_enabled()`, which keeps the "it holds a mode, not a flag" rule in one place: the #669 unit reports `3`, not `1`.

### Who is affected

| Unit | Before | After |
|---|---|---|
| Luxtronik 2.0 with SG2 on RFV | stuck on `evu_locked` / `reduced_operation` | follows the controller display |
| Luxtronik 2.1 / HMD2 | correct | **unchanged** (detection cannot fire: RFV reads `0.0`) |
| Any unit with a room station | correct | **unchanged** (condition 2 fails) |
| Any unit with SmartGrid off | sensor unavailable | **unchanged** (condition 1 fails) |

## 🧪 Verification

Replaying the two real diagnostics dumps from the issue through the new code reproduces the controller display:

```
sg_off.json  SG=3 RFV=  5.0 -> EVU1=0 EVU2=0 reduced_operation  display=2 OK
sg_on.json   SG=3 RFV= -5.0 -> EVU1=0 EVU2=1 normal_operation   display=3 OK
```

- **1034 tests pass**; `common.py` at 100% coverage, package total misses 3 → 1 (no regression)
- `ruff check` + `ruff format --check` clean, `basedpyright` **0 errors**, `codespell` clean
- New tests cover both wiring modes across the full truth table, plus the regression guards that keep 2.1/HMD2 users on the old path: configured room station, idle `0.0` reading, SmartGrid off, implausible RFV values, and an unparsable `RFVEinb`

## 📝 Notes for reviewers

**`evu_unlocked` and the status sensor look inverted on a 2.0 unit — both are correct.**
On that generation the EVU terminal is the utility-block input ("EVU … AUS = Sperrzeit") and SG1 is wired to it, so with SG1 closed `binary_sensor.*_evu_unlocked` reads `on` (the unit is genuinely not blocked) while the status sensor reports `reduced_operation`. The state table's `EVU1` column counts *blocking* as 1, which is the logical inverse of "unlocked". `calc 31` is therefore left reading verbatim on purpose — only the derived table input is inverted, and only for units detected as 2.0-wired.

**The EVU1 inversion is not yet confirmed at a blocked state.**
It follows from the Klemmenplan and the manual's input page, and it is consistent with both dumps — but both were taken with EVU1=0, so a dump at display state 1 or 4 would still be worth having. Note the fallback direction: without the inversion this unit reports states 1/4 instead of 2/3, so it is wrong either way, and shipping it cannot make any other generation worse because the branch is unreachable unless all three detection conditions hold.

**Separate bug, not addressed here.** `P1030 ID_Einst_SmartGrid` is modelled as a boolean switch while it holds a mode value (`3` on this unit), so toggling it off/on rewrites `3 → 0 → 1` and silently changes the SG variant. Its read path is now centralised in `common.smart_grid_enabled()`, which is a prerequisite for fixing that properly.

Refs #669
