### PR TITLE
fix(sensor,model,lux_overrides): 🩹 follow up on the review of #753 and #754

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ After setup, **Settings → Devices & Services → Luxtronik → Configure** let
 Entities and actions are organized into four logical devices in Home Assistant to keep things structured. Here is an overview of what each device does and how to use the most common entities.
 
 > **ℹ️ Note:** Not every entity documented below will exist on every installation. Each one is only created if your specific heat pump reports the corresponding feature as present (e.g. a solar collector, a second heat generator, cooling capability) or its firmware version meets that entity's minimum requirement. This means **updating your heat pump's firmware can make additional sensors and controls appear** in Home Assistant that weren't there before — if you're missing an entity mentioned here, check whether a firmware update is available (see [Advanced Features: Firmware Update Entity](ADVANCED_FEATURES.md#firmware-update-entity)) before assuming it's unsupported.
+>
+> A few entities — the pool heat and energy counters among them — are instead created only once their register reports something other than its idle value, because on a unit without that feature it never changes. This check runs when the integration starts, so if the feature is newly installed or has never run before, **restart Home Assistant or reload the integration** (Settings → Devices & Services → Luxtronik → ⋮ → Reload) once it has, to make those entities appear.
 
 ### 2.1 Heatpump
 This device represents the physical heat pump unit. It contains sensors and diagnostic entities such as electrical power consumption, thermal power output, operating hours, and current status.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,10 @@ If you want to accurately measure the SCOP (Seasonal Coefficient of Performance)
 
 The **Heating COP** and **DHW COP** sensors report an instantaneous efficiency ratio, and can use such an external meter directly as their power-consumption input instead of the heat pump's own reading — see [Advanced Features: COP Calculation and the External Power Sensor](ADVANCED_FEATURES.md#cop-calculation-and-the-external-power-sensor).
 
+> **⚠️ Series-2 controllers (firmware V2.x): the Additional heat generator energy sensors now read ten times lower.**
+> On a series-2 controller these counters step in 0.01 kWh, not the 0.1 kWh the integration previously assumed, so a unit that reported 14714 kWh now correctly reports 1471.4 kWh. Because they are total-increasing energy sensors, Home Assistant reads that one-off drop as a meter reset and books the first reading after the update as fresh consumption — a spurious spike of roughly the sensor's whole lifetime total in the energy dashboard.
+> To remove it, open **Developer Tools → Statistics**, find each *Additional heat generator energy* sensor, and use the **Fix issue / adjust sum** action on the day the update landed. Series-3 controllers (V3.x) are unaffected; their scale was verified in #625 and has not changed.
+
 ---
 
 ## 4. Troubleshooting

--- a/custom_components/luxtronik2/lux_overrides.py
+++ b/custom_components/luxtronik2/lux_overrides.py
@@ -203,10 +203,15 @@ parameters_to_add_update = {
     1137: Energy2("DHW_ENERGY_INPUT", False),
     1138: Energy2("POOL_ENERGY_INPUT", False),
     1139: Energy2("COOLING_ENERGY_INPUT", False),
-    # Auxiliary-heater heat counters, both in 0.1 kWh units, so Energy's own
-    # /10 is the whole conversion and their descriptions carry no factor. The
-    # scale was measured against the rated element power in #625; the name of
-    # 1059 must stay ID_Waermemenge_ZWE, which is how const.py resolves it.
+    # Auxiliary-heater heat counters. 0.1 kWh per count on a series-3
+    # controller, so Energy's own /10 is the whole conversion there (measured
+    # against the rated element power in #625), but 0.01 kWh on series 2, where
+    # their descriptions take a further /10 - see
+    # AUX_HEATER_ENERGY_FACTOR_BY_SERIES in sensor_entities_predefined.py for
+    # the per-generation evidence. The split cannot live here: these overrides
+    # are applied once per process, while one process can serve two config
+    # entries whose heat pumps are different generations. The name of 1059 must
+    # stay ID_Waermemenge_ZWE, which is how const.py resolves it.
     1059: Energy("ID_Waermemenge_ZWE", False),
     1140: Energy("SECOND_HEAT_GENERATOR_AMOUNT_COUNTER", False),
     # Bouni/python-luxtronik's in-progress definitions mark these read-only,

--- a/custom_components/luxtronik2/model.py
+++ b/custom_components/luxtronik2/model.py
@@ -3,6 +3,7 @@
 # region Imports
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from decimal import Decimal
@@ -113,13 +114,14 @@ class LuxtronikSensorDescription(  # type: ignore  # pyright: ignore[reportIncom
     platform = Platform.SENSOR
     factor: float | None = None
     native_precision: int | None = None
-    factor_by_firmware_series: dict[int, float] | None = None
+    factor_by_firmware_series: Mapping[int, float] | None = None
     """Per-controller-generation override of `factor`, keyed by firmware major.
 
     For the few registers whose *unit* differs between controller
     generations rather than their presence - see the auxiliary heater energy
     counters, 0.1 kWh on a series-3 controller and 0.01 kWh on a series-2 one
-    (#752). A series absent from the mapping falls back to `factor`.
+    (#752). A series absent from the mapping falls back to `factor`, which
+    includes series 0 - a firmware version that could not be read or parsed.
 
     This cannot live in the datatype the register is registered with: the
     library overrides are applied once per process, while one process can

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -60,6 +60,12 @@ from .model import (
 #   parameters 852/854/878/879, the other ID_Waermemenge_* counters, are
 #   0.01 kWh on both generations (checked against calculations 151/152, which
 #   are 0.1 kWh, on 21 diagnostics dumps). Series 3 is where 1059 leaves it.
+#   Both series-2 readings came from V2.88.3 units, so the sample fixes the
+#   series but not the minor: a change at x.88 rather than between generations
+#   would fit it equally well and would leave older series-2 firmware reading
+#   ten times low. Keyed on the series because a counter's scale is a property
+#   of the controller line, not of a register set; a pre-x.88 series-2 dump is
+#   the second thing to check for after a V1.x one (#752).
 # Series 1 - assumed to match series 2, never measured: there is no V1.x
 #   diagnostics dump in the corpus at all. A controller line that used 0.01 kWh
 #   on series 1, kept it on series 2 and changed to 0.1 on series 3 is a

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -1,6 +1,9 @@
 """Luxtronik sensors definitions."""
 
 # region Imports
+from collections.abc import Mapping
+from types import MappingProxyType
+
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
     PERCENTAGE,
@@ -75,8 +78,15 @@ from .model import (
 #
 # Listed exhaustively rather than as a single series-2 exception so that every
 # generation states its scale where it can be checked. A generation missing
-# from the mapping falls back to the description's own `factor`.
-AUX_HEATER_ENERGY_FACTOR_BY_SERIES: dict[int, float] = {1: 0.1, 2: 0.1, 3: 1}
+# from the mapping falls back to the description's own `factor`; that includes
+# series 0, which is what firmware_series reports when the version could not be
+# read or parsed (the coordinator logs a warning about it first). Such a unit
+# deliberately keeps the series-3 scale - it is what this integration applied
+# before the split existed, so a controller it cannot identify never has its
+# total_increasing counter silently rescaled by ten behind the user's back.
+AUX_HEATER_ENERGY_FACTOR_BY_SERIES: Mapping[int, float] = MappingProxyType(
+    {1: 0.1, 2: 0.1, 3: 1}
+)
 
 SENSORS_STATUS: list[descr] = [
     descr(

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -969,7 +969,7 @@
                 "name": "Energy input"
             },
             "pool_energy_input": {
-                "name": "Energy input pool"
+                "name": "Pool energy input"
             },
             "room_thermostat_temperature": {
                 "name": "Room thermostat"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -899,6 +899,17 @@ class TestEnergyInputScaling:
         """
         self._assert_raw_converts_to(SensorKey.POOL_ENERGY_INPUT, 113191, 1131.91)
 
+    def test_pool_heat_amount_scaling(self):
+        """The pool counters were read off the same page at the same moment:
+        calculation 153 showed 4364.1 kWh, so it is 0.1 kWh per count like its
+        siblings 151 and 152 and needs nothing beyond the Energy datatype.
+
+        Deliberately the module-level helper rather than this class's method of
+        the same name: 153 is a calculation, and the method resolves datatypes
+        through parameters_to_add_update, which holds no calculations.
+        """
+        _assert_raw_converts_to(SensorKey.POOL_HEAT_AMOUNT, 43641, 4364.1)
+
     def _converted_value(self, sensor_key: SensorKey, raw_value: int) -> float:
         description, datatype = _energy_input_case(sensor_key)
         converted = datatype.from_heatpump(raw_value)
@@ -1015,5 +1026,19 @@ class TestAuxHeaterAmountScaling:
             SensorKey.ADDITIONAL_HEAT_GENERATOR_ENERGY_P1059,
             147140,
             firmware_series=3,
+        )
+        assert value == 14714.0
+
+    def test_unknown_series_keeps_the_series_3_scale(self):
+        """firmware_series is 0 when the version could not be read or parsed.
+        That is not in the mapping, so the entity falls back to the
+        description's own factor - deliberately the series-3 scale, which is
+        what the integration applied before the split existed, so an
+        unidentifiable controller keeps reading what it always read.
+        """
+        value = self._converted_value(
+            SensorKey.ADDITIONAL_HEAT_GENERATOR_ENERGY_P1059,
+            147140,
+            firmware_series=0,
         )
         assert value == 14714.0


### PR DESCRIPTION
Follow-up to #753 and #754, from a code review of both. Two commits: the first is comments and documentation only, the second hardens and tests what that review flagged.

## 🐛 Corrections (16fde15)

- **`lux_overrides.py`** — the comment on parameters 1059/1140 still said they are "both in 0.1 kWh units" whose "descriptions carry no factor". #753 made both clauses false. It now states the per-generation scale, points at `AUX_HEATER_ENERGY_FACTOR_BY_SERIES`, and records why the split cannot live in the datatype: the overrides are applied once per process, while one process can serve two config entries whose heat pumps are different generations.
- **`sensor_entities_predefined.py`** — the series-2 entry was presented as settled while the series-1 and 1140 assumptions were carefully flagged. Both series-2 readings came from V2.88.3 units, so the sample fixes the *series* but not the *minor*; a change at x.88 fits it equally well and would leave older series-2 firmware reading ten times low. Now recorded, together with why the series is still the right key and which dump would settle it (#752).

## ⚠️ Warning for series-2 owners (16fde15)

The *Additional heat generator energy* sensors are `total_increasing`. On a series-2 unit #753 makes them drop by 10× (14714 → 1471.4 kWh) on the first poll after the update. Home Assistant reads that drop as a meter reset and books the next reading as fresh consumption — a spurious spike of roughly the sensor's whole lifetime total in the energy dashboard, on exactly the population the fix was written for. The remedy (Developer Tools → Statistics → adjust the sum on the day of the update) is not something anyone finds unprompted, so it is now in the README.

## 🩹 Hardening and tests (7b64cf2)

- An unreadable firmware version makes `firmware_series` 0, which is in no mapping, so the entity fell through to the description's own `factor` — the right outcome, reached by accident. Both the mapping and the field docstring now say it is deliberate, and why: the series-3 scale is what the integration applied before the split existed, so a controller it cannot identify never has its `total_increasing` counter silently rescaled by ten. A test drives series 0 through the entity.
- `AUX_HEATER_ENERGY_FACTOR_BY_SERIES` is a `MappingProxyType` and the field is typed `Mapping`, so one dict shared by three descriptions cannot be mutated through any of them.
- Calculation 153 is pinned against the reading that identified it (43641 counts → 4364.1 kWh on the #752 unit's page). Its /10 was asserted only in a comment, while sibling 1138 was already covered.
- README: a few entities appear only once their register leaves its idle value, and that is decided at startup — so a pool that has never run needs a reload before its counters show up.
- The English `pool_energy_input` read "Energy input pool" next to a neighbour reading "Pool heat amount"; renamed to "Pool energy input".

## 🧪 Verification

- `pytest --cov=custom_components.luxtronik2` → **1019 passed**, 99% coverage (the single miss is pre-existing in `text.py`)
- `ruff check` clean, `ruff format --check` clean, `codespell` clean
- `basedpyright` → 0 errors, 0 warnings, 0 notes

Refs #752.
