### PR TITLE
style(translations): 🎨 spell non-ascii characters literally in all language files

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Revisions that only reformat, so `git blame` should look straight through
+# them. GitHub honours this file automatically; locally, enable it once with:
+#
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# style(translations): spell non-ascii characters literally in all language files
+# Replaced every \uXXXX escape in cs/de/en/nl/pl.json with the character itself.
+444472f16e8df9efe0aa2affb65779f3cf17031c

--- a/.github/scripts/check_translation_coverage.py
+++ b/.github/scripts/check_translation_coverage.py
@@ -5,6 +5,7 @@ import ast
 import json
 import logging
 from pathlib import Path
+import re
 import sys
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -13,6 +14,12 @@ TRANS_DIR = ENTITY_DIR / "translations"
 CONST_FILE = ENTITY_DIR / "const.py"
 
 LANG_FILES = ["en.json", "de.json", "cs.json", "nl.json", "pl.json"]
+
+# An *effective* JSON \uXXXX escape: one whose backslash is not itself escaped.
+# "\\u0041" is an escaped backslash followed by the literal text u0041, not an
+# escape, so the run of backslashes is anchored and counted rather than just
+# looked behind.
+ASCII_ESCAPE = re.compile(r"(?<!\\)(?:\\\\)*\\u[0-9a-fA-F]{4}")
 
 ENTITY_CHECKS = [
     ("number_entities_predefined.py", "number"),
@@ -245,6 +252,33 @@ def find_device_translation_problems() -> list[str]:
     return problems
 
 
+def find_ascii_escaped_files() -> list[str]:
+    """Check that no language file spells non-ASCII characters as \\uXXXX escapes.
+
+    Home Assistant's hand-authored translation source, core's strings.json, is
+    plain UTF-8; the escaped translations/*.json shipped with core are Lokalise
+    build artifacts. This integration has no strings.json, so these files are
+    the authored source and follow the authored-source convention:
+    "Wärmemenge" is readable in a review diff, "W\\u00e4rmemenge" is not.
+
+    Both spellings parse to the same string, so nothing catches the drift at
+    runtime: it creeps back whenever a string is pasted from a tool that
+    defaults to `json.dump(..., ensure_ascii=True)`, and the next full rewrite
+    then churns every line in the file.
+    """
+    problems: list[str] = []
+    for lang_file in LANG_FILES:
+        raw = (TRANS_DIR / lang_file).read_text(encoding="utf-8")
+        matches = list(ASCII_ESCAPE.finditer(raw))
+        if matches:
+            line = raw.count("\n", 0, matches[0].start()) + 1
+            problems.append(
+                f"[{lang_file}] {len(matches)} \\uXXXX escape(s), first on line"
+                f" {line} ({matches[0].group(0)}) - write the character itself"
+            )
+    return problems
+
+
 def find_exceptions_translation_problems() -> list[str]:
     """Check that every top-level `exceptions.<key>.message` in en.json also
     exists (non-empty) in every other language file.
@@ -283,6 +317,7 @@ if __name__ == "__main__":
         + find_state_key_mismatches()
         + find_device_translation_problems()
         + find_exceptions_translation_problems()
+        + find_ascii_escaped_files()
     )
     if not all_problems:
         LOG.info("All translation files have complete coverage!")

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -1038,7 +1038,7 @@ class SensorAttrKey(StrEnum):
     TIMER_HEATPUMP_ON = "WP Seit (ID_WEB_Time_WPein_akt)"
     TIMER_ADD_HEAT_GENERATOR_ON = "ZWE1 seit (ID_WEB_Time_ZWE1_akt)"
     TIMER_SEC_HEAT_GENERATOR_ON = "ZWE2 seit (ID_WEB_Time_ZWE2_akt)"
-    TIMER_NET_INPUT_DELAY = "Netzeinschaltverz\u00f6gerung (ID_WEB_Timer_EinschVerz)"
+    TIMER_NET_INPUT_DELAY = "Netzeinschaltverzögerung (ID_WEB_Timer_EinschVerz)"
     TIMER_SCB_OFF = "Schaltspielsperre Aus-Zeit (ID_WEB_Time_SSPAUS_akt)"
     TIMER_SCB_ON = "Schaltspielsperre Ein-Zeit (ID_WEB_Time_SSPEIN_akt)"
     TIMER_COMPRESSOR_OFF = "VD-Stand (ID_WEB_Time_VDStd_akt)"

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -14,28 +14,28 @@
                 "name": "Kompresor 2"
             },
             "pump_flow": {
-                "name": "\u010cerpadlo"
+                "name": "Čerpadlo"
             },
             "compressor_heater": {
-                "name": "Oh\u0159ev kompresoru"
+                "name": "Ohřev kompresoru"
             },
             "defrost_valve": {
-                "name": "Ventil odmrazov\u00e1n\u00ed"
+                "name": "Ventil odmrazování"
             },
             "additional_heat_generator": {
-                "name": "P\u0159\u00eddavn\u00fd zdroj tepla"
+                "name": "Přídavný zdroj tepla"
             },
             "additional_heat_generator2": {
-                "name": "P\u0159\u00eddavn\u00fd zdroj tepla 2"
+                "name": "Přídavný zdroj tepla 2"
             },
             "disturbance_output": {
-                "name": "Stav syst\u00e9mu"
+                "name": "Stav systému"
             },
             "circulation_pump_heating": {
-                "name": "Ob\u011bhov\u00e9 \u010derpadlo vyt\u00e1p\u011bn\u00ed"
+                "name": "Oběhové čerpadlo vytápění"
             },
             "additional_circulation_pump": {
-                "name": "P\u0159\u00eddavn\u00e9 ob\u011bhov\u00e9 \u010derpadlo"
+                "name": "Přídavné oběhové čerpadlo"
             },
             "dhw_recirculation_pump": {
                 "name": "Recirkulace TUV"
@@ -44,16 +44,16 @@
                 "name": "Cirkulace TUV"
             },
             "dhw_charging_pump": {
-                "name": "\u010cerpadlo pro dob\u00edjen\u00ed oh\u0159\u00edva\u010de vody"
+                "name": "Čerpadlo pro dobíjení ohřívače vody"
             },
             "solar_pump": {
-                "name": "Sol\u00e1rn\u00ed \u010derpadlo"
+                "name": "Solární čerpadlo"
             },
             "approval_cooling": {
-                "name": "Ov\u011b\u0159en\u00ed chladic\u00edho syst\u00e9mu"
+                "name": "Ověření chladicího systému"
             },
             "defrost_end_flow_okay": {
-                "name": "Odtok odmrazov\u00e1n\u00ed"
+                "name": "Odtok odmrazování"
             },
             "motor_protection": {
                 "name": "Ochrana motoru"
@@ -61,40 +61,40 @@
         },
         "switch": {
             "remote_maintenance": {
-                "name": "Vzd\u00e1len\u00e1 \u00fadr\u017eba"
+                "name": "Vzdálená údržba"
             },
             "efficiency_pump": {
-                "name": "\u00da\u010dinnost \u010derpadla"
+                "name": "Účinnost čerpadla"
             },
             "electrical_power_limitation_switch": {
-                "name": "Omezen\u00ed v\u00fdkonu"
+                "name": "Omezení výkonu"
             },
             "thermal_power_limitation_switch": {
-                "name": "Max. tepeln\u00fd v\u00fdkon"
+                "name": "Max. tepelný výkon"
             },
             "pump_heat_control": {
-                "name": "Ovl\u00e1d\u00e1n\u00ed \u010derpadla pro oh\u0159ev"
+                "name": "Ovládání čerpadla pro ohřev"
             },
             "heating": {
-                "name": "Automatick\u00fd re\u017eim vyt\u00e1p\u011bn\u00ed"
+                "name": "Automatický režim vytápění"
             },
             "pump_optimization": {
-                "name": "Optimalizace \u010derpadla"
+                "name": "Optimalizace čerpadla"
             },
             "heating_threshold": {
-                "name": "Teplotn\u00ed mez pro vyt\u00e1p\u011bn\u00ed"
+                "name": "Teplotní mez pro vytápění"
             },
             "domestic_water": {
-                "name": "Automatick\u00fd re\u017eim oh\u0159evu TUV"
+                "name": "Automatický režim ohřevu TUV"
             },
             "cooling": {
-                "name": "Chlazen\u00ed"
+                "name": "Chlazení"
             },
             "pump_vent_hup": {
-                "name": "Odv\u011btr\u00e1v\u00e1n\u00ed HUP"
+                "name": "Odvětrávání HUP"
             },
             "pump_vent_active": {
-                "name": "Odv\u011btr\u00e1v\u00e1n\u00ed aktiv\u00ed"
+                "name": "Odvětrávání aktiví"
             },
             "smartgrid": {
                 "name": "Smart Grid"
@@ -107,148 +107,148 @@
         },
         "number": {
             "release_second_heat_generator": {
-                "name": "Odem\u010den\u00ed druh\u00e9ho gener\u00e1toru tepla"
+                "name": "Odemčení druhého generátoru tepla"
             },
             "release_time_second_heat_generator": {
-                "name": "\u010cas odem\u010den\u00ed druh\u00e9ho gener\u00e1toru tepla"
+                "name": "Čas odemčení druhého generátoru tepla"
             },
             "pump_optimization": {
-                "name": "Optimalizace \u010derpadla"
+                "name": "Optimalizace čerpadla"
             },
             "electrical_power_limitation_value": {
-                "name": "Limit v\u00fdkonu"
+                "name": "Limit výkonu"
             },
             "thermal_power_limitation_heating": {
-                "name": "Limit tepeln\u00e9ho v\u00fdkonu: Vyt\u00e1p\u011bn\u00ed"
+                "name": "Limit tepelného výkonu: Vytápění"
             },
             "thermal_power_limitation_water": {
-                "name": "Limit tepeln\u00e9ho v\u00fdkonu: TUV"
+                "name": "Limit tepelného výkonu: TUV"
             },
             "thermal_power_limitation_cooling": {
-                "name": "Limit tepeln\u00e9ho v\u00fdkonu: Chlazen\u00ed"
+                "name": "Limit tepelného výkonu: Chlazení"
             },
             "heating_threshold": {
-                "name": "Teplotn\u00ed mez pro vyt\u00e1p\u011bn\u00ed"
+                "name": "Teplotní mez pro vytápění"
             },
             "heating_target_correction": {
-                "name": "Korekce po\u017eadovan\u00e9 teploty vyt\u00e1p\u011bn\u00ed"
+                "name": "Korekce požadované teploty vytápění"
             },
             "heating_min_flow_out_temperature": {
-                "name": "Minim\u00e1ln\u00ed teplota zp\u00e1te\u010dky vyt\u00e1p\u011bn\u00ed"
+                "name": "Minimální teplota zpátečky vytápění"
             },
             "heating_curve_end_temperature": {
-                "name": "Koncov\u00fd bod topn\u00e9 k\u0159ivky"
+                "name": "Koncový bod topné křivky"
             },
             "heating_curve_parallel_shift_temperature": {
-                "name": "Paraleln\u00ed posun topn\u00e9 k\u0159ivky"
+                "name": "Paralelní posun topné křivky"
             },
             "heating_curve_night_temperature": {
-                "name": "No\u010dn\u00ed redukce topn\u00e9 k\u0159ivky"
+                "name": "Noční redukce topné křivky"
             },
             "heating_curve_circuit1_end_temperature": {
-                "name": "Koncov\u00fd bod topn\u00e9 k\u0159ivky pro okruh 1"
+                "name": "Koncový bod topné křivky pro okruh 1"
             },
             "heating_curve_circuit1_parallel_shift_temperature": {
-                "name": "Paraleln\u00ed posun topn\u00e9 k\u0159ivky pro okruh 1"
+                "name": "Paralelní posun topné křivky pro okruh 1"
             },
             "heating_curve_circuit1_night_temperature": {
-                "name": "No\u010dn\u00ed redukce topn\u00e9 k\u0159ivky pro okruh 1"
+                "name": "Noční redukce topné křivky pro okruh 1"
             },
             "heating_curve_circuit2_end_temperature": {
-                "name": "Koncov\u00fd bod topn\u00e9 k\u0159ivky pro okruh 2"
+                "name": "Koncový bod topné křivky pro okruh 2"
             },
             "heating_curve_circuit2_parallel_shift_temperature": {
-                "name": "Paraleln\u00ed posun topn\u00e9 k\u0159ivky pro okruh 2"
+                "name": "Paralelní posun topné křivky pro okruh 2"
             },
             "heating_curve_circuit2_night_temperature": {
-                "name": "No\u010dn\u00ed redukce topn\u00e9 k\u0159ivky pro okruh 2"
+                "name": "Noční redukce topné křivky pro okruh 2"
             },
             "heating_curve_circuit3_end_temperature": {
-                "name": "Koncov\u00fd bod topn\u00e9 k\u0159ivky pro okruh 3"
+                "name": "Koncový bod topné křivky pro okruh 3"
             },
             "heating_curve_circuit3_parallel_shift_temperature": {
-                "name": "Paraleln\u00ed posun topn\u00e9 k\u0159ivky pro okruh 3"
+                "name": "Paralelní posun topné křivky pro okruh 3"
             },
             "heating_curve_circuit3_night_temperature": {
-                "name": "No\u010dn\u00ed redukce topn\u00e9 k\u0159ivky pro okruh 3"
+                "name": "Noční redukce topné křivky pro okruh 3"
             },
             "dhw_target_temperature": {
-                "name": "po\u017eadovan\u00e1 teplota TUV"
+                "name": "požadovaná teplota TUV"
             },
             "dhw_thermal_desinfection_target": {
-                "name": "po\u017eadovan\u00e1 teplota term\u00e1ln\u00ed dezinfekce TUV"
+                "name": "požadovaná teplota termální dezinfekce TUV"
             },
             "solar_pump_max_temperature_collector": {
-                "name": "Maxim\u00e1ln\u00ed teplota sol\u00e1rn\u00edho kolektoru \u010derpadla"
+                "name": "Maximální teplota solárního kolektoru čerpadla"
             },
             "solar_pump_off_max_difference_temperature_boiler": {
-                "name": "Max. rozd\u00edl teploty vypnut\u00ed sol\u00e1rn\u00edho \u010derpadla kolektor/bojler"
+                "name": "Max. rozdíl teploty vypnutí solárního čerpadla kolektor/bojler"
             },
             "solar_pump_off_difference_temperature": {
-                "name": "Rozd\u00edl teploty vypnut\u00ed sol\u00e1rn\u00edho \u010derpadla kolektor/bojler"
+                "name": "Rozdíl teploty vypnutí solárního čerpadla kolektor/bojler"
             },
             "solar_pump_on_difference_temperature": {
-                "name": "Rozd\u00edl teploty zapnut\u00ed sol\u00e1rn\u00edho \u010derpadla kolektor/bojler"
+                "name": "Rozdíl teploty zapnutí solárního čerpadla kolektor/bojler"
             },
             "dhw_hysteresis": {
                 "name": "Hystereze TUV"
             },
             "heating_room_temperature_impact_factor": {
-                "name": "Faktor vlivu teploty m\u00edstnosti na vyt\u00e1p\u011bn\u00ed"
+                "name": "Faktor vlivu teploty místnosti na vytápění"
             },
             "heating_maximum_circulation_pump_speed": {
-                "name": "Maxim\u00e1ln\u00ed rychlost ob\u011bhov\u00e9ho \u010derpadla p\u0159i vyt\u00e1p\u011bn\u00ed"
+                "name": "Maximální rychlost oběhového čerpadla při vytápění"
             },
             "heating_max_flow_out_increase_temperature": {
-                "name": "Maxim\u00e1ln\u00ed zv\u00fd\u0161en\u00ed teploty zp\u00e1te\u010dky vyt\u00e1p\u011bn\u00ed"
+                "name": "Maximální zvýšení teploty zpátečky vytápění"
             },
             "heating_hysteresis": {
-                "name": "Hystereze regul\u00e1toru vyt\u00e1p\u011bn\u00ed"
+                "name": "Hystereze regulátoru vytápění"
             },
             "heating_night_lowering_to_temperature": {
-                "name": "Sn\u00ed\u017een\u00ed teploty na noc"
+                "name": "Snížení teploty na noc"
             },
             "efficiency_pump_nominal_voltage": {
-                "name": "Nomin\u00e1ln\u00ed nap\u011bt\u00ed \u00fa\u010dinn\u00e9ho \u010derpadla"
+                "name": "Nominální napětí účinného čerpadla"
             },
             "efficiency_pump_nominal_percentage": {
-                "name": "Nomin\u00e1ln\u00ed procento \u00fa\u010dinn\u00e9ho \u010derpadla"
+                "name": "Nominální procento účinného čerpadla"
             },
             "efficiency_pump_minimal_voltage": {
-                "name": "Minim\u00e1ln\u00ed nap\u011bt\u00ed \u00fa\u010dinn\u00e9ho \u010derpadla"
+                "name": "Minimální napětí účinného čerpadla"
             },
             "efficiency_pump_minimal_percentage": {
-                "name": "Minim\u00e1ln\u00ed procento \u00fa\u010dinn\u00e9ho \u010derpadla"
+                "name": "Minimální procento účinného čerpadla"
             },
             "cooling_threshold_temperature": {
-                "name": "Minim\u00e1ln\u00ed teplota pro chlazen\u00ed"
+                "name": "Minimální teplota pro chlazení"
             },
             "cooling_start_delay_hours": {
-                "name": "Zpo\u017ed\u011bn\u00ed za\u010d\u00e1tku chlazen\u00ed"
+                "name": "Zpoždění začátku chlazení"
             },
             "cooling_stop_delay_hours": {
-                "name": "Zpo\u017ed\u011bn\u00ed konce chlazen\u00ed"
+                "name": "Zpoždění konce chlazení"
             },
             "cooling_target_temperature_mk1": {
-                "name": "po\u017eadovan\u00e1 teplota chlazen\u00ed MK1"
+                "name": "požadovaná teplota chlazení MK1"
             },
             "cooling_target_temperature_mk2": {
-                "name": "po\u017eadovan\u00e1 teplota chlazen\u00ed MK2"
+                "name": "požadovaná teplota chlazení MK2"
             },
             "cooling_target_temperature_mk3": {
-                "name": "po\u017eadovan\u00e1 teplota chlazen\u00ed MK3"
+                "name": "požadovaná teplota chlazení MK3"
             },
             "cooling_min_flow_out_temperature": {
-                "name": "Minim\u00e1ln\u00ed teplota p\u0159\u00edvodu chlazen\u00ed"
+                "name": "Minimální teplota přívodu chlazení"
             },
             "heat_source_input_temperature_min": {
-                "name": "Minim\u00e1ln\u00ed vstupn\u00ed teplota zdroje tepla"
+                "name": "Minimální vstupní teplota zdroje tepla"
             },
             "heating_flow_out_temperature_target": {
-                "name": "Manu\u00e1ln\u00ed c\u00edlov\u00e1 teplota v\u00fdstupn\u00ed vody"
+                "name": "Manuální cílová teplota výstupní vody"
             },
             "pump_vent_timer_h": {
-                "name": "Doba provozu odvzdu\u0161\u0148ov\u00e1n\u00ed"
+                "name": "Doba provozu odvzdušňování"
             },
             "dhw_manual_frequency": {
                 "name": "DHW extra frekvence"
@@ -263,626 +263,626 @@
                 "name": "Heizgrenze Temperatur"
             },
             "pump_optimization_time": {
-                "name": "Doba trv\u00e1n\u00ed optimalizace \u010derpadla"
+                "name": "Doba trvání optimalizace čerpadla"
             }
         },
         "sensor": {
             "status": {
                 "name": "Stav",
                 "state": {
-                    "heating": "Vyt\u00e1p\u011bn\u00ed",
-                    "hot_water": "Oh\u0159ev TUV",
-                    "swimming_pool_solar": "Baz\u00e9n / Sol\u00e1rn\u00ed",
+                    "heating": "Vytápění",
+                    "hot_water": "Ohřev TUV",
+                    "swimming_pool_solar": "Bazén / Solární",
                     "evu": "Blokace HDO",
-                    "defrost": "Odmrazov\u00e1n\u00ed",
-                    "heating_external_source": "Vyt\u00e1p\u011bn\u00ed z extern\u00edho zdroje",
-                    "cooling": "Chlazen\u00ed",
-                    "no_request": "Klidov\u00fd re\u017eim"
+                    "defrost": "Odmrazování",
+                    "heating_external_source": "Vytápění z externího zdroje",
+                    "cooling": "Chlazení",
+                    "no_request": "Klidový režim"
                 }
             },
             "smart_grid_status": {
                 "name": "Stav SmartGrid",
                 "state": {
-                    "evu_locked": "Blokov\u00e1no EVU",
-                    "reduced_operation": "Sn\u00ed\u017een\u00fd provoz",
-                    "normal_operation": "Norm\u00e1ln\u00ed provoz",
-                    "increased_operation": "Zv\u00fd\u0161en\u00fd provoz"
+                    "evu_locked": "Blokováno EVU",
+                    "reduced_operation": "Snížený provoz",
+                    "normal_operation": "Normální provoz",
+                    "increased_operation": "Zvýšený provoz"
                 }
             },
             "error_reason": {
-                "name": "Posledn\u00ed chyba",
+                "name": "Poslední chyba",
                 "state": {
-                    "701": "N\u00edzkotlakov\u00e1 porucha",
-                    "702": "N\u00edzkotlakov\u00fd z\u00e1mek - RESET automaticky",
-                    "703": "Ochrana proti mrazu\nPros\u00edm, volejte technika",
-                    "704": "Porucha hork\u00e9ho plynu\n Reset automaticky za hh:mm",
-                    "705": "Ochrana ventil\u00e1toru motoru\nPros\u00edm, volejte technika",
-                    "706": "Ochrana motoru ob\u011bhov\u00e9ho \u010derpadla\nPros\u00edm, volejte technika",
-                    "707": "K\u00f3dov\u00e1n\u00ed tepeln\u00e9ho \u010derpadla\nPros\u00edm, volejte technika",
-                    "708": "Sn\u00edma\u010d zp\u00e1te\u010dky\nPros\u00edm, volejte technika",
-                    "709": "Sn\u00edma\u010d pr\u016ftoku\nPros\u00edm, volejte technika",
-                    "710": "Sn\u00edma\u010d hork\u00e9ho plynu\nPros\u00edm, volejte technika",
-                    "711": "Sn\u00edma\u010d venkovn\u00ed teploty\nPros\u00edm, volejte technika",
-                    "712": "Sn\u00edma\u010d TUV\nPros\u00edm, volejte technika",
-                    "713": "Sn\u00edma\u010d zdroje tepla - Zapnuto\nPros\u00edm, volejte technika",
-                    "714": "Hork\u00fd plyn pro oh\u0159ev vody - Reset automaticky za hh:mm",
-                    "715": "Vypnut\u00ed vysok\u00e9ho tlaku - RESET automaticky",
-                    "716": "Porucha vysok\u00e9ho tlaku\nPros\u00edm, volejte technika",
-                    "717": "Pr\u016ftokov\u00fd sn\u00edma\u010d tepla\nPros\u00edm, volejte technika",
-                    "718": "Max. venkovn\u00ed teplota - RESET automaticky za hh:mm",
-                    "719": "Min. venkovn\u00ed teplota - RESET automaticky za hh:mm",
+                    "701": "Nízkotlaková porucha",
+                    "702": "Nízkotlakový zámek - RESET automaticky",
+                    "703": "Ochrana proti mrazu\nProsím, volejte technika",
+                    "704": "Porucha horkého plynu\n Reset automaticky za hh:mm",
+                    "705": "Ochrana ventilátoru motoru\nProsím, volejte technika",
+                    "706": "Ochrana motoru oběhového čerpadla\nProsím, volejte technika",
+                    "707": "Kódování tepelného čerpadla\nProsím, volejte technika",
+                    "708": "Snímač zpátečky\nProsím, volejte technika",
+                    "709": "Snímač průtoku\nProsím, volejte technika",
+                    "710": "Snímač horkého plynu\nProsím, volejte technika",
+                    "711": "Snímač venkovní teploty\nProsím, volejte technika",
+                    "712": "Snímač TUV\nProsím, volejte technika",
+                    "713": "Snímač zdroje tepla - Zapnuto\nProsím, volejte technika",
+                    "714": "Horký plyn pro ohřev vody - Reset automaticky za hh:mm",
+                    "715": "Vypnutí vysokého tlaku - RESET automaticky",
+                    "716": "Porucha vysokého tlaku\nProsím, volejte technika",
+                    "717": "Průtokový snímač tepla\nProsím, volejte technika",
+                    "718": "Max. venkovní teplota - RESET automaticky za hh:mm",
+                    "719": "Min. venkovní teplota - RESET automaticky za hh:mm",
                     "720": "Teplota zdroje tepla - RESET automaticky za hh:mm",
-                    "721": "Vypnut\u00ed n\u00edzk\u00e9ho tlaku - RESET automaticky",
-                    "722": "Rozd\u00edl teploty topn\u00e9 vody\nPros\u00edm, volejte technika",
-                    "723": "Rozd\u00edl teploty TUV\nPros\u00edm, volejte technika",
-                    "724": "Rozd\u00edl teploty odmrazov\u00e1n\u00ed\nPros\u00edm, volejte technika",
-                    "725": "Chyba v syst\u00e9mu oh\u0159evu vody\nPros\u00edm, volejte technika",
-                    "726": "Sn\u00edma\u010d sm\u011b\u0161ovac\u00edho okruhu 1\nPros\u00edm, volejte technika",
-                    "727": "Tlak roztoku\nPros\u00edm, volejte technika",
-                    "728": "Sn\u00edma\u010d vypnut\u00ed zdroje tepla\nPros\u00edm, volejte technika",
-                    "729": "Chyba f\u00e1ze\nPros\u00edm, volejte technika",
-                    "730": "V\u00fdkon vyt\u00e1p\u011bn\u00ed\nPros\u00edm, volejte technika",
-                    "732": "Porucha chlazen\u00ed\nPros\u00edm, volejte technika",
-                    "733": "Porucha anody\nPros\u00edm, volejte technika",
-                    "734": "Porucha anody\nPros\u00edm, volejte technika",
-                    "735": "Sn\u00edma\u010d extern\u00edho zdroje energie\nPros\u00edm, volejte technika",
-                    "736": "Sn\u00edma\u010d sol\u00e1rn\u00edho kolektoru\nPros\u00edm, volejte technika",
-                    "737": "Sn\u00edma\u010d sol\u00e1rn\u00ed n\u00e1dr\u017ee\nPros\u00edm, volejte technika",
-                    "738": "Sn\u00edma\u010d sm\u011b\u0161ovac\u00edho okruhu 2\nPros\u00edm, volejte technika",
-                    "750": "Sn\u00edma\u010d extern\u00ed zp\u00e1te\u010dky\nPros\u00edm, volejte technika",
-                    "751": "Chyba monitorov\u00e1n\u00ed f\u00e1ze",
-                    "752": "Chyba monitorov\u00e1n\u00ed pr\u016ftoku",
-                    "755": "Ztr\u00e1ta spojen\u00ed se Slave \u010derpadlem\nPros\u00edm, volejte technika",
-                    "756": "Ztr\u00e1ta spojen\u00ed s Master \u010derpadlem\nPros\u00edm, volejte technika",
-                    "757": "Porucha n\u00edzk\u00e9ho tlaku u oh\u0159\u00edva\u010de vody",
-                    "758": "Porucha odmrazov\u00e1n\u00ed",
-                    "759": "Zpr\u00e1va o term\u00e1ln\u00ed dezinfekci",
-                    "760": "Porucha odmrazov\u00e1n\u00ed",
-                    "761": "P\u0159eru\u0161en\u00e9 LIN spojen\u00ed",
-                    "762": "Sn\u00edma\u010d sac\u00edho kompresoru",
-                    "763": "Sn\u00edma\u010d sac\u00edho v\u00fdparn\u00edku",
-                    "764": "Sn\u00edma\u010d oh\u0159evu kompresoru",
-                    "765": "P\u0159eh\u0159\u00e1t\u00ed",
-                    "766": "Hranice pou\u017eit\u00ed kompresoru",
-                    "767": "Omezova\u010d teploty topn\u00e9ho t\u011blesa",
-                    "768": "Monitorov\u00e1n\u00ed pr\u016ftoku",
-                    "769": "\u0158\u00edzen\u00ed \u010derpadla",
-                    "770": "N\u00edzk\u00e9 p\u0159eh\u0159\u00e1t\u00ed",
-                    "771": "Vysok\u00e9 p\u0159eh\u0159\u00e1t\u00ed",
-                    "776": "Meze pou\u017eit\u00ed kompresoru",
-                    "777": "Expanzn\u00ed ventil",
-                    "778": "Sn\u00edma\u010d n\u00edzk\u00e9ho tlaku",
-                    "779": "Sn\u00edma\u010d vysok\u00e9ho tlaku",
-                    "780": "Sn\u00edma\u010d EVI (Enhanced Vapour Injection)",
-                    "781": "Sn\u00edma\u010d kapaliny p\u0159ed expanzn\u00edm ventilem",
-                    "782": "Sn\u00edma\u010d EVI (Enhanced Vapour Injection) sac\u00edho plynu",
+                    "721": "Vypnutí nízkého tlaku - RESET automaticky",
+                    "722": "Rozdíl teploty topné vody\nProsím, volejte technika",
+                    "723": "Rozdíl teploty TUV\nProsím, volejte technika",
+                    "724": "Rozdíl teploty odmrazování\nProsím, volejte technika",
+                    "725": "Chyba v systému ohřevu vody\nProsím, volejte technika",
+                    "726": "Snímač směšovacího okruhu 1\nProsím, volejte technika",
+                    "727": "Tlak roztoku\nProsím, volejte technika",
+                    "728": "Snímač vypnutí zdroje tepla\nProsím, volejte technika",
+                    "729": "Chyba fáze\nProsím, volejte technika",
+                    "730": "Výkon vytápění\nProsím, volejte technika",
+                    "732": "Porucha chlazení\nProsím, volejte technika",
+                    "733": "Porucha anody\nProsím, volejte technika",
+                    "734": "Porucha anody\nProsím, volejte technika",
+                    "735": "Snímač externího zdroje energie\nProsím, volejte technika",
+                    "736": "Snímač solárního kolektoru\nProsím, volejte technika",
+                    "737": "Snímač solární nádrže\nProsím, volejte technika",
+                    "738": "Snímač směšovacího okruhu 2\nProsím, volejte technika",
+                    "750": "Snímač externí zpátečky\nProsím, volejte technika",
+                    "751": "Chyba monitorování fáze",
+                    "752": "Chyba monitorování průtoku",
+                    "755": "Ztráta spojení se Slave čerpadlem\nProsím, volejte technika",
+                    "756": "Ztráta spojení s Master čerpadlem\nProsím, volejte technika",
+                    "757": "Porucha nízkého tlaku u ohřívače vody",
+                    "758": "Porucha odmrazování",
+                    "759": "Zpráva o termální dezinfekci",
+                    "760": "Porucha odmrazování",
+                    "761": "Přerušené LIN spojení",
+                    "762": "Snímač sacího kompresoru",
+                    "763": "Snímač sacího výparníku",
+                    "764": "Snímač ohřevu kompresoru",
+                    "765": "Přehřátí",
+                    "766": "Hranice použití kompresoru",
+                    "767": "Omezovač teploty topného tělesa",
+                    "768": "Monitorování průtoku",
+                    "769": "Řízení čerpadla",
+                    "770": "Nízké přehřátí",
+                    "771": "Vysoké přehřátí",
+                    "776": "Meze použití kompresoru",
+                    "777": "Expanzní ventil",
+                    "778": "Snímač nízkého tlaku",
+                    "779": "Snímač vysokého tlaku",
+                    "780": "Snímač EVI (Enhanced Vapour Injection)",
+                    "781": "Snímač kapaliny před expanzním ventilem",
+                    "782": "Snímač EVI (Enhanced Vapour Injection) sacího plynu",
                     "783": "Komunikace SEC-Inverter",
-                    "784": "VSS uzam\u010deno",
+                    "784": "VSS uzamčeno",
                     "785": "Porucha desky SEC",
                     "786": "Komunikace SEC-Inverter",
-                    "787": "V\u00fdstraha VD",
-                    "788": "Z\u00e1va\u017en\u00e1 chyba m\u011bni\u010de",
-                    "789": "LIN/K\u00f3dov\u00e1n\u00ed nen\u00ed k dispozici",
-                    "790": "Z\u00e1va\u017en\u00e1 chyba m\u011bni\u010de",
-                    "791": "Ztr\u00e1ta ModBus spojen\u00ed",
-                    "792": "P\u0159eru\u0161en\u00e9 LIN spojen\u00ed",
-                    "793": "Z\u00e1va\u017en\u00e1 chyba m\u011bni\u010de",
-                    "731": "\u010casov\u00fd limit TDI",
-                    "739": "\u010cidlo sm\u011b\u0161ovac\u00edho okruhu 3",
-                    "794": "P\u0159ep\u011bt\u00ed",
-                    "795": "Podp\u011bt\u00ed",
-                    "796": "Bezpe\u010dnostn\u00ed vypnut\u00ed",
-                    "797": "MLRH nen\u00ed podporov\u00e1no",
-                    "798": "ModBus ventil\u00e1tor",
+                    "787": "Výstraha VD",
+                    "788": "Závažná chyba měniče",
+                    "789": "LIN/Kódování není k dispozici",
+                    "790": "Závažná chyba měniče",
+                    "791": "Ztráta ModBus spojení",
+                    "792": "Přerušené LIN spojení",
+                    "793": "Závažná chyba měniče",
+                    "731": "Časový limit TDI",
+                    "739": "Čidlo směšovacího okruhu 3",
+                    "794": "Přepětí",
+                    "795": "Podpětí",
+                    "796": "Bezpečnostní vypnutí",
+                    "797": "MLRH není podporováno",
+                    "798": "ModBus ventilátor",
                     "799": "ModBus ASB",
                     "800": "Chyba desuperheateru",
-                    "802": "Ventil\u00e1tor rozvad\u011b\u010de",
-                    "803": "Ventil\u00e1tor rozvad\u011b\u010de",
+                    "802": "Ventilátor rozvaděče",
+                    "803": "Ventilátor rozvaděče",
                     "806": "ModBus SEC",
-                    "807": "Ztr\u00e1ta spojen\u00ed ModBus",
-                    "minus_1": "Nezn\u00e1m\u00e1 chyba"
+                    "807": "Ztráta spojení ModBus",
+                    "minus_1": "Neznámá chyba"
                 },
                 "state_attributes": {
                     "timestamp": {
-                        "name": "\u010cas"
+                        "name": "Čas"
                     },
                     "cause": {
-                        "name": "P\u0159\u00ed\u010dina",
+                        "name": "Příčina",
                         "state": {
-                            "701": "N\u00edzkotlakov\u00fd p\u0159ep\u00edna\u010d v chladic\u00edm okruhu reagoval v\u00edcekr\u00e1t (LW) nebo d\u00e9le ne\u017e 20 sekund (SW).",
-                            "702": "Pouze u L/W za\u0159\u00edzen\u00ed mo\u017en\u00e9: N\u00edzk\u00fd tlak v chladic\u00edm okruhu reagoval. Po ur\u010dit\u00e9 dob\u011b automatick\u00fd restart tepeln\u00e9ho \u010derpadla.",
-                            "703": "Pouze u L/W za\u0159\u00edzen\u00ed mo\u017en\u00e9: Pokud tepeln\u00e9 \u010derpadlo b\u011b\u017e\u00ed a teplota v p\u0159edstihu je men\u0161\u00ed ne\u017e 5 \u00b0C, rozpozn\u00e1no jako ochrana proti mrazu.",
-                            "704": "P\u0159ekro\u010dena maxim\u00e1ln\u00ed teplota v hork\u00e9m plynov\u00e9m okruhu. Automatick\u00fd restart tepeln\u00e9ho \u010derpadla za hh:mm.",
-                            "705": "Pouze u L/W za\u0159\u00edzen\u00ed mo\u017en\u00e9: Spu\u0161t\u011bn ochrann\u00fd ventil\u00e1toru motoru.",
-                            "706": "Pouze u S/W a W/W za\u0159\u00edzen\u00ed mo\u017en\u00e9: Spu\u0161t\u011bna ochrana \u010derpadla solanky nebo studen\u00e9 vody nebo kompresoru.",
-                            "707": "P\u0159eru\u0161en\u00ed nebo zkrat v k\u00f3dovac\u00edm mostu v tepeln\u00e9m \u010derpadle po prvn\u00edm spu\u0161t\u011bn\u00ed.",
-                            "708": "P\u0159eru\u0161en\u00ed nebo zkrat v sn\u00edma\u010di zp\u00e1te\u010dky.",
-                            "709": "P\u0159eru\u0161en\u00ed nebo zkrat v sn\u00edma\u010di p\u0159edeh\u0159\u00e1t\u00ed.\n\u017d\u00e1dn\u00e9 vypnut\u00ed poruchy u S/W a W/W za\u0159\u00edzen\u00ed.",
-                            "710": "P\u0159eru\u0161en\u00ed nebo zkrat v sn\u00edma\u010di hork\u00e9ho plynu v chladic\u00edm okruhu.",
-                            "711": "P\u0159eru\u0161en\u00ed nebo zkrat v sn\u00edma\u010di venkovn\u00ed teploty.\n\u017d\u00e1dn\u00e9 vypnut\u00ed poruchy. Konstantn\u00ed hodnota na -5 \u00b0C.",
-                            "712": "P\u0159eru\u0161en\u00ed nebo zkrat v sn\u00edma\u010di tepl\u00e9 vody.\n\u017d\u00e1dn\u00e9 vypnut\u00ed poruchy.",
-                            "713": "P\u0159eru\u0161en\u00ed nebo zkrat v sn\u00edma\u010di tepl\u00e9ho zdroje (Vstup).",
-                            "714": "Tepeln\u00e1 hranice pou\u017eit\u00ed tepeln\u00e9ho \u010derpadla p\u0159ekro\u010dena.\nP\u0159\u00edprava tepl\u00e9 vody je uzam\u010dena po hh:mm.",
-                            "715": "Vysokotlakov\u00fd p\u0159ep\u00edna\u010d v chladic\u00edm okruhu reagoval. Po ur\u010dit\u00e9 dob\u011b automatick\u00fd restart tepeln\u00e9ho \u010derpadla.",
-                            "716": "Vysokotlakov\u00fd p\u0159ep\u00edna\u010d v chladic\u00edm okruhu reagoval opakovan\u011b.",
-                            "717": "Pr\u016ftokov\u00fd sp\u00edna\u010d u W/W za\u0159\u00edzen\u00ed reagoval b\u011bhem p\u0159edplachovac\u00ed doby nebo provozu.",
-                            "718": "Pouze u L/W za\u0159\u00edzen\u00ed mo\u017en\u00e9: Venkovn\u00ed teplota p\u0159ekro\u010dila povolenou maxim\u00e1ln\u00ed hodnotu.",
-                            "719": "Pouze u L/W za\u0159\u00edzen\u00ed mo\u017en\u00e9: Venkovn\u00ed teplota klesla pod povolenou minim\u00e1ln\u00ed hodnotu.",
-                            "720": "Pouze u S/W a W/W za\u0159\u00edzen\u00ed mo\u017en\u00e9: Teplota na v\u00fdstupu z parn\u00edku n\u011bkolikr\u00e1t klesla pod bezpe\u010dnostn\u00ed hodnotu. Automatick\u00fd restart tepeln\u00e9ho \u010derpadla po hh:mm.",
-                            "721": "N\u00edzkotlakov\u00fd p\u0159ep\u00edna\u010d v chladic\u00edm okruhu reagoval. Po ur\u010dit\u00e9 dob\u011b automatick\u00fd restart tepeln\u00e9ho \u010derpadla (SW a WW).",
-                            "722": "Teplotn\u00ed diference p\u0159i topn\u00e9 \u010dinnosti je negativn\u00ed (=chybn\u00e9).",
-                            "723": "Teplotn\u00ed diference p\u0159i oh\u0159evu tepl\u00e9 vody je negativn\u00ed (=chybn\u00e9).",
-                            "724": "Teplotn\u00ed diference v topn\u00e9 smy\u010dce b\u011bhem odmrazov\u00e1n\u00ed > 15 K (nebezpe\u010d\u00ed mrazu).",
-                            "725": "Porucha oh\u0159evu tepl\u00e9 vody, po\u017eadovan\u00e1 teplota z\u00e1sobn\u00edku je podstatn\u011b ni\u017e\u0161\u00ed.",
-                            "726": "P\u0159eru\u0161en\u00ed nebo zkrat v sn\u00edma\u010di sm\u011b\u0161ovac\u00ed smy\u010dky 1.",
-                            "727": "N\u00edzkotlakov\u00fd p\u0159ep\u00edna\u010d solanky reagoval b\u011bhem p\u0159edplachovac\u00ed doby nebo provozu.",
-                            "728": "P\u0159eru\u0161en\u00ed nebo zkrat v sn\u00edma\u010di vypnut\u00ed tepl\u00e9ho zdroje.",
-                            "729": "Kompresor bez v\u00fdkonu po zapnut\u00ed.",
-                            "730": "Program vyh\u0159\u00edv\u00e1n\u00ed nedok\u00e1zal dos\u00e1hnout teplotn\u00ed \u00farovn\u011b VZ v dan\u00e9m \u010dasov\u00e9m intervalu. Program vyh\u0159\u00edv\u00e1n\u00ed pokra\u010duje.",
-                            "732": "Topn\u00e1 voda byla n\u011bkolikr\u00e1t pod 16 \u00b0C.",
-                            "733": "Vstupn\u00ed sign\u00e1l z\u00e1mku ciz\u00edho proudu reagoval.",
-                            "734": "Chyba 733 trv\u00e1 d\u00e9le ne\u017e dva t\u00fddny a oh\u0159ev tepl\u00e9 vody je uzam\u010den.",
-                            "735": "Pouze s vestav\u011bnou deskou Comfort-/roz\u0161\u00ed\u0159en\u00edm mo\u017en\u00e9: P\u0159eru\u0161en\u00ed nebo zkrat ve sn\u00edma\u010di extern\u00edho zdroje energie.",
-                            "736": "Pouze s vestav\u011bnou deskou Comfort-/roz\u0161\u00ed\u0159en\u00edm mo\u017en\u00e9: P\u0159eru\u0161en\u00ed nebo zkrat ve sn\u00edma\u010di sol\u00e1rn\u00edho kolektoru.",
-                            "737": "Pouze s vestav\u011bnou deskou Comfort-/roz\u0161\u00ed\u0159en\u00edm mo\u017en\u00e9: P\u0159eru\u0161en\u00ed nebo zkrat ve sn\u00edma\u010di sol\u00e1rn\u00ed n\u00e1dr\u017ee.",
-                            "738": "Pouze s vestav\u011bnou deskou Comfort-/roz\u0161\u00ed\u0159en\u00edm mo\u017en\u00e9: P\u0159eru\u0161en\u00ed nebo zkrat ve sn\u00edma\u010di sm\u011b\u0161ovac\u00ed smy\u010dky 2.",
-                            "750": "P\u0159eru\u0161en\u00ed nebo zkrat ve sn\u00edma\u010di extern\u00edho zp\u00e1te\u010dky.",
-                            "751": "F\u00e1zov\u00e9 rel\u00e9 reagovalo.",
-                            "752": "F\u00e1zov\u00e9 rel\u00e9 nebo pr\u016ftokov\u00fd sp\u00edna\u010d reagoval.",
-                            "755": "Slave neodpov\u00edd\u00e1 d\u00e9le ne\u017e 5 minut.",
-                            "756": "Master neodpov\u00edd\u00e1 d\u00e9le ne\u017e 5 minut.",
-                            "757": "N\u00edzkotlakov\u00fd p\u0159ep\u00edna\u010d u za\u0159\u00edzen\u00ed s oh\u0159evem vody reagoval v\u00edcekr\u00e1t nebo d\u00e9le ne\u017e 20 sekund.",
-                            "758": "Odmrazov\u00e1n\u00ed bylo 5kr\u00e1t v \u0159ad\u011b ukon\u010deno kv\u016fli p\u0159\u00edli\u0161 n\u00edzk\u00e9 teplot\u011b p\u0159edstihu.",
-                            "759": "Term\u00e1ln\u00ed dezinfekce nemohla b\u00fdt provedena spr\u00e1vn\u011b 3kr\u00e1t v \u0159ad\u011b.",
-                            "760": "Odmrazov\u00e1n\u00ed bylo 5kr\u00e1t v \u0159ad\u011b ukon\u010deno po maxim\u00e1ln\u00ed dob\u011b (siln\u00fd v\u00edtr narazil na v\u00fdparn\u00edk).",
+                            "701": "Nízkotlakový přepínač v chladicím okruhu reagoval vícekrát (LW) nebo déle než 20 sekund (SW).",
+                            "702": "Pouze u L/W zařízení možné: Nízký tlak v chladicím okruhu reagoval. Po určité době automatický restart tepelného čerpadla.",
+                            "703": "Pouze u L/W zařízení možné: Pokud tepelné čerpadlo běží a teplota v předstihu je menší než 5 °C, rozpoznáno jako ochrana proti mrazu.",
+                            "704": "Překročena maximální teplota v horkém plynovém okruhu. Automatický restart tepelného čerpadla za hh:mm.",
+                            "705": "Pouze u L/W zařízení možné: Spuštěn ochranný ventilátoru motoru.",
+                            "706": "Pouze u S/W a W/W zařízení možné: Spuštěna ochrana čerpadla solanky nebo studené vody nebo kompresoru.",
+                            "707": "Přerušení nebo zkrat v kódovacím mostu v tepelném čerpadle po prvním spuštění.",
+                            "708": "Přerušení nebo zkrat v snímači zpátečky.",
+                            "709": "Přerušení nebo zkrat v snímači předehřátí.\nŽádné vypnutí poruchy u S/W a W/W zařízení.",
+                            "710": "Přerušení nebo zkrat v snímači horkého plynu v chladicím okruhu.",
+                            "711": "Přerušení nebo zkrat v snímači venkovní teploty.\nŽádné vypnutí poruchy. Konstantní hodnota na -5 °C.",
+                            "712": "Přerušení nebo zkrat v snímači teplé vody.\nŽádné vypnutí poruchy.",
+                            "713": "Přerušení nebo zkrat v snímači teplého zdroje (Vstup).",
+                            "714": "Tepelná hranice použití tepelného čerpadla překročena.\nPříprava teplé vody je uzamčena po hh:mm.",
+                            "715": "Vysokotlakový přepínač v chladicím okruhu reagoval. Po určité době automatický restart tepelného čerpadla.",
+                            "716": "Vysokotlakový přepínač v chladicím okruhu reagoval opakovaně.",
+                            "717": "Průtokový spínač u W/W zařízení reagoval během předplachovací doby nebo provozu.",
+                            "718": "Pouze u L/W zařízení možné: Venkovní teplota překročila povolenou maximální hodnotu.",
+                            "719": "Pouze u L/W zařízení možné: Venkovní teplota klesla pod povolenou minimální hodnotu.",
+                            "720": "Pouze u S/W a W/W zařízení možné: Teplota na výstupu z parníku několikrát klesla pod bezpečnostní hodnotu. Automatický restart tepelného čerpadla po hh:mm.",
+                            "721": "Nízkotlakový přepínač v chladicím okruhu reagoval. Po určité době automatický restart tepelného čerpadla (SW a WW).",
+                            "722": "Teplotní diference při topné činnosti je negativní (=chybné).",
+                            "723": "Teplotní diference při ohřevu teplé vody je negativní (=chybné).",
+                            "724": "Teplotní diference v topné smyčce během odmrazování > 15 K (nebezpečí mrazu).",
+                            "725": "Porucha ohřevu teplé vody, požadovaná teplota zásobníku je podstatně nižší.",
+                            "726": "Přerušení nebo zkrat v snímači směšovací smyčky 1.",
+                            "727": "Nízkotlakový přepínač solanky reagoval během předplachovací doby nebo provozu.",
+                            "728": "Přerušení nebo zkrat v snímači vypnutí teplého zdroje.",
+                            "729": "Kompresor bez výkonu po zapnutí.",
+                            "730": "Program vyhřívání nedokázal dosáhnout teplotní úrovně VZ v daném časovém intervalu. Program vyhřívání pokračuje.",
+                            "732": "Topná voda byla několikrát pod 16 °C.",
+                            "733": "Vstupní signál zámku cizího proudu reagoval.",
+                            "734": "Chyba 733 trvá déle než dva týdny a ohřev teplé vody je uzamčen.",
+                            "735": "Pouze s vestavěnou deskou Comfort-/rozšířením možné: Přerušení nebo zkrat ve snímači externího zdroje energie.",
+                            "736": "Pouze s vestavěnou deskou Comfort-/rozšířením možné: Přerušení nebo zkrat ve snímači solárního kolektoru.",
+                            "737": "Pouze s vestavěnou deskou Comfort-/rozšířením možné: Přerušení nebo zkrat ve snímači solární nádrže.",
+                            "738": "Pouze s vestavěnou deskou Comfort-/rozšířením možné: Přerušení nebo zkrat ve snímači směšovací smyčky 2.",
+                            "750": "Přerušení nebo zkrat ve snímači externího zpátečky.",
+                            "751": "Fázové relé reagovalo.",
+                            "752": "Fázové relé nebo průtokový spínač reagoval.",
+                            "755": "Slave neodpovídá déle než 5 minut.",
+                            "756": "Master neodpovídá déle než 5 minut.",
+                            "757": "Nízkotlakový přepínač u zařízení s ohřevem vody reagoval vícekrát nebo déle než 20 sekund.",
+                            "758": "Odmrazování bylo 5krát v řadě ukončeno kvůli příliš nízké teplotě předstihu.",
+                            "759": "Termální dezinfekce nemohla být provedena správně 3krát v řadě.",
+                            "760": "Odmrazování bylo 5krát v řadě ukončeno po maximální době (silný vítr narazil na výparník).",
                             "761": "LIN-Time out",
-                            "762": "Chyba sn\u00edma\u010de sac\u00edho kompresoru.",
-                            "763": "Chyba sn\u00edma\u010de sac\u00edho v\u00fdparn\u00edku.",
-                            "764": "Chyba sn\u00edma\u010de oh\u0159evu kompresoru.",
-                            "765": "P\u0159eh\u0159\u00e1t\u00ed trvaj\u00edc\u00ed d\u00e9le ne\u017e 5 minut pod 2K.",
-                            "766": "Provoz 5 minut mimo rozsah pou\u017eit\u00ed kompresoru.",
-                            "767": "STB oh\u0159\u00edva\u010de na SEC bylo aktivov\u00e1no.",
-                            "770": "P\u0159eh\u0159\u00e1t\u00ed trvaj\u00edc\u00ed d\u00e9le ne\u017e dlouhou dobu pod mezn\u00ed hodnotou.",
-                            "771": "P\u0159eh\u0159\u00e1t\u00ed trvaj\u00edc\u00ed d\u00e9le ne\u017e dlouhou dobu nad mezn\u00ed hodnotou.",
-                            "776": "Kompresor pracuje d\u00e9le ne\u017e dlouhou dobu mimo sv\u00e9 meze pou\u017eit\u00ed.",
-                            "777": "Expanzn\u00ed ventil je vadn\u00fd.",
-                            "778": "Sn\u00edma\u010d n\u00edzk\u00e9ho tlaku je vadn\u00fd.",
-                            "779": "Sn\u00edma\u010d vysok\u00e9ho tlaku je vadn\u00fd.",
-                            "780": "Sn\u00edma\u010d EVI je vadn\u00fd.",
-                            "781": "Sn\u00edma\u010d kapaliny p\u0159ed expanzn\u00edm ventilem je vadn\u00fd.",
-                            "782": "Sn\u00edma\u010d EVI (Enhanced Vapour Injection) sac\u00edho plynu je vadn\u00fd.",
-                            "783": "Komunikace mezi SEC a Inverterem je naru\u0161ena.",
-                            "784": "Inverter je uzam\u010den.",
+                            "762": "Chyba snímače sacího kompresoru.",
+                            "763": "Chyba snímače sacího výparníku.",
+                            "764": "Chyba snímače ohřevu kompresoru.",
+                            "765": "Přehřátí trvající déle než 5 minut pod 2K.",
+                            "766": "Provoz 5 minut mimo rozsah použití kompresoru.",
+                            "767": "STB ohřívače na SEC bylo aktivováno.",
+                            "770": "Přehřátí trvající déle než dlouhou dobu pod mezní hodnotou.",
+                            "771": "Přehřátí trvající déle než dlouhou dobu nad mezní hodnotou.",
+                            "776": "Kompresor pracuje déle než dlouhou dobu mimo své meze použití.",
+                            "777": "Expanzní ventil je vadný.",
+                            "778": "Snímač nízkého tlaku je vadný.",
+                            "779": "Snímač vysokého tlaku je vadný.",
+                            "780": "Snímač EVI je vadný.",
+                            "781": "Snímač kapaliny před expanzním ventilem je vadný.",
+                            "782": "Snímač EVI (Enhanced Vapour Injection) sacího plynu je vadný.",
+                            "783": "Komunikace mezi SEC a Inverterem je narušena.",
+                            "784": "Inverter je uzamčen.",
                             "785": "Chyba na desce SEC.",
-                            "786": "Naru\u0161en\u00ed komunikace mezi SEC a HZIO od SEC.",
-                            "787": "Kompresor hl\u00e1s\u00ed chybu.",
+                            "786": "Narušení komunikace mezi SEC a HZIO od SEC.",
+                            "787": "Kompresor hlásí chybu.",
                             "788": "Chyba v Inverteru.",
-                            "789": "Ovl\u00e1dac\u00ed panel nemohl detekovat \u017e\u00e1dn\u00e9 k\u00f3dov\u00e1n\u00ed. Bu\u010f je p\u0159eru\u0161eno LIN spojen\u00ed, nebo odpor k\u00f3dov\u00e1n\u00ed nen\u00ed rozpozn\u00e1n.",
-                            "790": "Chyba ve zdroji nap\u00e1jen\u00ed Inverteru / Kompresoru.",
-                            "791": "Deska SEC nen\u00ed del\u0161\u00ed dobu dostupn\u00e1. 791 se spust\u00ed, pokud byla nalezena deska HZIO (bez samostatn\u00e9ho k\u00f3dov\u00e1n\u00ed), ale nen\u00ed na n\u00ed rozpozn\u00e1na \u017e\u00e1dn\u00e1 deska SEC.",
-                            "792": "Nelze naj\u00edt \u017e\u00e1dn\u00fd z\u00e1kladn\u00ed panel a \u017e\u00e1dn\u00e1 konfigurace.",
+                            "789": "Ovládací panel nemohl detekovat žádné kódování. Buď je přerušeno LIN spojení, nebo odpor kódování není rozpoznán.",
+                            "790": "Chyba ve zdroji napájení Inverteru / Kompresoru.",
+                            "791": "Deska SEC není delší dobu dostupná. 791 se spustí, pokud byla nalezena deska HZIO (bez samostatného kódování), ale není na ní rozpoznána žádná deska SEC.",
+                            "792": "Nelze najít žádný základní panel a žádná konfigurace.",
                             "793": "Chyba teploty v Inverteru.",
-                            "minus_1": "Nezn\u00e1m\u00e1 chyba",
-                            "731": "Teplota pot\u0159ebn\u00e1 pro term\u00e1ln\u00ed dezinfekci nebyla dosa\u017eena v nastaven\u00e9m \u010dasov\u00e9m intervalu.",
-                            "739": "Pouze p\u0159i instalovan\u00e9 roz\u0161i\u0159uj\u00edc\u00ed desce: p\u0159eru\u0161en\u00ed nebo zkrat \u010didla \u201esm\u011b\u0161ovac\u00ed okruh 3\u201c.",
-                            "794": "P\u0159ep\u011bt\u00ed na invertoru.",
-                            "795": "Podp\u011bt\u00ed na invertoru.",
-                            "796": "Byl aktivov\u00e1n bezpe\u010dnostn\u00ed vstup. P\u0159\u00edpad 1: porucha invertoru. Automatick\u00fd reset. P\u0159\u00edpad 2: aktivovaly se presostaty vysok\u00e9ho tlaku v chladic\u00edm okruhu. Automatick\u00fd reset. P\u0159\u00edpad 3: pouze hl\u00e1\u0161en\u00ed poruchy LWDV zp\u016fsoben\u00e9 kol\u00eds\u00e1n\u00edm nap\u011bt\u00ed mimo platnou normu.",
-                            "797": "Regulace topn\u00e9 ty\u010de nen\u00ed podporov\u00e1na.",
-                            "798": "Nejm\u00e9n\u011b 10 sekund \u017e\u00e1dn\u00e1 komunikace ModBus s ventil\u00e1torem. Automatick\u00fd reset.",
-                            "799": "Nejm\u00e9n\u011b 10 sekund \u017e\u00e1dn\u00e1 komunikace ModBus s deskou ASB. Automatick\u00fd reset.",
-                            "800": "Vypnut\u00ed je aktivov\u00e1no, kdy\u017e teplota desuperheateru dos\u00e1hne \u2265 80 \u00b0C. Za\u0159\u00edzen\u00ed se vypne a do historie vypnut\u00ed se zap\u00ed\u0161e D0_Pause. Za\u0159\u00edzen\u00ed je op\u011bt uvoln\u011bno pro provoz po 2 hodin\u00e1ch. Pokud k vypnut\u00ed dojde 5kr\u00e1t b\u011bhem 24 hodin, zap\u00ed\u0161e se chyba 800 do pam\u011bti poruch.",
-                            "802": "Vypnut\u00ed je aktivov\u00e1no, kdy\u017e teplota v elektrick\u00e9m rozvad\u011b\u010di dos\u00e1hne \u2265 80 \u00b0C. Pokud teplota klesne pod 70 \u00b0C, tepeln\u00e9 \u010derpadlo se znovu spust\u00ed. Automatick\u00fd reset.",
-                            "803": "Chyba 802 se aktivovala 3kr\u00e1t b\u011bhem 24 hodin. Je nutn\u00fd ru\u010dn\u00ed reset. Pokud je teplota v elektrick\u00e9m rozvad\u011b\u010di st\u00e1le \u2265 80 \u00b0C, chyba se okam\u017eit\u011b aktivuje znovu.",
-                            "806": "Deska SEC nem\u00e1 nejm\u00e9n\u011b 10 sekund \u017e\u00e1dnou komunikaci ModBus nebo dotaz selhal 10kr\u00e1t za sebou. Automatick\u00fd reset.",
-                            "807": "V\u0161echny mo\u017en\u00e9 poruchy komunikace ModBus s komponentami za\u0159\u00edzen\u00ed jsou p\u0159\u00edtomny sou\u010dasn\u011b po dobu nejm\u00e9n\u011b 10 sekund. Automatick\u00fd reset.",
-                            "768": "5kr\u00e1t za sebou nedostate\u010dn\u00fd pr\u016ftok p\u0159ed odt\u00e1v\u00e1n\u00edm.",
-                            "769": "Chyb\u00ed platn\u00fd sign\u00e1l pr\u016ftoku od ob\u011bhov\u00e9ho \u010derpadla. Automatick\u00fd reset."
+                            "minus_1": "Neznámá chyba",
+                            "731": "Teplota potřebná pro termální dezinfekci nebyla dosažena v nastaveném časovém intervalu.",
+                            "739": "Pouze při instalované rozšiřující desce: přerušení nebo zkrat čidla „směšovací okruh 3“.",
+                            "794": "Přepětí na invertoru.",
+                            "795": "Podpětí na invertoru.",
+                            "796": "Byl aktivován bezpečnostní vstup. Případ 1: porucha invertoru. Automatický reset. Případ 2: aktivovaly se presostaty vysokého tlaku v chladicím okruhu. Automatický reset. Případ 3: pouze hlášení poruchy LWDV způsobené kolísáním napětí mimo platnou normu.",
+                            "797": "Regulace topné tyče není podporována.",
+                            "798": "Nejméně 10 sekund žádná komunikace ModBus s ventilátorem. Automatický reset.",
+                            "799": "Nejméně 10 sekund žádná komunikace ModBus s deskou ASB. Automatický reset.",
+                            "800": "Vypnutí je aktivováno, když teplota desuperheateru dosáhne ≥ 80 °C. Zařízení se vypne a do historie vypnutí se zapíše D0_Pause. Zařízení je opět uvolněno pro provoz po 2 hodinách. Pokud k vypnutí dojde 5krát během 24 hodin, zapíše se chyba 800 do paměti poruch.",
+                            "802": "Vypnutí je aktivováno, když teplota v elektrickém rozvaděči dosáhne ≥ 80 °C. Pokud teplota klesne pod 70 °C, tepelné čerpadlo se znovu spustí. Automatický reset.",
+                            "803": "Chyba 802 se aktivovala 3krát během 24 hodin. Je nutný ruční reset. Pokud je teplota v elektrickém rozvaděči stále ≥ 80 °C, chyba se okamžitě aktivuje znovu.",
+                            "806": "Deska SEC nemá nejméně 10 sekund žádnou komunikaci ModBus nebo dotaz selhal 10krát za sebou. Automatický reset.",
+                            "807": "Všechny možné poruchy komunikace ModBus s komponentami zařízení jsou přítomny současně po dobu nejméně 10 sekund. Automatický reset.",
+                            "768": "5krát za sebou nedostatečný průtok před odtáváním.",
+                            "769": "Chybí platný signál průtoku od oběhového čerpadla. Automatický reset."
                         }
                     },
                     "remedy": {
                         "name": "Oprava",
                         "state": {
-                            "701": "Kontrola tepeln\u00e9ho \u010derpadla na \u00fanik, sp\u00edna\u010de tlaku, odmrazov\u00e1n\u00ed a minim\u00e1ln\u00ed teplotu vzduchu.",
-                            "702": "Kontrola tepeln\u00e9ho \u010derpadla na \u00fanik, sp\u00edna\u010de tlaku, odmrazov\u00e1n\u00ed a minim\u00e1ln\u00ed teplotu vzduchu.",
-                            "703": "Kontrola v\u00fdkonu tepeln\u00e9ho \u010derpadla, odmrazovac\u00edho ventilu a topn\u00e9ho syst\u00e9mu.",
-                            "704": "Kontrola mno\u017estv\u00ed chladiva, v\u00fdparu, p\u0159eh\u0159\u00e1t\u00ed p\u0159edeh\u0159\u00e1t\u00e9ho, n\u00e1vratov\u00e9ho proudu a minim\u00e1ln\u00ed teploty vody.",
-                            "705": "Kontrola ventil\u00e1toru.",
-                            "706": "Kontrola nastaven\u00fdch hodnot, kompresoru, BOSUP.",
-                            "707": "Kontrola odporu k\u00f3dov\u00e1n\u00ed v tepeln\u00e9m \u010derpadle, konektoru a p\u0159ipojovac\u00edm veden\u00ed.",
-                            "708": "Kontrola zp\u011btn\u00e9ho chladi\u010de, konektoru a p\u0159ipojovac\u00edm veden\u00ed.",
-                            "709": "Kontrola p\u0159edeh\u0159\u00edva\u010de, konektoru a p\u0159ipojovac\u00edm veden\u00ed.",
-                            "710": "Kontrola \u010didla hork\u00e9ho plynu, konektoru a p\u0159ipojovac\u00edm veden\u00ed.",
-                            "711": "Kontrola \u010didla venkovn\u00ed teploty, konektoru a p\u0159ipojovac\u00edm veden\u00ed.",
-                            "712": "Kontrola \u010didla tepl\u00e9 vody, konektoru a p\u0159ipojovac\u00edm veden\u00ed.",
-                            "713": "Kontrola \u010didla zdroje tepla, konektoru a p\u0159ipojovac\u00edm veden\u00ed.",
-                            "714": "Kontrola pr\u016ftoku tepl\u00e9 vody, v\u00fdm\u011bn\u00edku tepla, teploty tepl\u00e9 vody a ob\u011bhov\u00e9ho \u010derpadla tepl\u00e9 vody.",
-                            "715": "Kontrola pr\u016ftoku tepl\u00e9 vody, odtokov\u00e9ho potrub\u00ed, teploty a kondenzace.",
-                            "716": "Kontrola pr\u016ftoku tepl\u00e9 vody, odtokov\u00e9ho potrub\u00ed, teploty a kondenzace.",
-                            "717": "Kontrola pr\u016ftoku, sp\u00edna\u010de bodu rosy, filtru, voln\u00e9ho vzduchu.",
-                            "718": "Kontrola venkovn\u00ed teploty a nastaven\u00e9 hodnoty.",
-                            "719": "Kontrola venkovn\u00ed teploty a nastaven\u00e9 hodnoty.",
-                            "720": "Kontrola pr\u016ftoku, filtru, voln\u00e9ho vzduchu, teploty.",
-                            "721": "Kontrola sp\u00edna\u010de tlaku, pr\u016ftoku strany WQ.",
-                            "722": "Kontrola funkce a um\u00edst\u011bn\u00ed \u010didel p\u0159ed a za odb\u011brem.",
-                            "723": "Kontrola funkce a um\u00edst\u011bn\u00ed \u010didel p\u0159ed a za odb\u011brem.",
-                            "724": "Kontrola funkce a um\u00edst\u011bn\u00ed \u010didel p\u0159ed a za odb\u011brem, v\u00fdkonu HUP, p\u0159epadu a topn\u00fdch okruh\u016f.",
-                            "725": "Kontrola ob\u011bhov\u00e9ho \u010derpadla tepl\u00e9 vody, pln\u011bn\u00ed z\u00e1sobn\u00edku, uz\u00e1v\u011brky a trojcestn\u00e9ho ventilu. Odvzdu\u0161n\u011bn\u00ed topn\u00e9 vody a tepl\u00e9 vody.",
-                            "726": "Kontrola \u010didla m\u00edchac\u00edho okruhu, konektoru a p\u0159ipojovac\u00edm veden\u00ed.",
-                            "727": "Kontrola tlaku sol\u00e1rn\u00edho kolektoru a tlakov\u00e9ho sp\u00edna\u010de sol\u00e1rn\u00edho kolektoru.",
-                            "728": "Kontrola \u010didla zdroje tepla, konektoru a p\u0159ipojovac\u00edm veden\u00ed.",
-                            "729": "Kontrola ot\u00e1\u010dek a kompresoru.",
-                            "730": "Kontrola spot\u0159eby v\u00fdkonu b\u011bhem oh\u0159evu.",
-                            "732": "Kontrola sm\u011b\u0161ova\u010de a ob\u011bhov\u00e9ho \u010derpadla pro vyt\u00e1p\u011bn\u00ed.",
-                            "733": "Kontrola p\u0159ipojovac\u00edho veden\u00ed anody a potenciostatu. Napln\u011bn\u00ed z\u00e1sobn\u00edku tepl\u00e9 vody.",
-                            "734": "Do\u010dasn\u00e9 potvrzen\u00ed chyby pro obnoven\u00ed p\u0159\u00edpravy tepl\u00e9 vody. Opravte chybu 733.",
-                            "735": "Kontrola \u010didla extern\u00edho zdroje energie, konektoru a p\u0159ipojovac\u00edho veden\u00ed.",
-                            "736": "Kontrola \u010didla sol\u00e1rn\u00edho kolektoru, konektoru a p\u0159ipojovac\u00edho veden\u00ed.",
-                            "737": "Kontrola \u010didla sol\u00e1rn\u00edho z\u00e1sobn\u00edku, konektoru a p\u0159ipojovac\u00edho veden\u00ed.",
-                            "738": "Kontrola \u010didla sm\u011b\u0161ovac\u00edho okruhu 2, konektoru a p\u0159ipojovac\u00edho veden\u00ed.",
-                            "750": "Kontrola extern\u00edho zp\u011btn\u00e9ho chladi\u010de, konektoru a p\u0159ipojovac\u00edho veden\u00ed.",
-                            "751": "Kontrola ot\u00e1\u010dek a rel\u00e9 po\u0159ad\u00ed f\u00e1z\u00ed.",
-                            "752": "Viz chyby \u010d. 751 a \u010d. 717.",
-                            "755": "Kontrola s\u00ed\u0165ov\u00e9ho p\u0159ipojen\u00ed, p\u0159ep\u00edna\u010de a IP adres. P\u0159\u00edpadn\u011b znovu spus\u0165te hled\u00e1n\u00ed tepeln\u00e9ho \u010derpadla.",
-                            "756": "Kontrola s\u00ed\u0165ov\u00e9ho p\u0159ipojen\u00ed, p\u0159ep\u00edna\u010de a IP adres. P\u0159\u00edpadn\u011b znovu spus\u0165te hled\u00e1n\u00ed tepeln\u00e9ho \u010derpadla.",
-                            "757": "P\u0159i t\u0159ikr\u00e1t opakovan\u00e9m v\u00fdskytu t\u00e9to poruchy m\u016f\u017ee b\u00fdt za\u0159\u00edzen\u00ed odem\u010deno pouze autorizovan\u00fdm servisn\u00edm person\u00e1lem!",
-                            "758": "Kontrola pr\u016ftoku a \u010didla p\u0159edeh\u0159\u00e1t\u00e9ho.",
-                            "759": "Kontrola nastaven\u00ed druh\u00e9ho zdroje tepla a bezpe\u010dnostn\u00edho teplotn\u00edho omezova\u010de.",
-                            "760": "Ochrana ventil\u00e1toru a v\u00fdparn\u00edku p\u0159ed siln\u00fdm v\u011btrem.",
+                            "701": "Kontrola tepelného čerpadla na únik, spínače tlaku, odmrazování a minimální teplotu vzduchu.",
+                            "702": "Kontrola tepelného čerpadla na únik, spínače tlaku, odmrazování a minimální teplotu vzduchu.",
+                            "703": "Kontrola výkonu tepelného čerpadla, odmrazovacího ventilu a topného systému.",
+                            "704": "Kontrola množství chladiva, výparu, přehřátí předehřátého, návratového proudu a minimální teploty vody.",
+                            "705": "Kontrola ventilátoru.",
+                            "706": "Kontrola nastavených hodnot, kompresoru, BOSUP.",
+                            "707": "Kontrola odporu kódování v tepelném čerpadle, konektoru a připojovacím vedení.",
+                            "708": "Kontrola zpětného chladiče, konektoru a připojovacím vedení.",
+                            "709": "Kontrola předehřívače, konektoru a připojovacím vedení.",
+                            "710": "Kontrola čidla horkého plynu, konektoru a připojovacím vedení.",
+                            "711": "Kontrola čidla venkovní teploty, konektoru a připojovacím vedení.",
+                            "712": "Kontrola čidla teplé vody, konektoru a připojovacím vedení.",
+                            "713": "Kontrola čidla zdroje tepla, konektoru a připojovacím vedení.",
+                            "714": "Kontrola průtoku teplé vody, výměníku tepla, teploty teplé vody a oběhového čerpadla teplé vody.",
+                            "715": "Kontrola průtoku teplé vody, odtokového potrubí, teploty a kondenzace.",
+                            "716": "Kontrola průtoku teplé vody, odtokového potrubí, teploty a kondenzace.",
+                            "717": "Kontrola průtoku, spínače bodu rosy, filtru, volného vzduchu.",
+                            "718": "Kontrola venkovní teploty a nastavené hodnoty.",
+                            "719": "Kontrola venkovní teploty a nastavené hodnoty.",
+                            "720": "Kontrola průtoku, filtru, volného vzduchu, teploty.",
+                            "721": "Kontrola spínače tlaku, průtoku strany WQ.",
+                            "722": "Kontrola funkce a umístění čidel před a za odběrem.",
+                            "723": "Kontrola funkce a umístění čidel před a za odběrem.",
+                            "724": "Kontrola funkce a umístění čidel před a za odběrem, výkonu HUP, přepadu a topných okruhů.",
+                            "725": "Kontrola oběhového čerpadla teplé vody, plnění zásobníku, uzávěrky a trojcestného ventilu. Odvzdušnění topné vody a teplé vody.",
+                            "726": "Kontrola čidla míchacího okruhu, konektoru a připojovacím vedení.",
+                            "727": "Kontrola tlaku solárního kolektoru a tlakového spínače solárního kolektoru.",
+                            "728": "Kontrola čidla zdroje tepla, konektoru a připojovacím vedení.",
+                            "729": "Kontrola otáček a kompresoru.",
+                            "730": "Kontrola spotřeby výkonu během ohřevu.",
+                            "732": "Kontrola směšovače a oběhového čerpadla pro vytápění.",
+                            "733": "Kontrola připojovacího vedení anody a potenciostatu. Naplnění zásobníku teplé vody.",
+                            "734": "Dočasné potvrzení chyby pro obnovení přípravy teplé vody. Opravte chybu 733.",
+                            "735": "Kontrola čidla externího zdroje energie, konektoru a připojovacího vedení.",
+                            "736": "Kontrola čidla solárního kolektoru, konektoru a připojovacího vedení.",
+                            "737": "Kontrola čidla solárního zásobníku, konektoru a připojovacího vedení.",
+                            "738": "Kontrola čidla směšovacího okruhu 2, konektoru a připojovacího vedení.",
+                            "750": "Kontrola externího zpětného chladiče, konektoru a připojovacího vedení.",
+                            "751": "Kontrola otáček a relé pořadí fází.",
+                            "752": "Viz chyby č. 751 a č. 717.",
+                            "755": "Kontrola síťového připojení, přepínače a IP adres. Případně znovu spusťte hledání tepelného čerpadla.",
+                            "756": "Kontrola síťového připojení, přepínače a IP adres. Případně znovu spusťte hledání tepelného čerpadla.",
+                            "757": "Při třikrát opakovaném výskytu této poruchy může být zařízení odemčeno pouze autorizovaným servisním personálem!",
+                            "758": "Kontrola průtoku a čidla předehřátého.",
+                            "759": "Kontrola nastavení druhého zdroje tepla a bezpečnostního teplotního omezovače.",
+                            "760": "Ochrana ventilátoru a výparníku před silným větrem.",
                             "761": "Kontrola kabelu/kontaktu.",
-                            "762": "Kontrola \u010didla, p\u0159\u00edpadn\u011b jeho v\u00fdm\u011bna.",
-                            "763": "Kontrola \u010didla, p\u0159\u00edpadn\u011b jeho v\u00fdm\u011bna.",
-                            "764": "Kontrola \u010didla, p\u0159\u00edpadn\u011b jeho v\u00fdm\u011bna.",
-                            "765": "P\u0159i prvn\u00edm zapnut\u00ed. Kontrola ot\u00e1\u010dek, jinak kontaktujte servis.",
-                            "766": "Kontrola ot\u00e1\u010dek.",
-                            "767": "Kontrola topn\u00e9ho t\u011blesa a znovu zasunut\u00ed pojistky.",
-                            "770": "Kontrola teplotn\u00edho \u010didla, tlakov\u00e9ho sn\u00edma\u010de a expanzn\u00edho ventilu.",
-                            "771": "Kontrola teplotn\u00edho \u010didla, tlakov\u00e9ho sn\u00edma\u010de, napln\u011bn\u00ed a expanzn\u00edho ventilu.",
+                            "762": "Kontrola čidla, případně jeho výměna.",
+                            "763": "Kontrola čidla, případně jeho výměna.",
+                            "764": "Kontrola čidla, případně jeho výměna.",
+                            "765": "Při prvním zapnutí. Kontrola otáček, jinak kontaktujte servis.",
+                            "766": "Kontrola otáček.",
+                            "767": "Kontrola topného tělesa a znovu zasunutí pojistky.",
+                            "770": "Kontrola teplotního čidla, tlakového snímače a expanzního ventilu.",
+                            "771": "Kontrola teplotního čidla, tlakového snímače, naplnění a expanzního ventilu.",
                             "776": "Kontrola termodynamiky.",
-                            "777": "Kontrola expanzn\u00edho ventilu, p\u0159ipojovac\u00edho kabelu a p\u0159\u00edpadn\u011b desky SEC.",
-                            "778": "Kontrola \u010didla, konektoru a p\u0159ipojovac\u00edho veden\u00ed.",
-                            "779": "Kontrola \u010didla, konektoru a p\u0159ipojovac\u00edho veden\u00ed.",
-                            "780": "Kontrola \u010didla, konektoru a p\u0159ipojovac\u00edho veden\u00ed.",
-                            "781": "Kontrola \u010didla, konektoru a p\u0159ipojovac\u00edho veden\u00ed.",
-                            "782": "Kontrola \u010didla, konektoru a p\u0159ipojovac\u00edho veden\u00ed.",
-                            "783": "Kontrola p\u0159ipojovac\u00edho kabelu, kondenz\u00e1tor\u016f proti ru\u0161en\u00ed a kabelov\u00e1n\u00ed.",
-                            "784": "Kompletn\u00ed odpojen\u00ed za\u0159\u00edzen\u00ed na 2 minuty od nap\u00e1jen\u00ed. P\u0159i opakovan\u00e9m v\u00fdskytu zkontrolujte invertor a kompresor.",
-                            "785": "V\u00fdm\u011bna desky SEC.",
-                            "786": "Kontrola kabelov\u00e9ho spojen\u00ed HZ/IO SEC-Board.",
-                            "787": "Potvrzen\u00ed poruchy. Pokud chyba opakovan\u011b nastane, kontaktujte autorizovan\u00fd servis (tj. z\u00e1kaznick\u00fd servis).",
+                            "777": "Kontrola expanzního ventilu, připojovacího kabelu a případně desky SEC.",
+                            "778": "Kontrola čidla, konektoru a připojovacího vedení.",
+                            "779": "Kontrola čidla, konektoru a připojovacího vedení.",
+                            "780": "Kontrola čidla, konektoru a připojovacího vedení.",
+                            "781": "Kontrola čidla, konektoru a připojovacího vedení.",
+                            "782": "Kontrola čidla, konektoru a připojovacího vedení.",
+                            "783": "Kontrola připojovacího kabelu, kondenzátorů proti rušení a kabelování.",
+                            "784": "Kompletní odpojení zařízení na 2 minuty od napájení. Při opakovaném výskytu zkontrolujte invertor a kompresor.",
+                            "785": "Výměna desky SEC.",
+                            "786": "Kontrola kabelového spojení HZ/IO SEC-Board.",
+                            "787": "Potvrzení poruchy. Pokud chyba opakovaně nastane, kontaktujte autorizovaný servis (tj. zákaznický servis).",
                             "788": "Kontrola invertoru.",
-                            "789": "Kontrola p\u0159ipojovac\u00edho kabelu LIN/kodovac\u00edho odporu.",
-                            "790": "Kontrola kabelov\u00e1n\u00ed, invertoru a kompresoru.",
-                            "791": "Pokud jde o konfiguraci SEC, zkontrolujte ModBus kabel mezi HZ/IO a deskou SEC. Stejn\u011b tak zkontrolujte DESKU SEC, zda v\u0161e blik\u00e1, jak m\u00e1. Pokud to nen\u00ed konfigurace s deskou SEC (nap\u0159\u00edklad u za\u0159\u00edzen\u00ed P184), pak zkontrolujte kodovac\u00ed odpor HZ/IO.",
-                            "792": "Kontrola k\u00f3dovac\u00edho konektoru na desce LIN.",
-                            "793": "Chyba se oprav\u00ed automaticky.",
-                            "739": "Kontrola \u010didla \u201esm\u011b\u0161ovac\u00ed okruh 3\u201c, konektoru a propojovac\u00edho veden\u00ed.",
-                            "794": "Kontrola nap\u00e1jen\u00ed invertoru.",
-                            "795": "Kontrola nap\u00e1jen\u00ed invertoru.",
-                            "796": "P\u0159\u00edpad 1: kontrola invertoru. Odstran\u011bn\u00ed poruchy. P\u0159\u00edpad 2: kontrola pr\u016ftoku topn\u00e9 vody, p\u0159epadu, \u010didla teploty na v\u00fdstupu a \u010didla vysok\u00e9ho tlaku. Odstran\u011bn\u00ed poruchy. P\u0159\u00edpad 3: nutn\u00e9 ru\u010dn\u00ed vypnut\u00ed a op\u011btovn\u00e9 zaji\u0161t\u011bn\u00ed.",
-                            "798": "Kontrola kabel\u00e1\u017ee ModBus ventil\u00e1toru.",
-                            "799": "Kontrola kabel\u00e1\u017ee ModBus desky ASB.",
-                            "800": "Odebr\u00e1n\u00ed energie ze z\u00e1sobn\u00edku desuperheateru. Jakmile teplota klesne pod 80 \u00b0C, lze za\u0159\u00edzen\u00ed znovu spustit.",
-                            "802": "Kontrola funkce ventil\u00e1toru. Kontrola p\u0159ipojovac\u00edho kabelu. Kontrola \u010didla. Kontrola otvor\u016f rozvad\u011b\u010de na ucp\u00e1n\u00ed.",
-                            "803": "Kontrola funkce ventil\u00e1toru. Kontrola p\u0159ipojovac\u00edho kabelu. Kontrola \u010didla. Kontrola otvor\u016f rozvad\u011b\u010de na ucp\u00e1n\u00ed.",
-                            "806": "Kontrola kabel\u00e1\u017ee ModBus desky SEC.",
-                            "807": "Kontrola rozhran\u00ed ModBus na ovl\u00e1dac\u00edm panelu, propojovac\u00edho kabelu k rozbo\u010dova\u010di ModBus a samotn\u00e9ho rozbo\u010dova\u010de ModBus. Kontrola kabel\u00e1\u017ee ModBus.",
-                            "768": "Kontrola pr\u016ftoku topn\u00e9 vody a p\u0159epadu. Odstran\u011bn\u00ed poruchy.",
-                            "769": "Kontrola kabel\u00e1\u017ee z\u00e1t\u011b\u017ee a \u0159\u00edzen\u00ed ob\u011bhov\u00e9ho \u010derpadla. Odstran\u011bn\u00ed poruchy."
+                            "789": "Kontrola připojovacího kabelu LIN/kodovacího odporu.",
+                            "790": "Kontrola kabelování, invertoru a kompresoru.",
+                            "791": "Pokud jde o konfiguraci SEC, zkontrolujte ModBus kabel mezi HZ/IO a deskou SEC. Stejně tak zkontrolujte DESKU SEC, zda vše bliká, jak má. Pokud to není konfigurace s deskou SEC (například u zařízení P184), pak zkontrolujte kodovací odpor HZ/IO.",
+                            "792": "Kontrola kódovacího konektoru na desce LIN.",
+                            "793": "Chyba se opraví automaticky.",
+                            "739": "Kontrola čidla „směšovací okruh 3“, konektoru a propojovacího vedení.",
+                            "794": "Kontrola napájení invertoru.",
+                            "795": "Kontrola napájení invertoru.",
+                            "796": "Případ 1: kontrola invertoru. Odstranění poruchy. Případ 2: kontrola průtoku topné vody, přepadu, čidla teploty na výstupu a čidla vysokého tlaku. Odstranění poruchy. Případ 3: nutné ruční vypnutí a opětovné zajištění.",
+                            "798": "Kontrola kabeláže ModBus ventilátoru.",
+                            "799": "Kontrola kabeláže ModBus desky ASB.",
+                            "800": "Odebrání energie ze zásobníku desuperheateru. Jakmile teplota klesne pod 80 °C, lze zařízení znovu spustit.",
+                            "802": "Kontrola funkce ventilátoru. Kontrola připojovacího kabelu. Kontrola čidla. Kontrola otvorů rozvaděče na ucpání.",
+                            "803": "Kontrola funkce ventilátoru. Kontrola připojovacího kabelu. Kontrola čidla. Kontrola otvorů rozvaděče na ucpání.",
+                            "806": "Kontrola kabeláže ModBus desky SEC.",
+                            "807": "Kontrola rozhraní ModBus na ovládacím panelu, propojovacího kabelu k rozbočovači ModBus a samotného rozbočovače ModBus. Kontrola kabeláže ModBus.",
+                            "768": "Kontrola průtoku topné vody a přepadu. Odstranění poruchy.",
+                            "769": "Kontrola kabeláže zátěže a řízení oběhového čerpadla. Odstranění poruchy."
                         }
                     }
                 }
             },
             "switchoff_reason": {
-                "name": "Vypnut\u00ed",
+                "name": "Vypnutí",
                 "state": {
-                    "0": "Porucha tepeln\u00e9ho \u010derpadla",
-                    "1": "Porucha za\u0159\u00edzen\u00ed",
-                    "2": "Re\u017eim druh\u00e9ho zdroje tepla",
-                    "3": "Blokov\u00e1no distribu\u010dn\u00edm subjektem",
+                    "0": "Porucha tepelného čerpadla",
+                    "1": "Porucha zařízení",
+                    "2": "Režim druhého zdroje tepla",
+                    "3": "Blokováno distribučním subjektem",
                     "4": "",
-                    "5": "Odmrazov\u00e1n\u00ed vzduchu (pouze za\u0159\u00edzen\u00ed vzduch/voda)",
-                    "6": "Maxim\u00e1ln\u00ed teplotn\u00ed limit provozu",
-                    "7": "Minim\u00e1ln\u00ed teplotn\u00ed limit provozu",
-                    "8": "Ni\u017e\u0161\u00ed limit provozu",
-                    "9": "\u017d\u00e1dn\u00fd po\u017eadavek",
-                    "10": "Extern\u00ed zdroj energie",
-                    "11": "Pr\u016ftok v tepeln\u00e9m zdroji",
-                    "12": "Pauza n\u00edzk\u00e9ho tlaku",
-                    "13": "Pauza p\u0159eh\u0159\u00e1t\u00ed",
+                    "5": "Odmrazování vzduchu (pouze zařízení vzduch/voda)",
+                    "6": "Maximální teplotní limit provozu",
+                    "7": "Minimální teplotní limit provozu",
+                    "8": "Nižší limit provozu",
+                    "9": "Žádný požadavek",
+                    "10": "Externí zdroj energie",
+                    "11": "Průtok v tepelném zdroji",
+                    "12": "Pauza nízkého tlaku",
+                    "13": "Pauza přehřátí",
                     "14": "Pauza invertoru",
                     "15": "Pauza desuperheateru",
-                    "16": "Re\u017eim p\u0159ep\u00edn\u00e1n\u00ed",
-                    "17": "Jin\u00e9 vypnut\u00ed",
-                    "18": "Minim\u00e1ln\u00ed pr\u016ftok chlazen\u00ed",
+                    "16": "Režim přepínání",
+                    "17": "Jiné vypnutí",
+                    "18": "Minimální průtok chlazení",
                     "19": "PV max",
-                    "20": "Pauza hork\u00e9ho plynu",
-                    "21": "Pauza p\u0159eh\u0159\u00e1t\u00ed hork\u00e9ho plynu",
-                    "22": "\u017d\u00e1dn\u00fd po\u017eadavek",
-                    "23": "Minim\u00e1ln\u00ed v\u00fdstupn\u00ed teplota zdroje tepla p\u0159i chlazen\u00ed",
+                    "20": "Pauza horkého plynu",
+                    "21": "Pauza přehřátí horkého plynu",
+                    "22": "Žádný požadavek",
+                    "23": "Minimální výstupní teplota zdroje tepla při chlazení",
                     "24": "LPC",
                     "25": "Restart",
-                    "27": "Maxim\u00e1ln\u00ed teplota v\u00fdstupu"
+                    "27": "Maximální teplota výstupu"
                 },
                 "state_attributes": {
                     "timestamp": {
-                        "name": "\u010casov\u00e1 zn\u00e1mka"
+                        "name": "Časová známka"
                     },
                     "code_1": {
-                        "name": "P\u0159edposledn\u00ed vypnut\u00ed",
+                        "name": "Předposlední vypnutí",
                         "state": {
-                            "0": "Porucha tepeln\u00e9ho \u010derpadla",
-                            "1": "Porucha za\u0159\u00edzen\u00ed",
-                            "2": "Re\u017eim druh\u00e9ho zdroje tepla",
-                            "3": "Blokov\u00e1no distribu\u010dn\u00edm subjektem",
+                            "0": "Porucha tepelného čerpadla",
+                            "1": "Porucha zařízení",
+                            "2": "Režim druhého zdroje tepla",
+                            "3": "Blokováno distribučním subjektem",
                             "4": "",
-                            "5": "Odmrazov\u00e1n\u00ed vzduchu (pouze za\u0159\u00edzen\u00ed vzduch/voda)",
-                            "6": "Maxim\u00e1ln\u00ed teplotn\u00ed limit provozu",
-                            "7": "Minim\u00e1ln\u00ed teplotn\u00ed limit provozu",
-                            "8": "Ni\u017e\u0161\u00ed limit provozu",
-                            "9": "\u017d\u00e1dn\u00fd po\u017eadavek",
-                            "10": "Extern\u00ed zdroj energie",
-                            "11": "Pr\u016ftok v tepeln\u00e9m zdroji",
-                            "12": "Pauza n\u00edzk\u00e9ho tlaku",
-                            "13": "Pauza p\u0159eh\u0159\u00e1t\u00ed",
+                            "5": "Odmrazování vzduchu (pouze zařízení vzduch/voda)",
+                            "6": "Maximální teplotní limit provozu",
+                            "7": "Minimální teplotní limit provozu",
+                            "8": "Nižší limit provozu",
+                            "9": "Žádný požadavek",
+                            "10": "Externí zdroj energie",
+                            "11": "Průtok v tepelném zdroji",
+                            "12": "Pauza nízkého tlaku",
+                            "13": "Pauza přehřátí",
                             "14": "Pauza invertoru",
                             "15": "Pauza desuperheateru",
-                            "16": "Re\u017eim p\u0159ep\u00edn\u00e1n\u00ed",
-                            "17": "Jin\u00e9 vypnut\u00ed",
-                            "18": "Minim\u00e1ln\u00ed pr\u016ftok chlazen\u00ed",
+                            "16": "Režim přepínání",
+                            "17": "Jiné vypnutí",
+                            "18": "Minimální průtok chlazení",
                             "19": "PV max",
-                            "20": "Pauza hork\u00e9ho plynu",
-                            "21": "Pauza p\u0159eh\u0159\u00e1t\u00ed hork\u00e9ho plynu",
-                            "22": "\u017d\u00e1dn\u00fd po\u017eadavek",
-                            "23": "Minim\u00e1ln\u00ed v\u00fdstupn\u00ed teplota zdroje tepla p\u0159i chlazen\u00ed",
+                            "20": "Pauza horkého plynu",
+                            "21": "Pauza přehřátí horkého plynu",
+                            "22": "Žádný požadavek",
+                            "23": "Minimální výstupní teplota zdroje tepla při chlazení",
                             "24": "LPC",
                             "25": "Restart",
-                            "27": "Maxim\u00e1ln\u00ed teplota v\u00fdstupu"
+                            "27": "Maximální teplota výstupu"
                         }
                     },
                     "timestamp_1": {
-                        "name": "P\u0159edposledn\u00ed \u010dasov\u00fd okam\u017eik"
+                        "name": "Předposlední časový okamžik"
                     },
                     "code_2": {
-                        "name": "P\u0159edp\u0159edposledn\u00ed d\u016fvod vypnut\u00ed",
+                        "name": "Předpředposlední důvod vypnutí",
                         "state": {
-                            "0": "Porucha tepeln\u00e9ho \u010derpadla",
-                            "1": "Porucha za\u0159\u00edzen\u00ed",
-                            "2": "Re\u017eim druh\u00e9ho zdroje tepla",
-                            "3": "Blokov\u00e1no distribu\u010dn\u00edm subjektem",
+                            "0": "Porucha tepelného čerpadla",
+                            "1": "Porucha zařízení",
+                            "2": "Režim druhého zdroje tepla",
+                            "3": "Blokováno distribučním subjektem",
                             "4": "",
-                            "5": "Odmrazov\u00e1n\u00ed vzduchu (pouze za\u0159\u00edzen\u00ed vzduch/voda)",
-                            "6": "Maxim\u00e1ln\u00ed teplotn\u00ed limit provozu",
-                            "7": "Minim\u00e1ln\u00ed teplotn\u00ed limit provozu",
-                            "8": "Ni\u017e\u0161\u00ed limit provozu",
-                            "9": "\u017d\u00e1dn\u00fd po\u017eadavek",
-                            "10": "Extern\u00ed zdroj energie",
-                            "11": "Pr\u016ftok v tepeln\u00e9m zdroji",
-                            "12": "Pauza n\u00edzk\u00e9ho tlaku",
-                            "13": "Pauza p\u0159eh\u0159\u00e1t\u00ed",
+                            "5": "Odmrazování vzduchu (pouze zařízení vzduch/voda)",
+                            "6": "Maximální teplotní limit provozu",
+                            "7": "Minimální teplotní limit provozu",
+                            "8": "Nižší limit provozu",
+                            "9": "Žádný požadavek",
+                            "10": "Externí zdroj energie",
+                            "11": "Průtok v tepelném zdroji",
+                            "12": "Pauza nízkého tlaku",
+                            "13": "Pauza přehřátí",
                             "14": "Pauza invertoru",
                             "15": "Pauza desuperheateru",
-                            "16": "Re\u017eim p\u0159ep\u00edn\u00e1n\u00ed",
-                            "17": "Jin\u00e9 vypnut\u00ed",
-                            "18": "Minim\u00e1ln\u00ed pr\u016ftok chlazen\u00ed",
+                            "16": "Režim přepínání",
+                            "17": "Jiné vypnutí",
+                            "18": "Minimální průtok chlazení",
                             "19": "PV max",
-                            "20": "Pauza hork\u00e9ho plynu",
-                            "21": "Pauza p\u0159eh\u0159\u00e1t\u00ed hork\u00e9ho plynu",
-                            "22": "\u017d\u00e1dn\u00fd po\u017eadavek",
-                            "23": "Minim\u00e1ln\u00ed v\u00fdstupn\u00ed teplota zdroje tepla p\u0159i chlazen\u00ed",
+                            "20": "Pauza horkého plynu",
+                            "21": "Pauza přehřátí horkého plynu",
+                            "22": "Žádný požadavek",
+                            "23": "Minimální výstupní teplota zdroje tepla při chlazení",
                             "24": "LPC",
                             "25": "Restart",
-                            "27": "Maxim\u00e1ln\u00ed teplota v\u00fdstupu"
+                            "27": "Maximální teplota výstupu"
                         }
                     },
                     "timestamp_2": {
-                        "name": "P\u0159edp\u0159edposledn\u00ed \u010dasov\u00fd okam\u017eik"
+                        "name": "Předpředposlední časový okamžik"
                     },
                     "code_3": {
-                        "name": "T\u0159et\u00ed p\u0159edposledn\u00ed d\u016fvod vypnut\u00ed",
+                        "name": "Třetí předposlední důvod vypnutí",
                         "state": {
-                            "0": "Porucha tepeln\u00e9ho \u010derpadla",
-                            "1": "Porucha za\u0159\u00edzen\u00ed",
-                            "2": "Re\u017eim druh\u00e9ho zdroje tepla",
-                            "3": "Blokov\u00e1no distribu\u010dn\u00edm subjektem",
+                            "0": "Porucha tepelného čerpadla",
+                            "1": "Porucha zařízení",
+                            "2": "Režim druhého zdroje tepla",
+                            "3": "Blokováno distribučním subjektem",
                             "4": "",
-                            "5": "Odmrazov\u00e1n\u00ed vzduchu (pouze za\u0159\u00edzen\u00ed vzduch/voda)",
-                            "6": "Maxim\u00e1ln\u00ed teplotn\u00ed limit provozu",
-                            "7": "Minim\u00e1ln\u00ed teplotn\u00ed limit provozu",
-                            "8": "Ni\u017e\u0161\u00ed limit provozu",
-                            "9": "\u017d\u00e1dn\u00fd po\u017eadavek",
-                            "10": "Extern\u00ed zdroj energie",
-                            "11": "Pr\u016ftok v tepeln\u00e9m zdroji",
-                            "12": "Pauza n\u00edzk\u00e9ho tlaku",
-                            "13": "Pauza p\u0159eh\u0159\u00e1t\u00ed",
+                            "5": "Odmrazování vzduchu (pouze zařízení vzduch/voda)",
+                            "6": "Maximální teplotní limit provozu",
+                            "7": "Minimální teplotní limit provozu",
+                            "8": "Nižší limit provozu",
+                            "9": "Žádný požadavek",
+                            "10": "Externí zdroj energie",
+                            "11": "Průtok v tepelném zdroji",
+                            "12": "Pauza nízkého tlaku",
+                            "13": "Pauza přehřátí",
                             "14": "Pauza invertoru",
                             "15": "Pauza desuperheateru",
-                            "16": "Re\u017eim p\u0159ep\u00edn\u00e1n\u00ed",
-                            "17": "Jin\u00e9 vypnut\u00ed",
-                            "18": "Minim\u00e1ln\u00ed pr\u016ftok chlazen\u00ed",
+                            "16": "Režim přepínání",
+                            "17": "Jiné vypnutí",
+                            "18": "Minimální průtok chlazení",
                             "19": "PV max",
-                            "20": "Pauza hork\u00e9ho plynu",
-                            "21": "Pauza p\u0159eh\u0159\u00e1t\u00ed hork\u00e9ho plynu",
-                            "22": "\u017d\u00e1dn\u00fd po\u017eadavek",
-                            "23": "Minim\u00e1ln\u00ed v\u00fdstupn\u00ed teplota zdroje tepla p\u0159i chlazen\u00ed",
+                            "20": "Pauza horkého plynu",
+                            "21": "Pauza přehřátí horkého plynu",
+                            "22": "Žádný požadavek",
+                            "23": "Minimální výstupní teplota zdroje tepla při chlazení",
                             "24": "LPC",
                             "25": "Restart",
-                            "27": "Maxim\u00e1ln\u00ed teplota v\u00fdstupu"
+                            "27": "Maximální teplota výstupu"
                         }
                     },
                     "timestamp_3": {
-                        "name": "\u010ctvrt\u00fd p\u0159edposledn\u00ed \u010dasov\u00fd okam\u017eik"
+                        "name": "Čtvrtý předposlední časový okamžik"
                     },
                     "code_4": {
-                        "name": "P\u00e1t\u00e9 p\u0159edposledn\u00ed vypnut\u00ed",
+                        "name": "Páté předposlední vypnutí",
                         "state": {
-                            "0": "Porucha tepeln\u00e9ho \u010derpadla",
-                            "1": "Porucha za\u0159\u00edzen\u00ed",
-                            "2": "Re\u017eim druh\u00e9ho zdroje tepla",
-                            "3": "Blokov\u00e1no distribu\u010dn\u00edm subjektem",
+                            "0": "Porucha tepelného čerpadla",
+                            "1": "Porucha zařízení",
+                            "2": "Režim druhého zdroje tepla",
+                            "3": "Blokováno distribučním subjektem",
                             "4": "",
-                            "5": "Odmrazov\u00e1n\u00ed vzduchu (pouze za\u0159\u00edzen\u00ed vzduch/voda)",
-                            "6": "Maxim\u00e1ln\u00ed teplotn\u00ed limit provozu",
-                            "7": "Minim\u00e1ln\u00ed teplotn\u00ed limit provozu",
-                            "8": "Ni\u017e\u0161\u00ed limit provozu",
-                            "9": "\u017d\u00e1dn\u00fd po\u017eadavek",
-                            "10": "Extern\u00ed zdroj energie",
-                            "11": "Pr\u016ftok v tepeln\u00e9m zdroji",
-                            "12": "Pauza n\u00edzk\u00e9ho tlaku",
-                            "13": "Pauza p\u0159eh\u0159\u00e1t\u00ed",
+                            "5": "Odmrazování vzduchu (pouze zařízení vzduch/voda)",
+                            "6": "Maximální teplotní limit provozu",
+                            "7": "Minimální teplotní limit provozu",
+                            "8": "Nižší limit provozu",
+                            "9": "Žádný požadavek",
+                            "10": "Externí zdroj energie",
+                            "11": "Průtok v tepelném zdroji",
+                            "12": "Pauza nízkého tlaku",
+                            "13": "Pauza přehřátí",
                             "14": "Pauza invertoru",
                             "15": "Pauza desuperheateru",
-                            "16": "Re\u017eim p\u0159ep\u00edn\u00e1n\u00ed",
-                            "17": "Jin\u00e9 vypnut\u00ed",
-                            "18": "Minim\u00e1ln\u00ed pr\u016ftok chlazen\u00ed",
+                            "16": "Režim přepínání",
+                            "17": "Jiné vypnutí",
+                            "18": "Minimální průtok chlazení",
                             "19": "PV max",
-                            "20": "Pauza hork\u00e9ho plynu",
-                            "21": "Pauza p\u0159eh\u0159\u00e1t\u00ed hork\u00e9ho plynu",
-                            "22": "\u017d\u00e1dn\u00fd po\u017eadavek",
-                            "23": "Minim\u00e1ln\u00ed v\u00fdstupn\u00ed teplota zdroje tepla p\u0159i chlazen\u00ed",
+                            "20": "Pauza horkého plynu",
+                            "21": "Pauza přehřátí horkého plynu",
+                            "22": "Žádný požadavek",
+                            "23": "Minimální výstupní teplota zdroje tepla při chlazení",
                             "24": "LPC",
                             "25": "Restart",
-                            "27": "Maxim\u00e1ln\u00ed teplota v\u00fdstupu"
+                            "27": "Maximální teplota výstupu"
                         }
                     },
                     "timestamp_4": {
-                        "name": "P\u00e1t\u00fd p\u0159edposledn\u00ed \u010dasov\u00fd okam\u017eik"
+                        "name": "Pátý předposlední časový okamžik"
                     }
                 }
             },
             "status_line_1": {
                 "name": "Stav 1",
                 "state": {
-                    "heatpump_running": "Tepeln\u00e9 \u010derpadlo b\u011b\u017e\u00ed",
-                    "heatpump_idle": "Tepeln\u00e9 \u010derpadlo je v klidov\u00e9m re\u017eimu",
-                    "heatpump_coming": "Tepeln\u00e9 \u010derpadlo se spou\u0161t\u00ed",
-                    "heatpump_shutdown": "Tepeln\u00e9 \u010derpadlo vyp\u00edn\u00e1",
-                    "errorcode_slot_0": "Chybov\u00fd k\u00f3d tepeln\u00e9ho \u010derpadla ve slotu 0",
-                    "pump_forerun": "P\u0159edeh\u0159ev \u010derpadla",
-                    "defrost": "Odmrazov\u00e1n\u00ed",
-                    "waiting_on_lin_connection": "\u010cek\u00e1n\u00ed na p\u0159ipojen\u00ed LIN",
-                    "compressor_heating_up": "Kompresor se zah\u0159\u00edv\u00e1",
-                    "compressor_heater": "Oh\u0159ev kompresoru"
+                    "heatpump_running": "Tepelné čerpadlo běží",
+                    "heatpump_idle": "Tepelné čerpadlo je v klidovém režimu",
+                    "heatpump_coming": "Tepelné čerpadlo se spouští",
+                    "heatpump_shutdown": "Tepelné čerpadlo vypíná",
+                    "errorcode_slot_0": "Chybový kód tepelného čerpadla ve slotu 0",
+                    "pump_forerun": "Předehřev čerpadla",
+                    "defrost": "Odmrazování",
+                    "waiting_on_lin_connection": "Čekání na připojení LIN",
+                    "compressor_heating_up": "Kompresor se zahřívá",
+                    "compressor_heater": "Ohřev kompresoru"
                 }
             },
             "status_line_2": {
                 "name": "Stav 2",
                 "state": {
-                    "since": "ji\u017e",
+                    "since": "již",
                     "in": "za",
-                    "unknown": "nezn\u00e1mo"
+                    "unknown": "neznámo"
                 }
             },
             "status_line_3": {
                 "name": "Stav 3",
                 "state": {
-                    "heating": "vyt\u00e1p\u011bn\u00ed",
-                    "defrost": "odmrazov\u00e1n\u00ed",
-                    "cooling": "chlazen\u00ed",
-                    "pump_forerun": "p\u0159edeh\u0159ev \u010derpadla",
-                    "thermal_desinfection": "tepeln\u00e1 dezinfekce",
-                    "swimming_pool_solar": "baz\u00e9n/sol\u00e1ry",
-                    "no_request": "\u017e\u00e1dn\u00fd po\u017eadavek",
-                    "cycle_lock": "blokov\u00e1n\u00ed cyklu",
-                    "lock_time": "\u010das blokace",
-                    "domestic_water": "nah\u0159\u00edv\u00e1n\u00ed TUV",
-                    "flow_monitoring": "kontrola pr\u016ftoku",
-                    "grid_switch_on_delay": "zpo\u017ed\u011bn\u00ed p\u0159i zapnut\u00ed s\u00edt\u011b",
-                    "info_bake_out_program": "informace z programu pe\u010den\u00ed",
-                    "heating_external_energy_source": "oh\u0159ev z extern\u00edho zdroje energie",
-                    "domestic_water_external_energy_source": "TUV z extern\u00edho zdroje energie",
-                    "second_heat_generator_1_active": "druh\u00fd gener\u00e1tor tepla 1 aktivn\u00ed"
+                    "heating": "vytápění",
+                    "defrost": "odmrazování",
+                    "cooling": "chlazení",
+                    "pump_forerun": "předehřev čerpadla",
+                    "thermal_desinfection": "tepelná dezinfekce",
+                    "swimming_pool_solar": "bazén/soláry",
+                    "no_request": "žádný požadavek",
+                    "cycle_lock": "blokování cyklu",
+                    "lock_time": "čas blokace",
+                    "domestic_water": "nahřívání TUV",
+                    "flow_monitoring": "kontrola průtoku",
+                    "grid_switch_on_delay": "zpoždění při zapnutí sítě",
+                    "info_bake_out_program": "informace z programu pečení",
+                    "heating_external_energy_source": "ohřev z externího zdroje energie",
+                    "domestic_water_external_energy_source": "TUV z externího zdroje energie",
+                    "second_heat_generator_1_active": "druhý generátor tepla 1 aktivní"
                 }
             },
             "heat_source_output": {
-                "name": "V\u00fdstup vyt\u00e1p\u011bn\u00ed"
+                "name": "Výstup vytápění"
             },
             "heat_source_input_temperature": {
-                "name": "Teplota vstupu vyt\u00e1p\u011bn\u00ed"
+                "name": "Teplota vstupu vytápění"
             },
             "outdoor_temperature": {
-                "name": "Venkovn\u00ed teplota"
+                "name": "Venkovní teplota"
             },
             "status_time": {
-                "name": "\u010cas stavu"
+                "name": "Čas stavu"
             },
             "outdoor_temperature_average": {
-                "name": "Pr\u016fm\u011brn\u00e1 venkovn\u00ed teplota"
+                "name": "Průměrná venkovní teplota"
             },
             "compressor1_impulses": {
-                "name": "Impuls\u016f kompresoru 1"
+                "name": "Impulsů kompresoru 1"
             },
             "compressor1_operation_hours": {
                 "name": "Hodiny provozu kompresoru 1"
             },
             "compressor2_impulses": {
-                "name": "Impuls\u016f kompresoru 2"
+                "name": "Impulsů kompresoru 2"
             },
             "compressor2_operation_hours": {
                 "name": "Hodiny provozu kompresoru 2"
             },
             "operation_hours": {
-                "name": "Celkov\u00e9 hodiny provozu"
+                "name": "Celkové hodiny provozu"
             },
             "heat_amount_counter": {
-                "name": "Mno\u017estv\u00ed tepla"
+                "name": "Množství tepla"
             },
             "hot_gas_temperature": {
-                "name": "Teplota hork\u00e9ho plynu"
+                "name": "Teplota horkého plynu"
             },
             "suction_compressor_temperature": {
-                "name": "Teplota sac\u00edho kompresoru"
+                "name": "Teplota sacího kompresoru"
             },
             "suction_evaporator_temperature": {
-                "name": "Teplota sac\u00edho vypa\u0159ova\u010de"
+                "name": "Teplota sacího vypařovače"
             },
             "compressor_heating_temperature": {
-                "name": "Teplota oh\u0159evu kompresoru"
+                "name": "Teplota ohřevu kompresoru"
             },
             "overheating_temperature": {
-                "name": "P\u0159et\u00e1p\u011bc\u00ed teplota"
+                "name": "Přetápěcí teplota"
             },
             "overheating_target_temperature": {
-                "name": "po\u017eadovan\u00e1 p\u0159et\u00e1p\u011bc\u00ed teplota"
+                "name": "požadovaná přetápěcí teplota"
             },
             "high_pressure": {
-                "name": "Vysok\u00fd tlak"
+                "name": "Vysoký tlak"
             },
             "low_pressure": {
-                "name": "N\u00edzk\u00fd tlak"
+                "name": "Nízký tlak"
             },
             "additional_heat_generator_operation_hours": {
-                "name": "Hodiny provozu dodate\u010dn\u00e9ho zdroje tepla"
+                "name": "Hodiny provozu dodatečného zdroje tepla"
             },
             "additional_heat_generator2_operation_hours": {
-                "name": "Hodiny provozu dodate\u010dn\u00e9ho zdroje tepla 2"
+                "name": "Hodiny provozu dodatečného zdroje tepla 2"
             },
             "analog_out1": {
-                "name": "Analogov\u00fd v\u00fdstup 1"
+                "name": "Analogový výstup 1"
             },
             "analog_out2": {
-                "name": "Analogov\u00fd v\u00fdstup 2"
+                "name": "Analogový výstup 2"
             },
             "current_heat_output": {
-                "name": "Aktu\u00e1ln\u00ed v\u00fdkon"
+                "name": "Aktuální výkon"
             },
             "current_power_consumption": {
-                "name": "Aktu\u00e1ln\u00ed spot\u0159eba energie"
+                "name": "Aktuální spotřeba energie"
             },
             "additional_heat_generator_energy_p1059": {
-                "name": "Mno\u017estv\u00ed tepla dodate\u010dn\u00e9ho zdroje (firmware p\u0159ed x.88)"
+                "name": "Množství tepla dodatečného zdroje (firmware před x.88)"
             },
             "additional_heat_generator_energy_p1140": {
-                "name": "Mno\u017estv\u00ed tepla dodate\u010dn\u00e9ho zdroje (firmware x.88 a nov\u011bj\u0161\u00ed)"
+                "name": "Množství tepla dodatečného zdroje (firmware x.88 a novější)"
             },
             "additional_heat_generator_energy": {
-                "name": "Mno\u017estv\u00ed tepla dodate\u010dn\u00e9ho zdroje"
+                "name": "Množství tepla dodatečného zdroje"
             },
             "heat_source_output_temperature": {
-                "name": "Teplota v\u00fdstupu tepla"
+                "name": "Teplota výstupu tepla"
             },
             "pump_frequency": {
-                "name": "Frekvence \u010derpadla"
+                "name": "Frekvence čerpadla"
             },
             "domestic_water": {
                 "name": "TUV"
@@ -894,10 +894,10 @@
                 "name": "Hodiny provozu TUV"
             },
             "dhw_heat_amount": {
-                "name": "Mno\u017estv\u00ed tepla pro TUV"
+                "name": "Množství tepla pro TUV"
             },
             "dhw_energy_input": {
-                "name": "Spot\u0159ebovan\u00e1 energie pro TUV"
+                "name": "Spotřebovaná energie pro TUV"
             },
             "cop_dhw": {
                 "name": "COP"
@@ -906,88 +906,88 @@
                 "name": "Teplota vstupu"
             },
             "flow_in_circuit1_temperature": {
-                "name": "Okruh vstupn\u00ed teploty 1"
+                "name": "Okruh vstupní teploty 1"
             },
             "flow_in_circuit2_temperature": {
-                "name": "Okruh vstupn\u00ed teploty 2"
+                "name": "Okruh vstupní teploty 2"
             },
             "flow_in_circuit3_temperature": {
-                "name": "Okruh vstupn\u00ed teploty 3"
+                "name": "Okruh vstupní teploty 3"
             },
             "flow_in_circuit1_target_temperature": {
-                "name": "Obvod c\u00edlov\u00e9 teploty vstupu 1"
+                "name": "Obvod cílové teploty vstupu 1"
             },
             "flow_in_circuit2_target_temperature": {
-                "name": "Obvod c\u00edlov\u00e9 teploty vstupu 2"
+                "name": "Obvod cílové teploty vstupu 2"
             },
             "flow_in_circuit3_target_temperature": {
-                "name": "Obvod c\u00edlov\u00e9 teploty vstupu 3"
+                "name": "Obvod cílové teploty vstupu 3"
             },
             "flow_out_temperature": {
-                "name": "Teplota zp\u00e1te\u010dky"
+                "name": "Teplota zpátečky"
             },
             "flow_out_temperature_target": {
-                "name": "po\u017eadovan\u00e1 teplota zp\u00e1te\u010dky"
+                "name": "požadovaná teplota zpátečky"
             },
             "operation_hours_heating": {
-                "name": "Hodiny provozu topen\u00ed"
+                "name": "Hodiny provozu topení"
             },
             "heat_amount_heating": {
-                "name": "Mno\u017estv\u00ed tepla pro topen\u00ed"
+                "name": "Množství tepla pro topení"
             },
             "pool_heat_amount": {
                 "name": "Množství tepla pro bazén"
             },
             "heat_amount_flow_rate": {
-                "name": "Mno\u017estv\u00ed tepla"
+                "name": "Množství tepla"
             },
             "heat_source_flow_rate": {
-                "name": "Pr\u016ftok zdroje vyt\u00e1p\u011bn\u00ed"
+                "name": "Průtok zdroje vytápění"
             },
             "heat_energy_input": {
-                "name": "Spot\u0159ebovan\u00e1 energie pro topen\u00ed"
+                "name": "Spotřebovaná energie pro topení"
             },
             "cop_heating": {
                 "name": "COP"
             },
             "flow_out_temperature_external": {
-                "name": "Teplota vn\u011bj\u0161\u00edho zp\u00e1te\u010dky"
+                "name": "Teplota vnějšího zpátečky"
             },
             "solar_collector_temperature": {
-                "name": "Teplota sol\u00e1rn\u00edho kolektoru"
+                "name": "Teplota solárního kolektoru"
             },
             "solar_buffer_temperature": {
-                "name": "Teplota sol\u00e1rn\u00edho z\u00e1sobn\u00edku"
+                "name": "Teplota solárního zásobníku"
             },
             "operation_hours_solar": {
-                "name": "Hodiny provozu sol\u00e1rn\u00edho za\u0159\u00edzen\u00ed"
+                "name": "Hodiny provozu solárního zařízení"
             },
             "operation_hours_cooling": {
-                "name": "Hodiny provozu chlazen\u00ed"
+                "name": "Hodiny provozu chlazení"
             },
             "cooling_energy_input": {
-                "name": "Spot\u0159ebovan\u00e1 energie pro chlazen\u00ed"
+                "name": "Spotřebovaná energie pro chlazení"
             },
             "pool_energy_input": {
                 "name": "Spotřebovaná energie pro bazén"
             },
             "room_thermostat_temperature": {
-                "name": "Teplota termostatu m\u00edstnosti"
+                "name": "Teplota termostatu místnosti"
             },
             "room_thermostat_temperature_target": {
-                "name": "po\u017eadovan\u00e1 teplota termostatu m\u00edstnosti"
+                "name": "požadovaná teplota termostatu místnosti"
             },
             "pump_flow_delta_target": {
-                "name": "po\u017eadovan\u00fd rozd\u00edl pr\u016ftoku \u010derpadla"
+                "name": "požadovaný rozdíl průtoku čerpadla"
             },
             "pump_flow_delta": {
-                "name": "Rozd\u00edl pr\u016ftoku \u010derpadla"
+                "name": "Rozdíl průtoku čerpadla"
             },
             "circulation_pump_delta_target": {
-                "name": "po\u017eadovan\u00fd rozd\u00edl pr\u016ftoku ob\u011bhov\u00e9ho \u010derpadla"
+                "name": "požadovaný rozdíl průtoku oběhového čerpadla"
             },
             "circulation_pump_delta": {
-                "name": "Rozd\u00edl pr\u016ftoku ob\u011bhov\u00e9ho \u010derpadla"
+                "name": "Rozdíl průtoku oběhového čerpadla"
             },
             "ventilation_supply_air_temperature": {
                 "name": "Teplota přiváděného vzduchu"
@@ -1016,212 +1016,212 @@
         },
         "date": {
             "away_dhw_startdate": {
-                "name": "Datum za\u010d\u00e1tku re\u017eimu mimo domov - tepl\u00e1 voda"
+                "name": "Datum začátku režimu mimo domov - teplá voda"
             },
             "away_dhw_enddate": {
-                "name": "Datum konce re\u017eimu mimo domov - tepl\u00e1 voda"
+                "name": "Datum konce režimu mimo domov - teplá voda"
             },
             "away_heating_startdate": {
-                "name": "Datum za\u010d\u00e1tku re\u017eimu mimo domov - vyt\u00e1p\u011bn\u00ed"
+                "name": "Datum začátku režimu mimo domov - vytápění"
             },
             "away_heating_enddate": {
-                "name": "Datum konce re\u017eimu mimo domov - vyt\u00e1p\u011bn\u00ed"
+                "name": "Datum konce režimu mimo domov - vytápění"
             }
         },
         "text": {
             "timer_dhw_schedule_week": {
-                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (t\u00fdden)"
+                "name": "Časový plán teplé vody (týden)"
             },
             "timer_dhw_schedule_weekday": {
-                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (pracovn\u00ed dny)"
+                "name": "Časový plán teplé vody (pracovní dny)"
             },
             "timer_dhw_schedule_weekend": {
-                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (v\u00edkend)"
+                "name": "Časový plán teplé vody (víkend)"
             },
             "timer_dhw_schedule_monday": {
-                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (pond\u011bl\u00ed)"
+                "name": "Časový plán teplé vody (pondělí)"
             },
             "timer_dhw_schedule_tuesday": {
-                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (\u00fater\u00fd)"
+                "name": "Časový plán teplé vody (úterý)"
             },
             "timer_dhw_schedule_wednesday": {
-                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (st\u0159eda)"
+                "name": "Časový plán teplé vody (středa)"
             },
             "timer_dhw_schedule_thursday": {
-                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (\u010dtvrtek)"
+                "name": "Časový plán teplé vody (čtvrtek)"
             },
             "timer_dhw_schedule_friday": {
-                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (p\u00e1tek)"
+                "name": "Časový plán teplé vody (pátek)"
             },
             "timer_dhw_schedule_saturday": {
-                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (sobota)"
+                "name": "Časový plán teplé vody (sobota)"
             },
             "timer_dhw_schedule_sunday": {
-                "name": "\u010casov\u00fd pl\u00e1n tepl\u00e9 vody (ned\u011ble)"
+                "name": "Časový plán teplé vody (neděle)"
             },
             "timer_heating_schedule_week": {
-                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (t\u00fdden)"
+                "name": "Časový plán vytápění (týden)"
             },
             "timer_heating_schedule_weekday": {
-                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (pracovn\u00ed dny)"
+                "name": "Časový plán vytápění (pracovní dny)"
             },
             "timer_heating_schedule_weekend": {
-                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (v\u00edkend)"
+                "name": "Časový plán vytápění (víkend)"
             },
             "timer_heating_schedule_monday": {
-                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (pond\u011bl\u00ed)"
+                "name": "Časový plán vytápění (pondělí)"
             },
             "timer_heating_schedule_tuesday": {
-                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (\u00fater\u00fd)"
+                "name": "Časový plán vytápění (úterý)"
             },
             "timer_heating_schedule_wednesday": {
-                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (st\u0159eda)"
+                "name": "Časový plán vytápění (středa)"
             },
             "timer_heating_schedule_thursday": {
-                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (\u010dtvrtek)"
+                "name": "Časový plán vytápění (čtvrtek)"
             },
             "timer_heating_schedule_friday": {
-                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (p\u00e1tek)"
+                "name": "Časový plán vytápění (pátek)"
             },
             "timer_heating_schedule_saturday": {
-                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (sobota)"
+                "name": "Časový plán vytápění (sobota)"
             },
             "timer_heating_schedule_sunday": {
-                "name": "\u010casov\u00fd pl\u00e1n vyt\u00e1p\u011bn\u00ed (ned\u011ble)"
+                "name": "Časový plán vytápění (neděle)"
             },
             "timer_ventilation_schedule_week": {
-                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (t\u00fdden)"
+                "name": "Časový plán větrání (týden)"
             },
             "timer_ventilation_schedule_weekday": {
-                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (pracovn\u00ed dny)"
+                "name": "Časový plán větrání (pracovní dny)"
             },
             "timer_ventilation_schedule_weekend": {
-                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (v\u00edkend)"
+                "name": "Časový plán větrání (víkend)"
             },
             "timer_ventilation_schedule_monday": {
-                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (pond\u011bl\u00ed)"
+                "name": "Časový plán větrání (pondělí)"
             },
             "timer_ventilation_schedule_tuesday": {
-                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (\u00fater\u00fd)"
+                "name": "Časový plán větrání (úterý)"
             },
             "timer_ventilation_schedule_wednesday": {
-                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (st\u0159eda)"
+                "name": "Časový plán větrání (středa)"
             },
             "timer_ventilation_schedule_thursday": {
-                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (\u010dtvrtek)"
+                "name": "Časový plán větrání (čtvrtek)"
             },
             "timer_ventilation_schedule_friday": {
-                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (p\u00e1tek)"
+                "name": "Časový plán větrání (pátek)"
             },
             "timer_ventilation_schedule_saturday": {
-                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (sobota)"
+                "name": "Časový plán větrání (sobota)"
             },
             "timer_ventilation_schedule_sunday": {
-                "name": "\u010casov\u00fd pl\u00e1n v\u011btr\u00e1n\u00ed (ned\u011ble)"
+                "name": "Časový plán větrání (neděle)"
             }
         },
         "select": {
             "thermal_desinfection_day": {
-                "name": "Den termick\u00e9 dezinfekce",
+                "name": "Den termické dezinfekce",
                 "state": {
-                    "none": "\u017d\u00e1dn\u00fd",
-                    "monday": "Pond\u011bl\u00ed",
-                    "tuesday": "\u00dater\u00fd",
-                    "wednesday": "St\u0159eda",
-                    "thursday": "\u010ctvrtek",
-                    "friday": "P\u00e1tek",
+                    "none": "Žádný",
+                    "monday": "Pondělí",
+                    "tuesday": "Úterý",
+                    "wednesday": "Středa",
+                    "thursday": "Čtvrtek",
+                    "friday": "Pátek",
                     "saturday": "Sobota",
-                    "sunday": "Ned\u011ble",
-                    "continuous": "Kontinu\u00e1ln\u011b"
+                    "sunday": "Neděle",
+                    "continuous": "Kontinuálně"
                 }
             },
             "heating_control_circuit_mode": {
-                "name": "Re\u017eim regulace topn\u00e9ho okruhu",
+                "name": "Režim regulace topného okruhu",
                 "state": {
-                    "0": "Regulace topnou k\u0159ivkou - \u0158\u00edzen\u00e9 venkovn\u00ed teplotou",
-                    "1": "Manu\u00e1ln\u011b nastaven\u00e1 teplota",
-                    "2": "Analogov\u00fd vstup"
+                    "0": "Regulace topnou křivkou - Řízené venkovní teplotou",
+                    "1": "Manuálně nastavená teplota",
+                    "2": "Analogový vstup"
                 }
             },
             "timer_dhw_program": {
-                "name": "\u010casov\u00fd program TUV",
+                "name": "Časový program TUV",
                 "state": {
-                    "week": "Cel\u00fd t\u00fdden",
-                    "weekday_weekend": "Pracovn\u00ed dny + v\u00edkend",
-                    "daily": "Jednotliv\u00e9 dny"
+                    "week": "Celý týden",
+                    "weekday_weekend": "Pracovní dny + víkend",
+                    "daily": "Jednotlivé dny"
                 }
             },
             "timer_heating_program": {
-                "name": "\u010casov\u00fd program vyt\u00e1p\u011bn\u00ed",
+                "name": "Časový program vytápění",
                 "state": {
-                    "week": "Cel\u00fd t\u00fdden",
-                    "weekday_weekend": "Pracovn\u00ed dny + v\u00edkend",
-                    "daily": "Jednotliv\u00e9 dny"
+                    "week": "Celý týden",
+                    "weekday_weekend": "Pracovní dny + víkend",
+                    "daily": "Jednotlivé dny"
                 }
             },
             "timer_ventilation_program": {
-                "name": "\u010casov\u00fd program v\u011btr\u00e1n\u00ed",
+                "name": "Časový program větrání",
                 "state": {
-                    "week": "Cel\u00fd t\u00fdden",
-                    "weekday_weekend": "Pracovn\u00ed dny + v\u00edkend",
-                    "daily": "Jednotliv\u00e9 dny"
+                    "week": "Celý týden",
+                    "weekday_weekend": "Pracovní dny + víkend",
+                    "daily": "Jednotlivé dny"
                 }
             },
             "pv_mode_selector": {
-                "name": "PV re\u017eim",
+                "name": "PV režim",
                 "state": {
                     "automatic": "Automaticky",
                     "pv_off": "PV vypnuto",
                     "pool_off": "Pool vypnuto",
-                    "pool_party": "Pool p\u00e1rty",
-                    "pool_holidays": "Pool pr\u00e1zdniny"
+                    "pool_party": "Pool párty",
+                    "pool_holidays": "Pool prázdniny"
                 }
             },
             "heating_mode": {
-                "name": "Re\u017eim vyt\u00e1p\u011bn\u00ed",
+                "name": "Režim vytápění",
                 "state": {
                     "off": "Vypnuto",
                     "automatic": "Automaticky",
-                    "second_heatsource": "Druh\u00fd zdroj tepla",
-                    "party": "P\u00e1rty",
-                    "holidays": "Dovolen\u00e1"
+                    "second_heatsource": "Druhý zdroj tepla",
+                    "party": "Párty",
+                    "holidays": "Dovolená"
                 }
             },
             "dhw_mode": {
-                "name": "Re\u017eim tepl\u00e9 vody",
+                "name": "Režim teplé vody",
                 "state": {
                     "off": "Vypnuto",
                     "automatic": "Automaticky",
-                    "second_heatsource": "Druh\u00fd zdroj tepla",
-                    "party": "P\u00e1rty",
-                    "holidays": "Dovolen\u00e1"
+                    "second_heatsource": "Druhý zdroj tepla",
+                    "party": "Párty",
+                    "holidays": "Dovolená"
                 }
             },
             "heating_mode_mk1": {
-                "name": "Re\u017eim vyt\u00e1p\u011bn\u00ed MK1",
+                "name": "Režim vytápění MK1",
                 "state": {
                     "off": "Vypnuto",
                     "automatic": "Automaticky",
-                    "party": "P\u00e1rty",
-                    "holidays": "Dovolen\u00e1"
+                    "party": "Párty",
+                    "holidays": "Dovolená"
                 }
             },
             "heating_mode_mk2": {
-                "name": "Re\u017eim vyt\u00e1p\u011bn\u00ed MK2",
+                "name": "Režim vytápění MK2",
                 "state": {
                     "off": "Vypnuto",
                     "automatic": "Automaticky",
-                    "party": "P\u00e1rty",
-                    "holidays": "Dovolen\u00e1"
+                    "party": "Párty",
+                    "holidays": "Dovolená"
                 }
             },
             "heating_mode_mk3": {
-                "name": "Re\u017eim vyt\u00e1p\u011bn\u00ed MK3",
+                "name": "Režim vytápění MK3",
                 "state": {
                     "off": "Vypnuto",
                     "automatic": "Automaticky",
-                    "party": "P\u00e1rty",
-                    "holidays": "Dovolen\u00e1"
+                    "party": "Párty",
+                    "holidays": "Dovolená"
                 }
             },
             "ventilation_mode": {
@@ -1236,10 +1236,10 @@
         },
         "climate": {
             "heating_controller": {
-                "name": "Topen\u00ed"
+                "name": "Topení"
             },
             "cooling_controller": {
-                "name": "Chlazen\u00ed"
+                "name": "Chlazení"
             }
         },
         "water_heater": {
@@ -1250,16 +1250,16 @@
     },
     "device": {
         "heatpump": {
-            "name": "T\u010c"
+            "name": "TČ"
         },
         "heating": {
-            "name": "Topen\u00ed"
+            "name": "Topení"
         },
         "domestic_water": {
             "name": "TUV"
         },
         "cooling": {
-            "name": "Chlazen\u00ed"
+            "name": "Chlazení"
         },
         "ventilation": {
             "name": "Větrání"
@@ -1267,30 +1267,30 @@
     },
     "config": {
         "abort": {
-            "cannot_connect": "Nepoda\u0159ilo se p\u0159ipojit k Luxtronik na adrese {host}.\\nChyba: {connect_error}",
-            "cannot_identify": "P\u0159ipojeno k za\u0159\u00edzen\u00ed na adrese {host}, ale nepoda\u0159ilo se p\u0159e\u010d\u00edst jeho s\u00e9riov\u00e9 \u010d\u00edslo pro identifikaci.\\nChyba: {error}",
-            "already_configured": "Toto za\u0159\u00edzen\u00ed je ji\u017e nakonfigurov\u00e1no.",
-            "already_configured_serial": "Tepeln\u00e9 \u010derpadlo na {host} hl\u00e1s\u00ed s\u00e9riov\u00e9 \u010d\u00edslo {serial}, kter\u00e9 je ji\u017e nakonfigurov\u00e1no jako {existing_title} ({existing_host}). Ob\u011b adresy vedou ke stejn\u00e9mu tepeln\u00e9mu \u010derpadlu - pokud jste o\u010dek\u00e1vali dv\u011b samostatn\u00e9 jednotky, zkontrolujte duplicitn\u00ed p\u0159esm\u011brov\u00e1n\u00ed port\u016f.",
-            "reconfigure_successful": "Konfigurace \u00fasp\u011b\u0161n\u011b aktualizov\u00e1na.",
-            "unique_id_mismatch": "Za\u0159\u00edzen\u00ed na nov\u00e9 adrese m\u00e1 jinou identitu ne\u017e aktu\u00e1ln\u011b nakonfigurovan\u00e9 za\u0159\u00edzen\u00ed.",
-            "already_in_progress": "Konfigura\u010dn\u00ed proces ji\u017e prob\u00edh\u00e1.",
-            "devices_configured": "V\u0161echna vybran\u00e1 za\u0159\u00edzen\u00ed jsou ji\u017e nakonfigurov\u00e1na.",
-            "options_error": "P\u0159i na\u010d\u00edt\u00e1n\u00ed mo\u017enost\u00ed do\u0161lo k chyb\u011b.",
-            "no_devices_found": "Na s\u00edti nebyla nalezena \u017e\u00e1dn\u00e1 za\u0159\u00edzen\u00ed.",
-            "single_instance_allowed": "Ji\u017e nakonfigurov\u00e1no. Povolen\u00e1 je pouze jedna instance.",
-            "unknown": "Nezn\u00e1m\u00e1 chyba."
+            "cannot_connect": "Nepodařilo se připojit k Luxtronik na adrese {host}.\\nChyba: {connect_error}",
+            "cannot_identify": "Připojeno k zařízení na adrese {host}, ale nepodařilo se přečíst jeho sériové číslo pro identifikaci.\\nChyba: {error}",
+            "already_configured": "Toto zařízení je již nakonfigurováno.",
+            "already_configured_serial": "Tepelné čerpadlo na {host} hlásí sériové číslo {serial}, které je již nakonfigurováno jako {existing_title} ({existing_host}). Obě adresy vedou ke stejnému tepelnému čerpadlu - pokud jste očekávali dvě samostatné jednotky, zkontrolujte duplicitní přesměrování portů.",
+            "reconfigure_successful": "Konfigurace úspěšně aktualizována.",
+            "unique_id_mismatch": "Zařízení na nové adrese má jinou identitu než aktuálně nakonfigurované zařízení.",
+            "already_in_progress": "Konfigurační proces již probíhá.",
+            "devices_configured": "Všechna vybraná zařízení jsou již nakonfigurována.",
+            "options_error": "Při načítání možností došlo k chybě.",
+            "no_devices_found": "Na síti nebyla nalezena žádná zařízení.",
+            "single_instance_allowed": "Již nakonfigurováno. Povolená je pouze jedna instance.",
+            "unknown": "Neznámá chyba."
         },
         "error": {
-            "address": "Neplatn\u00e1 vzd\u00e1len\u00e1 adresa. Adresa mus\u00ed b\u00fdt IP adresa nebo rozpoznateln\u00fd n\u00e1zev hostitele.",
-            "address_in_use": "Zvolen\u00fd port je ji\u017e v tomto syst\u00e9mu pou\u017e\u00edv\u00e1n.",
-            "cannot_connect": "P\u0159ipojen\u00ed se nezda\u0159ilo. Zkontrolujte pros\u00edm host a port.",
-            "cannot_identify": "P\u0159ipojeno k za\u0159\u00edzen\u00ed, ale nepoda\u0159ilo se p\u0159e\u010d\u00edst jeho s\u00e9riov\u00e9 \u010d\u00edslo pro identifikaci.",
-            "unknown": "Neo\u010dek\u00e1van\u00e1 chyba"
+            "address": "Neplatná vzdálená adresa. Adresa musí být IP adresa nebo rozpoznatelný název hostitele.",
+            "address_in_use": "Zvolený port je již v tomto systému používán.",
+            "cannot_connect": "Připojení se nezdařilo. Zkontrolujte prosím host a port.",
+            "cannot_identify": "Připojeno k zařízení, ale nepodařilo se přečíst jeho sériové číslo pro identifikaci.",
+            "unknown": "Neočekávaná chyba"
         },
         "step": {
             "user": {
-                "title": "Instalace tepeln\u00e9ho \u010derpadla Luxtronik",
-                "description": "Zji\u0161t\u011bn\u00e1 za\u0159\u00edzen\u00ed ji\u017e nakonfigurov\u00e1na: {configured}",
+                "title": "Instalace tepelného čerpadla Luxtronik",
+                "description": "Zjištěná zařízení již nakonfigurována: {configured}",
                 "data": {
                     "host": "Host",
                     "port": "Network Port",
@@ -1298,37 +1298,37 @@
                     "max_data_length": "Max data package length"
                 },
                 "data_description": {
-                    "host": "N\u00e1zev hostitele nebo IP adresa",
+                    "host": "Název hostitele nebo IP adresa",
                     "port": "Obvykle 8889 nebo 8888",
-                    "timeout": "Pokud je s\u00ed\u0165 nebo tepeln\u00e9 \u010derpadlo pomal\u00e9, m\u016f\u017eete upravit timeout.",
-                    "max_data_length": "Pokud je s\u00ed\u0165 nebo tepeln\u00e9 \u010derpadlo pomal\u00e9, m\u016f\u017eete upravit d\u00e9lku datov\u00e9ho paketu."
+                    "timeout": "Pokud je síť nebo tepelné čerpadlo pomalé, můžete upravit timeout.",
+                    "max_data_length": "Pokud je síť nebo tepelné čerpadlo pomalé, můžete upravit délku datového paketu."
                 }
             },
             "manual_entry": {
-                "title": "Manu\u00e1ln\u00ed konfigurace Luxtronik",
-                "description": "Nebyla nalezena \u017e\u00e1dn\u00e1 nov\u00e1 za\u0159\u00edzen\u00ed nebo v\u0161echna zji\u0161t\u011bn\u00e1 za\u0159\u00edzen\u00ed jsou ji\u017e nakonfigurov\u00e1na. M\u016f\u017eete ru\u010dn\u011b zadat hostitele a port."
+                "title": "Manuální konfigurace Luxtronik",
+                "description": "Nebyla nalezena žádná nová zařízení nebo všechna zjištěná zařízení jsou již nakonfigurována. Můžete ručně zadat hostitele a port."
             },
             "select_devices": {
-                "title": "Vyberte za\u0159\u00edzen\u00ed k nakonfigurov\u00e1n\u00ed",
-                "description": "Vyberte jedno nebo v\u00edce za\u0159\u00edzen\u00ed k p\u0159id\u00e1n\u00ed. Ji\u017e nakonfigurovan\u00e1 za\u0159\u00edzen\u00ed: {configured}",
+                "title": "Vyberte zařízení k nakonfigurování",
+                "description": "Vyberte jedno nebo více zařízení k přidání. Již nakonfigurovaná zařízení: {configured}",
                 "data": {
-                    "select_device_to_configure": "Vyberte za\u0159\u00edzen\u00ed, kter\u00e9 chcete nakonfigurovat"
+                    "select_device_to_configure": "Vyberte zařízení, které chcete nakonfigurovat"
                 }
             },
             "reconfigure": {
-                "title": "P\u0159ekonfigurovat p\u0159ipojen\u00ed Luxtronik",
-                "description": "Aktualizujte nastaven\u00ed p\u0159ipojen\u00ed pro tepeln\u00e9 \u010derpadlo Luxtronik.",
+                "title": "Překonfigurovat připojení Luxtronik",
+                "description": "Aktualizujte nastavení připojení pro tepelné čerpadlo Luxtronik.",
                 "data": {
                     "host": "Host",
-                    "port": "S\u00ed\u0165ov\u00fd port",
-                    "timeout": "\u010casov\u00fd limit s\u00ed\u0165ov\u00e9ho socketu (s)",
-                    "max_data_length": "Maxim\u00e1ln\u00ed d\u00e9lka datov\u00e9ho paketu"
+                    "port": "Síťový port",
+                    "timeout": "Časový limit síťového socketu (s)",
+                    "max_data_length": "Maximální délka datového paketu"
                 },
                 "data_description": {
-                    "host": "N\u00e1zev hostitele nebo IP adresa",
+                    "host": "Název hostitele nebo IP adresa",
                     "port": "Obvykle 8889 nebo 8888",
-                    "timeout": "Pokud je s\u00ed\u0165 nebo tepeln\u00e9 \u010derpadlo pomal\u00e9, m\u016f\u017eete upravit timeout.",
-                    "max_data_length": "Pokud je s\u00ed\u0165 nebo tepeln\u00e9 \u010derpadlo pomal\u00e9, m\u016f\u017eete upravit d\u00e9lku datov\u00e9ho paketu."
+                    "timeout": "Pokud je síť nebo tepelné čerpadlo pomalé, můžete upravit timeout.",
+                    "max_data_length": "Pokud je síť nebo tepelné čerpadlo pomalé, můžete upravit délku datového paketu."
                 }
             }
         }
@@ -1336,48 +1336,48 @@
     "options": {
         "step": {
             "user": {
-                "title": "Nakonfigurujte mo\u017enosti pro {name}",
-                "description": "Nastaven\u00ed pro tepeln\u00e9 \u010derpadlo Luxtronik {name}.",
+                "title": "Nakonfigurujte možnosti pro {name}",
+                "description": "Nastavení pro tepelné čerpadlo Luxtronik {name}.",
                 "data": {
-                    "ha_sensor_indoor_temperature": "ID senzoru vnit\u0159n\u00ed teploty",
-                    "ha_sensor_current_power_consumption": "ID senzoru aktu\u00e1ln\u00ed spot\u0159eby energie",
+                    "ha_sensor_indoor_temperature": "ID senzoru vnitřní teploty",
+                    "ha_sensor_current_power_consumption": "ID senzoru aktuální spotřeby energie",
                     "update_interval": "Interval aktualizace"
                 },
                 "data_description": {
-                    "ha_sensor_indoor_temperature": "Termostat pro \u0159\u00edzen\u00ed vyt\u00e1p\u011bn\u00ed je vytvo\u0159en v Home Assistant. Skute\u010dn\u00e1 teplota je nastavena senzorem Home Assistant.\nPokud je Luxtronik p\u0159ipojen k hardwarov\u00e9mu pokojov\u00e9mu termostatu, ponechte toto pole pr\u00e1zdn\u00e9.",
-                    "ha_sensor_current_power_consumption": "Pokud je vestav\u011bn\u00e9 m\u011b\u0159en\u00ed aktu\u00e1ln\u00ed spot\u0159eby energie tepeln\u00e9ho \u010derpadla nep\u0159esn\u00e9, lze pro v\u00fdpo\u010dty COP (vyt\u00e1p\u011bn\u00ed/TUV) m\u00edsto toho pou\u017e\u00edt extern\u00ed senzor v\u00fdkonu Home Assistant (nap\u0159. chytrou z\u00e1suvku). Toto nezm\u011bn\u00ed hodnotu zobrazovanou samotn\u00fdm senzorem aktu\u00e1ln\u00ed spot\u0159eby energie.\nPonechte pr\u00e1zdn\u00e9 pro pou\u017eit\u00ed vestav\u011bn\u00e9ho m\u011b\u0159en\u00ed tepeln\u00e9ho \u010derpadla.",
-                    "update_interval": "Jak \u010dasto se m\u00e1 tepeln\u00e9 \u010derpadlo dotazovat na nov\u00e1 data."
+                    "ha_sensor_indoor_temperature": "Termostat pro řízení vytápění je vytvořen v Home Assistant. Skutečná teplota je nastavena senzorem Home Assistant.\nPokud je Luxtronik připojen k hardwarovému pokojovému termostatu, ponechte toto pole prázdné.",
+                    "ha_sensor_current_power_consumption": "Pokud je vestavěné měření aktuální spotřeby energie tepelného čerpadla nepřesné, lze pro výpočty COP (vytápění/TUV) místo toho použít externí senzor výkonu Home Assistant (např. chytrou zásuvku). Toto nezmění hodnotu zobrazovanou samotným senzorem aktuální spotřeby energie.\nPonechte prázdné pro použití vestavěného měření tepelného čerpadla.",
+                    "update_interval": "Jak často se má tepelné čerpadlo dotazovat na nová data."
                 }
             }
         }
     },
     "exceptions": {
         "invalid_parameter_name": {
-            "message": "Neplatn\u00fd n\u00e1zev parametru: {parameter}"
+            "message": "Neplatný název parametru: {parameter}"
         },
         "parameter_not_writable": {
-            "message": "Parametr {parameter} odm\u00edtnut \u2014 zapisovat lze pouze parametry s p\u0159edponami {prefixes}"
+            "message": "Parametr {parameter} odmítnut — zapisovat lze pouze parametry s předponami {prefixes}"
         },
         "ambiguous_write_target": {
-            "message": "Je nakonfigurov\u00e1no v\u00edce tepeln\u00fdch \u010derpadel Luxtronik ({count} na\u010dteno) \u2014 zadejte device_id nebo config_entry_id pro v\u00fdb\u011br c\u00edle z\u00e1pisu"
+            "message": "Je nakonfigurováno více tepelných čerpadel Luxtronik ({count} načteno) — zadejte device_id nebo config_entry_id pro výběr cíle zápisu"
         },
         "invalid_write_target": {
-            "message": "Nepoda\u0159ilo se naj\u00edt na\u010dten\u00e9 tepeln\u00e9 \u010derpadlo Luxtronik pro c\u00edl {target}"
+            "message": "Nepodařilo se najít načtené tepelné čerpadlo Luxtronik pro cíl {target}"
         },
         "invalid_timer_schedule": {
-            "message": "Neplatn\u00fd \u010dasov\u00fd pl\u00e1n \"{value}\": o\u010dek\u00e1vaj\u00ed se polo\u017eky \"HH:MM-HH:MM\" odd\u011blen\u00e9 znakem \"/\", maxim\u00e1ln\u011b {max_rows} polo\u017eek"
+            "message": "Neplatný časový plán \"{value}\": očekávají se položky \"HH:MM-HH:MM\" oddělené znakem \"/\", maximálně {max_rows} položek"
         },
         "write_confirmation_mismatch": {
-            "message": "Tepeln\u00e9 \u010derpadlo Luxtronik nepotvrdilo zapsan\u00e9 hodnoty: {details}"
+            "message": "Tepelné čerpadlo Luxtronik nepotvrdilo zapsané hodnoty: {details}"
         },
         "write_confirmation_unavailable": {
-            "message": "Hodnoty {parameters} byly zaps\u00e1ny do tepeln\u00e9ho \u010derpadla Luxtronik, ale potvrzuj\u00edc\u00ed obnoven\u00ed selhalo \u2014 v\u00fdsledek nebylo mo\u017en\u00e9 potvrdit"
+            "message": "Hodnoty {parameters} byly zapsány do tepelného čerpadla Luxtronik, ale potvrzující obnovení selhalo — výsledek nebylo možné potvrdit"
         }
     },
     "issues": {
         "connection_failed": {
-            "title": "Nelze se p\u0159ipojit k tepeln\u00e9mu \u010derpadlu Luxtronik",
-            "description": "Integrace se nemohla p\u0159ipojit k tepeln\u00e9mu \u010derpadlu Luxtronik na adrese **{host}:{port}**.\n\nChyba: `{error}`\n\nZkontrolujte pros\u00edm, \u017ee je tepeln\u00e9 \u010derpadlo zapnut\u00e9, s\u00ed\u0165ov\u00e9 p\u0159ipojen\u00ed funguje a host/port jsou spr\u00e1vn\u00e9. Nastaven\u00ed p\u0159ipojen\u00ed m\u016f\u017eete aktualizovat pomoc\u00ed volby **P\u0159ekonfigurovat** v nab\u00eddce integrace."
+            "title": "Nelze se připojit k tepelnému čerpadlu Luxtronik",
+            "description": "Integrace se nemohla připojit k tepelnému čerpadlu Luxtronik na adrese **{host}:{port}**.\n\nChyba: `{error}`\n\nZkontrolujte prosím, že je tepelné čerpadlo zapnuté, síťové připojení funguje a host/port jsou správné. Nastavení připojení můžete aktualizovat pomocí volby **Překonfigurovat** v nabídce integrace."
         }
     }
 }

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -14,7 +14,7 @@
                 "name": "Verdichter 2"
             },
             "pump_flow": {
-                "name": "Soleumw\u00e4lzpumpe"
+                "name": "Soleumwälzpumpe"
             },
             "compressor_heater": {
                 "name": "Verdichterheizung"
@@ -23,22 +23,22 @@
                 "name": "Abtau Ventil"
             },
             "additional_heat_generator": {
-                "name": "Zus\u00e4tzlicher W\u00e4rmeerzeuger"
+                "name": "Zusätzlicher Wärmeerzeuger"
             },
             "additional_heat_generator2": {
-                "name": "Zus\u00e4tzlicher W\u00e4rmeerzeuger 2"
+                "name": "Zusätzlicher Wärmeerzeuger 2"
             },
             "disturbance_output": {
                 "name": "Systemzustand"
             },
             "circulation_pump_heating": {
-                "name": "Umw\u00e4lzpumpe"
+                "name": "Umwälzpumpe"
             },
             "additional_circulation_pump": {
-                "name": "Zusatzumw\u00e4lzpumpe"
+                "name": "Zusatzumwälzpumpe"
             },
             "dhw_recirculation_pump": {
-                "name": "Umw\u00e4lzpumpe"
+                "name": "Umwälzpumpe"
             },
             "dhw_circulation_pump": {
                 "name": "Zirkulationspumpe"
@@ -88,13 +88,13 @@
                 "name": "Modus Automatik"
             },
             "cooling": {
-                "name": "K\u00fchlung"
+                "name": "Kühlung"
             },
             "pump_vent_hup": {
-                "name": "Entl\u00fcften HUP"
+                "name": "Entlüften HUP"
             },
             "pump_vent_active": {
-                "name": "Entl\u00fcften aktiv"
+                "name": "Entlüften aktiv"
             },
             "smartgrid": {
                 "name": "Smart Grid"
@@ -125,7 +125,7 @@
                 "name": "Therm. Leistung max: Warmwasser"
             },
             "thermal_power_limitation_cooling": {
-                "name": "Therm. Leistung max: K\u00fchlung"
+                "name": "Therm. Leistung max: Kühlung"
             },
             "heating_threshold": {
                 "name": "Heizgrenze"
@@ -134,7 +134,7 @@
                 "name": "Ziel Korrektur"
             },
             "heating_min_flow_out_temperature": {
-                "name": "Min. Soll R\u00fccklauf"
+                "name": "Min. Soll Rücklauf"
             },
             "heating_curve_end_temperature": {
                 "name": "Heizkurve Endpunkt"
@@ -203,7 +203,7 @@
                 "name": "Maximale Pumpen Zirkulations Geschwindigkeit (Heizen)"
             },
             "heating_max_flow_out_increase_temperature": {
-                "name": "Max. Soll R\u00fccklauferh\u00f6hung"
+                "name": "Max. Soll Rücklauferhöhung"
             },
             "heating_hysteresis": {
                 "name": "Hysterese Heizungsregler"
@@ -224,34 +224,34 @@
                 "name": "Effizienzpumpe Minimal Prozent"
             },
             "cooling_threshold_temperature": {
-                "name": "minimale Au\u00dfentemperatur"
+                "name": "minimale Außentemperatur"
             },
             "cooling_start_delay_hours": {
-                "name": "Start Verz\u00f6gerung"
+                "name": "Start Verzögerung"
             },
             "cooling_stop_delay_hours": {
-                "name": "Ende Verz\u00f6gerung"
+                "name": "Ende Verzögerung"
             },
             "cooling_target_temperature_mk1": {
-                "name": "K\u00fchlung Ziel"
+                "name": "Kühlung Ziel"
             },
             "cooling_target_temperature_mk2": {
-                "name": "K\u00fchlung Ziel"
+                "name": "Kühlung Ziel"
             },
             "cooling_target_temperature_mk3": {
-                "name": "K\u00fchlung Ziel"
+                "name": "Kühlung Ziel"
             },
             "cooling_min_flow_out_temperature": {
-                "name": "K\u00fchlung minimale Vorlauftemperatur"
+                "name": "Kühlung minimale Vorlauftemperatur"
             },
             "heat_source_input_temperature_min": {
-                "name": "W\u00e4rmequelle Eingang Minimum"
+                "name": "Wärmequelle Eingang Minimum"
             },
             "heating_flow_out_temperature_target": {
-                "name": "Manuelle R\u00fccklauf Soll Temperatur"
+                "name": "Manuelle Rücklauf Soll Temperatur"
             },
             "pump_vent_timer_h": {
-                "name": "Entl\u00fcftung Laufzeit"
+                "name": "Entlüftung Laufzeit"
             },
             "extra_dhw_target_temperature": {
                 "name": "Extra Warmwasser Solltemperatur"
@@ -276,7 +276,7 @@
                     "evu": "Netzsperre",
                     "defrost": "Abtauen",
                     "heating_external_source": "Heizt aus externer Quelle",
-                    "cooling": "K\u00fchlen",
+                    "cooling": "Kühlen",
                     "no_request": "Leerlauf (keine Anforderung)"
                 }
             },
@@ -286,74 +286,74 @@
                     "evu_locked": "EVU-Sperre",
                     "reduced_operation": "abgesenkte Betriebsweise",
                     "normal_operation": "Normalbetrieb",
-                    "increased_operation": "erh\u00f6hte Betriebsweise"
+                    "increased_operation": "erhöhte Betriebsweise"
                 }
             },
             "error_reason": {
                 "name": "Letzter Fehler",
                 "state": {
-                    "701": "Niederdruckst\u00f6rung",
+                    "701": "Niederdruckstörung",
                     "702": "Niederdrucksperre - RESET automatisch",
                     "703": "Frostschutz",
-                    "704": "Heissgasst\u00f6rung - Reset automatisch nach Zeitsperre",
+                    "704": "Heissgasstörung - Reset automatisch nach Zeitsperre",
                     "705": "Motorschutz Ventilator",
-                    "706": "Motorschutz Sole- oder Brunnenwasserumw\u00e4lzpumpe",
-                    "707": "Codierung W\u00e4rmepumpe",
-                    "708": "F\u00fchler R\u00fccklauf",
-                    "709": "F\u00fchler Vorlauf",
-                    "710": "F\u00fchler Heissgas",
-                    "711": "F\u00fchler Aussentemp.",
-                    "712": "F\u00fchler Warmwasser",
-                    "713": "F\u00fchler W\u00e4rmequelle-Ein",
+                    "706": "Motorschutz Sole- oder Brunnenwasserumwälzpumpe",
+                    "707": "Codierung Wärmepumpe",
+                    "708": "Fühler Rücklauf",
+                    "709": "Fühler Vorlauf",
+                    "710": "Fühler Heissgas",
+                    "711": "Fühler Aussentemp.",
+                    "712": "Fühler Warmwasser",
+                    "713": "Fühler Wärmequelle-Ein",
                     "714": "Heissgas Brauchwasser - Reset automatisch nach Zeitsperre",
                     "715": "Hochdruck-Abschaltung - RESET automatisch",
-                    "716": "Hochdruckst\u00f6rung - Bitte Inst rufen",
-                    "717": "Durchfluss-W\u00e4rmequelle",
+                    "716": "Hochdruckstörung - Bitte Inst rufen",
+                    "717": "Durchfluss-Wärmequelle",
                     "718": "Max. Aussentemperatur - RESET automatisch",
                     "719": "Min. Aussentemperatur - RESET automatisch",
-                    "720": "W\u00e4rmequelle-Temperatur - RESET automatisch nach Zeitsperre",
+                    "720": "Wärmequelle-Temperatur - RESET automatisch nach Zeitsperre",
                     "721": "Niederdruckabschaltung - RESET automatisch",
                     "722": "Tempdiff Heizwasser",
                     "723": "Tempdiff Warmwasser",
                     "724": "Tempdiff Abtauen",
                     "725": "Anlagefehler Brauchwasser",
-                    "726": "F\u00fchler Mischkreis 1",
+                    "726": "Fühler Mischkreis 1",
                     "727": "Soledruck",
-                    "728": "F\u00fchler W\u00e4rmequelle-Aus",
+                    "728": "Fühler Wärmequelle-Aus",
                     "729": "Drehfeldfehler",
                     "730": "Leistung Ausheizen",
-                    "732": "St\u00f6rung K\u00fchlung",
-                    "733": "St\u00f6rung Anode",
-                    "734": "St\u00f6rung Anode",
-                    "735": "F\u00fchler Externe Energiequelle",
-                    "736": "F\u00fchler Solarkollektor",
-                    "737": "F\u00fchler Solarspeicher",
-                    "738": "F\u00fchler Mischkreis2",
-                    "750": "F\u00fchler R\u00fccklauf extern",
-                    "751": "Phasen\u00fcberwachungsfehler",
-                    "752": "Phasen\u00fcberwachungs / Durchflussfehler",
+                    "732": "Störung Kühlung",
+                    "733": "Störung Anode",
+                    "734": "Störung Anode",
+                    "735": "Fühler Externe Energiequelle",
+                    "736": "Fühler Solarkollektor",
+                    "737": "Fühler Solarspeicher",
+                    "738": "Fühler Mischkreis2",
+                    "750": "Fühler Rücklauf extern",
+                    "751": "Phasenüberwachungsfehler",
+                    "752": "Phasenüberwachungs / Durchflussfehler",
                     "755": "Verbindung zu Slave verloren",
                     "756": "Verbindung zu Master verloren",
-                    "757": "Niederdruck-St\u00f6rung bei Brauchwasser-Ger\u00e4t",
-                    "758": "St\u00f6rung Abtauung",
+                    "757": "Niederdruck-Störung bei Brauchwasser-Gerät",
+                    "758": "Störung Abtauung",
                     "759": "Meldung thermische Desinfektion",
-                    "760": "St\u00f6rung Abtauung",
+                    "760": "Störung Abtauung",
                     "761": "LIN-Verbindung unterbrochen",
-                    "762": "F\u00fchler Ansaug-Verdichter",
-                    "763": "F\u00fchler Ansaug-Verdampfer",
-                    "764": "F\u00fchler Verdichterheizung",
-                    "765": "\u00fcberhitzung",
+                    "762": "Fühler Ansaug-Verdichter",
+                    "763": "Fühler Ansaug-Verdampfer",
+                    "764": "Fühler Verdichterheizung",
+                    "765": "überhitzung",
                     "766": "Einsatzgrenzen-Verdichter",
                     "767": "Sicherheitstemperaturbegrenzer Heizstab",
-                    "770": "Niedrige \u00fcberhitzung",
-                    "771": "Hohe \u00fcberhitzung",
+                    "770": "Niedrige überhitzung",
+                    "771": "Hohe überhitzung",
                     "776": "Einsatzgrenzen-Verdichter",
                     "777": "Expansionsventil",
-                    "778": "F\u00fchler Niederdruck",
-                    "779": "F\u00fchler Hochdruck",
-                    "780": "F\u00fchler EVI",
-                    "781": "F\u00fchler Fl\u00fcssig, vor Ex-Ventil",
-                    "782": "F\u00fchler EVI (Enhanced Vapour Injection) Sauggas",
+                    "778": "Fühler Niederdruck",
+                    "779": "Fühler Hochdruck",
+                    "780": "Fühler EVI",
+                    "781": "Fühler Flüssig, vor Ex-Ventil",
+                    "782": "Fühler EVI (Enhanced Vapour Injection) Sauggas",
                     "783": "Kommunikation SEC-Inverter",
                     "784": "VSS gesperrt",
                     "785": "SEC-Board defekt",
@@ -365,14 +365,14 @@
                     "791": "ModBus Verbindung verloren",
                     "792": "LIN-Verbindung unterbrochen",
                     "793": "Schwerw. Inverter Fehler",
-                    "731": "Zeit\u00fcberschreitung TDI",
-                    "739": "F\u00fchler Mischkreis 3",
-                    "768": "Durchfluss\u00fcberwachung",
+                    "731": "Zeitüberschreitung TDI",
+                    "739": "Fühler Mischkreis 3",
+                    "768": "Durchflussüberwachung",
                     "769": "Pumpenansteuerung",
-                    "794": "\u00dcberspannung",
+                    "794": "Überspannung",
                     "795": "Unterspannung",
                     "796": "Sicherheitsabschaltung",
-                    "797": "MLRH wird nicht unterst\u00fctzt",
+                    "797": "MLRH wird nicht unterstützt",
                     "798": "ModBus Ventilator",
                     "799": "ModBus ASB",
                     "800": "Enthitzer-Fehler",
@@ -389,186 +389,186 @@
                     "cause": {
                         "name": "Ursache",
                         "state": {
-                            "701": "Niederdruckpressostat im K\u00e4ltekreis hat mehrmals angesprochen (LW) oder l\u00e4nger als 20 Sekunden (SW).",
-                            "702": "Nur bei L/W-Ger\u00e4ten m\u00f6glich: Niederdruck im K\u00e4ltekreis hat angesprochen. Nach einiger Zeit automatischer WP-Neuanlauf.",
-                            "703": "Nur bei L/W-Ger\u00e4ten m\u00f6glich: L\u00e4uft die W\u00e4rmepumpe und wird die Temperatur im Vorlauf < 5 \u00b0C, wird auf Frostschutz erkannt.",
-                            "704": "Maximale Temperatur im Heissgas-K\u00e4ltekreis \u00fcberschritten. Automatischer WP-Neuanlauf nach hh:mm.",
-                            "705": "Nur bei L/W-Ger\u00e4ten m\u00f6glich: Motorschutz des Ventilators hat angesprochen.",
-                            "706": "Nur bei S/W- und W/W-Ger\u00e4ten m\u00f6glich: Motorschutz der Sole- oder Brunnenwasserumw\u00e4lzpumpe oder des Verdichters hat angesprochen.",
-                            "707": "Bruch oder Kurzschluss der Kodierungsbr\u00fccke in WP nach der Ersteinschaltung.",
-                            "708": "Bruch oder Kurzschluss des R\u00fccklauff\u00fchlers.",
-                            "709": "Bruch oder Kurzschluss des Vorlauff\u00fchlers.\nKeine St\u00f6rabschaltung bei S/W- und W/W-Ger\u00e4ten.",
-                            "710": "Bruch oder Kurzschluss des Heissgasf\u00fchlers im K\u00e4ltekreis.",
-                            "711": "Bruch oder Kurzschluss des Aussentemperaturf\u00fchlers.\nKeine St\u00f6rabschaltung. Festwert auf -5 \u00b0C.",
-                            "712": "Bruch oder Kurzschluss des Warmwasserf\u00fchlers.\nKeine St\u00f6rabschaltung.",
-                            "713": "Bruch oder Kurzschluss des W\u00e4rmequellenf\u00fchlers (Eintritt).",
-                            "714": "Thermische Einsatzgrenze der WP \u00fcberschritten.\nWarmwasserbereitung gesperrt f\u00fcr hh:mm.",
-                            "715": "Hochdruckpressostat im K\u00e4ltekreis hat angesprochen. Nach einiger Zeit automatischer WP-Neuanlauf.",
-                            "716": "Hochdruckpressostat im K\u00e4ltekreis hat mehrfach angesprochen.",
-                            "717": "Durchflussschalter bei W/W-Ger\u00e4ten hat w\u00e4hrend der Vorsp\u00fclzeit oder des Betriebs angesprochen.",
-                            "718": "Nur bei L/W-Ger\u00e4ten m\u00f6glich: Aussentemperatur hat zul\u00e4ssigen Maximalwert \u00fcberschritten.",
-                            "719": "Nur bei L/W-Ger\u00e4ten m\u00f6glich: Aussentemperatur hat zul\u00e4ssigen Minimalwert unterschritten.",
-                            "720": "Nur bei S/W- und W/W-Ger\u00e4ten m\u00f6glich: Temperatur am Verdampferaustritt ist auf WQ-Seite mehrfach unter den Sicherheitswert gefallen. Automatischer WP-Neuanlauf nach hh:mm.",
-                            "721": "Niederdruckpressostat im K\u00e4ltekreis hat angesprochen. Nach einiger Zeit automatischer WP-Neuanlauf (SW und WW).",
+                            "701": "Niederdruckpressostat im Kältekreis hat mehrmals angesprochen (LW) oder länger als 20 Sekunden (SW).",
+                            "702": "Nur bei L/W-Geräten möglich: Niederdruck im Kältekreis hat angesprochen. Nach einiger Zeit automatischer WP-Neuanlauf.",
+                            "703": "Nur bei L/W-Geräten möglich: Läuft die Wärmepumpe und wird die Temperatur im Vorlauf < 5 °C, wird auf Frostschutz erkannt.",
+                            "704": "Maximale Temperatur im Heissgas-Kältekreis überschritten. Automatischer WP-Neuanlauf nach hh:mm.",
+                            "705": "Nur bei L/W-Geräten möglich: Motorschutz des Ventilators hat angesprochen.",
+                            "706": "Nur bei S/W- und W/W-Geräten möglich: Motorschutz der Sole- oder Brunnenwasserumwälzpumpe oder des Verdichters hat angesprochen.",
+                            "707": "Bruch oder Kurzschluss der Kodierungsbrücke in WP nach der Ersteinschaltung.",
+                            "708": "Bruch oder Kurzschluss des Rücklauffühlers.",
+                            "709": "Bruch oder Kurzschluss des Vorlauffühlers.\nKeine Störabschaltung bei S/W- und W/W-Geräten.",
+                            "710": "Bruch oder Kurzschluss des Heissgasfühlers im Kältekreis.",
+                            "711": "Bruch oder Kurzschluss des Aussentemperaturfühlers.\nKeine Störabschaltung. Festwert auf -5 °C.",
+                            "712": "Bruch oder Kurzschluss des Warmwasserfühlers.\nKeine Störabschaltung.",
+                            "713": "Bruch oder Kurzschluss des Wärmequellenfühlers (Eintritt).",
+                            "714": "Thermische Einsatzgrenze der WP überschritten.\nWarmwasserbereitung gesperrt für hh:mm.",
+                            "715": "Hochdruckpressostat im Kältekreis hat angesprochen. Nach einiger Zeit automatischer WP-Neuanlauf.",
+                            "716": "Hochdruckpressostat im Kältekreis hat mehrfach angesprochen.",
+                            "717": "Durchflussschalter bei W/W-Geräten hat während der Vorspülzeit oder des Betriebs angesprochen.",
+                            "718": "Nur bei L/W-Geräten möglich: Aussentemperatur hat zulässigen Maximalwert überschritten.",
+                            "719": "Nur bei L/W-Geräten möglich: Aussentemperatur hat zulässigen Minimalwert unterschritten.",
+                            "720": "Nur bei S/W- und W/W-Geräten möglich: Temperatur am Verdampferaustritt ist auf WQ-Seite mehrfach unter den Sicherheitswert gefallen. Automatischer WP-Neuanlauf nach hh:mm.",
+                            "721": "Niederdruckpressostat im Kältekreis hat angesprochen. Nach einiger Zeit automatischer WP-Neuanlauf (SW und WW).",
                             "722": "Temperaturspreizung im Heizbetrieb ist negativ (=fehlerhaft).",
                             "723": "Temperaturspreizung im Warmwasserbetrieb ist negativ (=fehlerhaft).",
-                            "724": "Temperaturspreizung im Heizkreis ist w\u00e4hrend des Abtauens > 15 K (=Frostgefahr).",
-                            "725": "Warmwasserbetrieb gest\u00f6rt, gew\u00fcnschte Speichertemperatur ist weit unterschritten.",
-                            "726": "Bruch oder Kurzschluss des Mischkreisf\u00fchlers.",
-                            "727": "Soledruckpressostat hat w\u00e4hrend Vorsp\u00fclzeit oder w\u00e4hrend des Betriebs angesprochen.",
-                            "728": "Bruch oder Kurzschluss des W\u00e4rmequellenf\u00fchlers am WQ-Austritt.",
+                            "724": "Temperaturspreizung im Heizkreis ist während des Abtauens > 15 K (=Frostgefahr).",
+                            "725": "Warmwasserbetrieb gestört, gewünschte Speichertemperatur ist weit unterschritten.",
+                            "726": "Bruch oder Kurzschluss des Mischkreisfühlers.",
+                            "727": "Soledruckpressostat hat während Vorspülzeit oder während des Betriebs angesprochen.",
+                            "728": "Bruch oder Kurzschluss des Wärmequellenfühlers am WQ-Austritt.",
                             "729": "Verdichter nach dem Einschalten ohne Leistung.",
-                            "730": "Das Ausheizprogramm konnte eine VL-Temperaturstufe nicht im vorgegebenen Zeitintervall erreichen. Ausheizprogramm l\u00e4uft weiter.",
-                            "732": "Die Heizwassertemperatur von 16 \u00b0C wurde mehrfach unterschritten.",
-                            "733": "St\u00f6rmeldeeingang der Fremdstromanode hat angesprochen.",
+                            "730": "Das Ausheizprogramm konnte eine VL-Temperaturstufe nicht im vorgegebenen Zeitintervall erreichen. Ausheizprogramm läuft weiter.",
+                            "732": "Die Heizwassertemperatur von 16 °C wurde mehrfach unterschritten.",
+                            "733": "Störmeldeeingang der Fremdstromanode hat angesprochen.",
                             "734": "Fehler 733 liegt seit mehr als zwei Wochen an und Warmwasserbereitung ist gesperrt.",
-                            "735": "Nur bei eingebauter Comfort-/Erweiterungs-Platine m\u00f6glich: Bruch oder Kurzschluss des F\u00fchlers Externe Energiequelle.",
-                            "736": "Nur bei eingebauter Comfort-/Erweiterungs-Platine m\u00f6glich: Bruch oder Kurzschluss des F\u00fchlers Solarkollektor.",
-                            "737": "Nur bei eingebauter Comfort-/Erweiterungs-Platine m\u00f6glich: Bruch oder Kurzschluss des F\u00fchlers Solarspeicher.",
-                            "738": "Nur bei eingebauter Comfort-/Erweiterungs-Platine m\u00f6glich: Bruch oder Kurzschluss des F\u00fchlers Mischkreis2.",
-                            "750": "Bruch oder Kurzschluss des externen R\u00fccklauff\u00fchlers.",
+                            "735": "Nur bei eingebauter Comfort-/Erweiterungs-Platine möglich: Bruch oder Kurzschluss des Fühlers Externe Energiequelle.",
+                            "736": "Nur bei eingebauter Comfort-/Erweiterungs-Platine möglich: Bruch oder Kurzschluss des Fühlers Solarkollektor.",
+                            "737": "Nur bei eingebauter Comfort-/Erweiterungs-Platine möglich: Bruch oder Kurzschluss des Fühlers Solarspeicher.",
+                            "738": "Nur bei eingebauter Comfort-/Erweiterungs-Platine möglich: Bruch oder Kurzschluss des Fühlers Mischkreis2.",
+                            "750": "Bruch oder Kurzschluss des externen Rücklauffühlers.",
                             "751": "Phasenfolgerelais hat angesprochen.",
                             "752": "Phasenfolgerelais oder Durchflussschalter hat angesprochen.",
-                            "755": "Ein Slave hat f\u00fcr mehr als 5 Minuten nicht geantwortet.",
-                            "756": "Ein Master hat f\u00fcr mehr als 5 Minuten nicht geantwortet.",
-                            "757": "Niederdruckpressostat bei WW-Ger\u00e4t hat mehrmals oder l\u00e4nger als 20 Sekunden angesprochen.",
-                            "758": "Die Abtauung wurde 5mal in Folge \u00fcber zu niedrige Vorlauftemperatur beendet.",
-                            "759": "Thermische Desinfektion konnte 3mal in Folge nicht korrekt durchgef\u00fchrt werden.",
-                            "760": "Abtauung wurde 5mal in Folge \u00fcber Maximalzeit beendet (starker Wind trifft auf Verdampfer).",
+                            "755": "Ein Slave hat für mehr als 5 Minuten nicht geantwortet.",
+                            "756": "Ein Master hat für mehr als 5 Minuten nicht geantwortet.",
+                            "757": "Niederdruckpressostat bei WW-Gerät hat mehrmals oder länger als 20 Sekunden angesprochen.",
+                            "758": "Die Abtauung wurde 5mal in Folge über zu niedrige Vorlauftemperatur beendet.",
+                            "759": "Thermische Desinfektion konnte 3mal in Folge nicht korrekt durchgeführt werden.",
+                            "760": "Abtauung wurde 5mal in Folge über Maximalzeit beendet (starker Wind trifft auf Verdampfer).",
                             "761": "LIN-Timeout",
-                            "762": "F\u00fchlerfehler T\u00fc (Ansaug Verdichter).",
-                            "763": "F\u00fchlerfehler T\u00fc1 (Ansaug Verdampfer).",
-                            "764": "F\u00fchlerfehler Verdichterheizung.",
-                            "765": "\u00dcberhitzung l\u00e4nger als 5 Minuten unter 2K.",
-                            "766": "Betrieb 5 Minuten au\u00dferhalb des Einsatzbereichs des Verdichters.",
+                            "762": "Fühlerfehler Tü (Ansaug Verdichter).",
+                            "763": "Fühlerfehler Tü1 (Ansaug Verdampfer).",
+                            "764": "Fühlerfehler Verdichterheizung.",
+                            "765": "Überhitzung länger als 5 Minuten unter 2K.",
+                            "766": "Betrieb 5 Minuten außerhalb des Einsatzbereichs des Verdichters.",
                             "767": "STB des Heizstabs am SEC wurde aktiviert.",
-                            "770": "\u00dcberhitzung liegt \u00fcber einen l\u00e4ngeren Zeitraum unter dem Grenzwert.",
-                            "771": "\u00dcberhitzung liegt \u00fcber einen l\u00e4ngeren Zeitraum \u00fcber dem Grenzwert.",
-                            "776": "Verdichter arbeitet \u00fcber l\u00e4ngeren Zeitraum au\u00dferhalb seiner Einsatzgrenzen.",
+                            "770": "Überhitzung liegt über einen längeren Zeitraum unter dem Grenzwert.",
+                            "771": "Überhitzung liegt über einen längeren Zeitraum über dem Grenzwert.",
+                            "776": "Verdichter arbeitet über längeren Zeitraum außerhalb seiner Einsatzgrenzen.",
                             "777": "Expansionsventil defekt.",
-                            "778": "Niederdruckf\u00fchler defekt.",
-                            "779": "Hochdruckf\u00fchler defekt.",
-                            "780": "EVI-F\u00fchler defekt.",
-                            "781": "Temperaturf\u00fchler Fl\u00fcssig vor Ex-Ventil defekt.",
-                            "782": "Temperaturf\u00fchler EVI Sauggas defekt.",
-                            "783": "Kommunikation zwischen SEC u. Inverter gest\u00f6rt",
+                            "778": "Niederdruckfühler defekt.",
+                            "779": "Hochdruckfühler defekt.",
+                            "780": "EVI-Fühler defekt.",
+                            "781": "Temperaturfühler Flüssig vor Ex-Ventil defekt.",
+                            "782": "Temperaturfühler EVI Sauggas defekt.",
+                            "783": "Kommunikation zwischen SEC u. Inverter gestört",
                             "784": "Inverter gesperrt",
                             "785": "Fehler im SEC Board festgestellt.",
-                            "786": "St\u00f6rung der Kommunikation zwischen SEC und HZIO von SEC festgestellt.",
+                            "786": "Störung der Kommunikation zwischen SEC und HZIO von SEC festgestellt.",
                             "787": "Verdichter meldet Fehler.",
                             "788": "Fehler im Inverter",
                             "789": "Bedienteil konnte keine Kodierung feststellen. Entweder ist die LIN-Verbindung unterbrochen oder der Kodierungswiderstand wird nicht erkannt.",
                             "790": "Fehler in der Stromversorgung des Inverters / Verdichters.",
-                            "791": "SEC-Board seit einiger Zeit nicht mehr erreichbar. 791 wird ausgel\u00f6st, wenn zwar eine HZIO-Platine gefunden worden ist (ohne separate Kodierung), allerdings kein SEC-Board daran erkannt werden kann.",
+                            "791": "SEC-Board seit einiger Zeit nicht mehr erreichbar. 791 wird ausgelöst, wenn zwar eine HZIO-Platine gefunden worden ist (ohne separate Kodierung), allerdings kein SEC-Board daran erkannt werden kann.",
                             "792": "Es konnte keine Grundplatine und auch sonst keine Konfiguration gefunden werden.",
                             "793": "Temperaturfehler im Inverter",
                             "minus_1": "Unbekannter Fehler",
-                            "731": "Die f\u00fcr die thermische Desinfektion n\u00f6tige Temperatur konnte innerhalb der eingestellten Schaltzeiten nicht erreicht werden.",
-                            "739": "Bruch oder Kurzschlu\u00df des F\u00fchlers \u201eMischkreis3\u201c.",
+                            "731": "Die für die thermische Desinfektion nötige Temperatur konnte innerhalb der eingestellten Schaltzeiten nicht erreicht werden.",
+                            "739": "Bruch oder Kurzschluß des Fühlers „Mischkreis3“.",
                             "768": "5mal in Folge zu geringer Durchfluss vor der Abtauung.",
-                            "769": "Kein g\u00fcltiges Durchflusssignal von der Umw\u00e4lzpumpe. Reset automatisch.",
-                            "794": "\u00dcberspannung am Inverter.",
+                            "769": "Kein gültiges Durchflusssignal von der Umwälzpumpe. Reset automatisch.",
+                            "794": "Überspannung am Inverter.",
                             "795": "Unterspannung am Inverter.",
-                            "796": "Safety Input wurde ausgel\u00f6st. Fall 1: Inverterst\u00f6rung. Reset automatisch. Fall 2: Hochdruckpressostaten im K\u00e4ltekreis hat ausgel\u00f6st. Reset automatisch. Fall 3: Nur LADV St\u00f6rmeldung durch Spannungsschwankungen au\u00dferhalb der g\u00fcltigen Norm.",
-                            "797": "Heizstabregelung wird nicht unterst\u00fctzt.",
+                            "796": "Safety Input wurde ausgelöst. Fall 1: Inverterstörung. Reset automatisch. Fall 2: Hochdruckpressostaten im Kältekreis hat ausgelöst. Reset automatisch. Fall 3: Nur LADV Störmeldung durch Spannungsschwankungen außerhalb der gültigen Norm.",
+                            "797": "Heizstabregelung wird nicht unterstützt.",
                             "798": "Mindestens 10 Sekunden keine ModBus-Kommunikation zum Ventilator. Reset automatisch.",
                             "799": "Mindestens 10 Sekunden keine ModBus-Kommunikation mit der ASB-Platine. Reset automatisch.",
-                            "800": "Abschaltung wird ausgel\u00f6st, wenn Enthitzer-Temperatur \u2265 80\u00b0C. Ger\u00e4t wird abgeschaltet und es wird D0_Pause in Abschaltungen geschrieben. Ger\u00e4t wird nach 2 Stunden wieder f\u00fcr den Betrieb freigegeben. Tritt die Abschaltung 5 mal innerhalb von 24 Stunden auf, wird Fehler 800 in den Fehlerspeicher geschrieben.",
-                            "802": "Abschaltung wird ausgel\u00f6st, wenn Temperatur im elektrischen Schaltkasten \u2265 80\u00b0C. F\u00e4llt die Temperatur unter 70\u00b0C, l\u00e4uft die W\u00e4rmepumpe wieder an. Reset automatisch.",
-                            "803": "Fehler 802 hat 3 mal innerhalb von 24h ausgel\u00f6st. Reset manuell erforderlich. Ist die Temperatur im elektrischen Schaltkasten noch \u2265 80\u00b0C, wird der Fehler sofort wieder ausgel\u00f6st.",
+                            "800": "Abschaltung wird ausgelöst, wenn Enthitzer-Temperatur ≥ 80°C. Gerät wird abgeschaltet und es wird D0_Pause in Abschaltungen geschrieben. Gerät wird nach 2 Stunden wieder für den Betrieb freigegeben. Tritt die Abschaltung 5 mal innerhalb von 24 Stunden auf, wird Fehler 800 in den Fehlerspeicher geschrieben.",
+                            "802": "Abschaltung wird ausgelöst, wenn Temperatur im elektrischen Schaltkasten ≥ 80°C. Fällt die Temperatur unter 70°C, läuft die Wärmepumpe wieder an. Reset automatisch.",
+                            "803": "Fehler 802 hat 3 mal innerhalb von 24h ausgelöst. Reset manuell erforderlich. Ist die Temperatur im elektrischen Schaltkasten noch ≥ 80°C, wird der Fehler sofort wieder ausgelöst.",
                             "806": "SEC-Platine hat seit mindestens 10 Sekunden keine ModBus-Kommunikation oder Abfrage ist 10 mal hintereinander fehlgeschlagen. Reset automatisch.",
-                            "807": "Alle f\u00fcr das jeweilige Ger\u00e4t m\u00f6glichen ModBus-Kommunikationsst\u00f6rungen mit Ger\u00e4tekomponenten liegen f\u00fcr mindestens 10 Sekunden gleichzeitig an. Reset automatisch."
+                            "807": "Alle für das jeweilige Gerät möglichen ModBus-Kommunikationsstörungen mit Gerätekomponenten liegen für mindestens 10 Sekunden gleichzeitig an. Reset automatisch."
                         }
                     },
                     "remedy": {
                         "name": "Abhilfe",
                         "state": {
-                            "701": "WP auf Leckage, Schaltpunkt Pressostat, Abtauung und TA-min \u00fcberpr\u00fcfen.",
-                            "702": "WP auf Leckage, Schaltpunkt Pressostat, Abtauung und TA-min \u00fcberpr\u00fcfen.",
-                            "703": "WP-Leistung, Abtauventil und Heizanlage \u00fcberpr\u00fcfen.",
-                            "704": "K\u00e4ltemittelmenge, Verdampfung, \u00dcberhitzung Vorlauf, R\u00fccklauf und WQ-min \u00fcberpr\u00fcfen.",
-                            "705": "Ventilator \u00fcberpr\u00fcfen.",
-                            "706": "Eingestellte Werte, Verdichter, BOSUP \u00fcberpr\u00fcfen.",
-                            "707": "Kodierungswiderstand in WP, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "708": "R\u00fccklauff\u00fchler, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "709": "Vorlauff\u00fchler, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "710": "Heissgasf\u00fchler, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "711": "Aussentemperaturf\u00fchler, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "712": "Warmwasserf\u00fchler, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "713": "W\u00e4rmequellenf\u00fchler, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen",
-                            "714": "Durchfluss Warmwasser, W\u00e4rmetauscher, Warmwasser-Temperatur und Umw\u00e4lzpumpe Warmwasser \u00fcberpr\u00fcfen.",
-                            "715": "Durchfluss HW, \u00fcberstr\u00f6mer, Temperatur und Kondensation \u00fcberpr\u00fcfen.",
-                            "716": "Durchfluss HW, \u00fcberstr\u00f6mer, Temperatur und Kondensation \u00fcberpr\u00fcfen.",
-                            "717": "Durchfluss, Schaltpunkt DFS, Filter, Luftfreiheit \u00fcberpr\u00fcfen",
-                            "718": "Aussentemperatur und eingestellten Wert \u00fcberpr\u00fcfen.",
-                            "719": "Aussentemperatur und eingestellten Wert \u00fcberpr\u00fcfen.",
-                            "720": "Durchfluss, Filter, Luftfreiheit, Temperatur \u00fcberpr\u00fcfen.",
-                            "721": "Schaltpunkt Pressostat, Durchfluss WQ-Seite \u00fcberpr\u00fcfen.",
-                            "722": "Funktion und Platzierung der Vor- und R\u00fccklauff\u00fchler \u00fcberpr\u00fcfen.",
-                            "723": "Funktion und Platzierung der Vor- und R\u00fccklauff\u00fchler \u00fcberpr\u00fcfen.",
-                            "724": "Funktion und Platzierung der Vor- und R\u00fccklauff\u00fchler, F\u00f6rderleistung HUP, \u00fcberstr\u00f6mer und Heizkreise \u00fcberpr\u00fcfen.",
-                            "725": "Umw\u00e4lzpumpe WW, Speicherf\u00fcllung, Absperrschieber und 3-Wege-Ventil \u00fcberpr\u00fcfen. Heizwasser und WW entl\u00fcften.",
-                            "726": "Mischkreisf\u00fchler, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "727": "Soledruck und Soledruckpressostat \u00fcberpr\u00fcfen.",
-                            "728": "W\u00e4rmequellenf\u00fchler, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "729": "Drehfeld und Verdichter \u00fcberpr\u00fcfen.",
-                            "730": "Leistungsbedarf w\u00e4hrend des Ausheizens \u00fcberpr\u00fcfen.",
-                            "732": "Mischer und Heizungsumw\u00e4lzpumpe \u00fcberpr\u00fcfen.",
-                            "733": "Verbindungsleitung Anode und Potenziostat \u00fcberpr\u00fcfen. WW-Speicher f\u00fcllen.",
-                            "734": "Fehler vor\u00fcbergehend quittieren, um Warmwasserbereitung wieder freizugeben. Fehler 733 beheben.",
-                            "735": "F\u00fchler Externe Energiequelle, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "736": "F\u00fchler Solarkollektor, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "737": "F\u00fchler Solarspeicher, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "738": "F\u00fchler Mischkreis2, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "750": "Externer R\u00fccklauff\u00fchler, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "751": "\u00fcberpr\u00fcfung Drehfeld und Phasenfolgerelais.",
+                            "701": "WP auf Leckage, Schaltpunkt Pressostat, Abtauung und TA-min überprüfen.",
+                            "702": "WP auf Leckage, Schaltpunkt Pressostat, Abtauung und TA-min überprüfen.",
+                            "703": "WP-Leistung, Abtauventil und Heizanlage überprüfen.",
+                            "704": "Kältemittelmenge, Verdampfung, Überhitzung Vorlauf, Rücklauf und WQ-min überprüfen.",
+                            "705": "Ventilator überprüfen.",
+                            "706": "Eingestellte Werte, Verdichter, BOSUP überprüfen.",
+                            "707": "Kodierungswiderstand in WP, Stecker und Verbindungsleitung überprüfen.",
+                            "708": "Rücklauffühler, Stecker und Verbindungsleitung überprüfen.",
+                            "709": "Vorlauffühler, Stecker und Verbindungsleitung überprüfen.",
+                            "710": "Heissgasfühler, Stecker und Verbindungsleitung überprüfen.",
+                            "711": "Aussentemperaturfühler, Stecker und Verbindungsleitung überprüfen.",
+                            "712": "Warmwasserfühler, Stecker und Verbindungsleitung überprüfen.",
+                            "713": "Wärmequellenfühler, Stecker und Verbindungsleitung überprüfen",
+                            "714": "Durchfluss Warmwasser, Wärmetauscher, Warmwasser-Temperatur und Umwälzpumpe Warmwasser überprüfen.",
+                            "715": "Durchfluss HW, überströmer, Temperatur und Kondensation überprüfen.",
+                            "716": "Durchfluss HW, überströmer, Temperatur und Kondensation überprüfen.",
+                            "717": "Durchfluss, Schaltpunkt DFS, Filter, Luftfreiheit überprüfen",
+                            "718": "Aussentemperatur und eingestellten Wert überprüfen.",
+                            "719": "Aussentemperatur und eingestellten Wert überprüfen.",
+                            "720": "Durchfluss, Filter, Luftfreiheit, Temperatur überprüfen.",
+                            "721": "Schaltpunkt Pressostat, Durchfluss WQ-Seite überprüfen.",
+                            "722": "Funktion und Platzierung der Vor- und Rücklauffühler überprüfen.",
+                            "723": "Funktion und Platzierung der Vor- und Rücklauffühler überprüfen.",
+                            "724": "Funktion und Platzierung der Vor- und Rücklauffühler, Förderleistung HUP, überströmer und Heizkreise überprüfen.",
+                            "725": "Umwälzpumpe WW, Speicherfüllung, Absperrschieber und 3-Wege-Ventil überprüfen. Heizwasser und WW entlüften.",
+                            "726": "Mischkreisfühler, Stecker und Verbindungsleitung überprüfen.",
+                            "727": "Soledruck und Soledruckpressostat überprüfen.",
+                            "728": "Wärmequellenfühler, Stecker und Verbindungsleitung überprüfen.",
+                            "729": "Drehfeld und Verdichter überprüfen.",
+                            "730": "Leistungsbedarf während des Ausheizens überprüfen.",
+                            "732": "Mischer und Heizungsumwälzpumpe überprüfen.",
+                            "733": "Verbindungsleitung Anode und Potenziostat überprüfen. WW-Speicher füllen.",
+                            "734": "Fehler vorübergehend quittieren, um Warmwasserbereitung wieder freizugeben. Fehler 733 beheben.",
+                            "735": "Fühler Externe Energiequelle, Stecker und Verbindungsleitung überprüfen.",
+                            "736": "Fühler Solarkollektor, Stecker und Verbindungsleitung überprüfen.",
+                            "737": "Fühler Solarspeicher, Stecker und Verbindungsleitung überprüfen.",
+                            "738": "Fühler Mischkreis2, Stecker und Verbindungsleitung überprüfen.",
+                            "750": "Externer Rücklauffühler, Stecker und Verbindungsleitung überprüfen.",
+                            "751": "überprüfung Drehfeld und Phasenfolgerelais.",
                             "752": "siehe Fehler Nr. 751 und Nr. 717",
-                            "755": "Netzwerkverbindung, Switch und IPAdressen pr\u00fcfen. Gegebenenfalls WP-Suche erneut ausf\u00fchren.",
-                            "756": "Netzwerkverbindung, Switch und IPAdressen pr\u00fcfen. Gegebenenfalls WP-Suche erneut ausf\u00fchren.",
-                            "757": "Bei 3maligem Auftreten dieser St\u00f6rung kann die Anlage nur vom authorisierten Servicepersonal freigeschaltet werden!",
-                            "758": "Durchfluss und Vorlaufsensor pr\u00fcfen",
-                            "759": "Einstellung Zweiter W\u00e4rmeerzeuger und Sicherheitstemperaturbegrenzer pr\u00fcfen",
-                            "760": "Ventilator und Verdampfer vor starkem Wind sch\u00fctzen",
-                            "761": "Kabel/Kontakt pr\u00fcfen",
-                            "762": "F\u00fchler pr\u00fcfen, evtl. tauschen",
-                            "763": "F\u00fchler pr\u00fcfen, evtl. tauschen",
-                            "764": "F\u00fchler pr\u00fcfen, evtl. tauschen",
-                            "765": "Bei Ersteinschaltung. Drehfeld pr\u00fcfen, sonst Kundendienst rufen",
-                            "766": "Drehfeld pr\u00fcfen",
-                            "767": "Heizstab \u00fcberpr\u00fcfen und Sicherung wieder reindr\u00fccken",
-                            "770": "Temperaturf\u00fchler, Drucksensor und Expansionsventil pr\u00fcfen",
-                            "771": "Temperaturf\u00fchler, Drucksensor, F\u00fcllmenge und Expansionsventil pr\u00fcfen",
-                            "776": "Thermodynamik pr\u00fcfen",
-                            "777": "Expansionsventil, Verbindungskabel und ggf. SEC-Board pr\u00fcfen",
-                            "778": "Sensor, Stecker und Verbindungsleitung pr\u00fcfen",
-                            "779": "Sensor, Stecker und Verbindungsleitung pr\u00fcfen",
-                            "780": "Sensor, Stecker und Verbindungsleitung pr\u00fcfen",
-                            "781": "Sensor, Stecker und Verbindungsleitung pr\u00fcfen",
-                            "782": "Sensor, Stecker und Verbindungsleitung pr\u00fcfen",
-                            "783": "Verbindungskabel, Entst\u00f6rkondensatoren und Verkabelung pr\u00fcfen",
-                            "784": "Komplette Anlage 2 Minuten lang spannungslos schalten. Bei wiederholtem Auftreten Inverter und Verdichter pr\u00fcfen",
+                            "755": "Netzwerkverbindung, Switch und IPAdressen prüfen. Gegebenenfalls WP-Suche erneut ausführen.",
+                            "756": "Netzwerkverbindung, Switch und IPAdressen prüfen. Gegebenenfalls WP-Suche erneut ausführen.",
+                            "757": "Bei 3maligem Auftreten dieser Störung kann die Anlage nur vom authorisierten Servicepersonal freigeschaltet werden!",
+                            "758": "Durchfluss und Vorlaufsensor prüfen",
+                            "759": "Einstellung Zweiter Wärmeerzeuger und Sicherheitstemperaturbegrenzer prüfen",
+                            "760": "Ventilator und Verdampfer vor starkem Wind schützen",
+                            "761": "Kabel/Kontakt prüfen",
+                            "762": "Fühler prüfen, evtl. tauschen",
+                            "763": "Fühler prüfen, evtl. tauschen",
+                            "764": "Fühler prüfen, evtl. tauschen",
+                            "765": "Bei Ersteinschaltung. Drehfeld prüfen, sonst Kundendienst rufen",
+                            "766": "Drehfeld prüfen",
+                            "767": "Heizstab überprüfen und Sicherung wieder reindrücken",
+                            "770": "Temperaturfühler, Drucksensor und Expansionsventil prüfen",
+                            "771": "Temperaturfühler, Drucksensor, Füllmenge und Expansionsventil prüfen",
+                            "776": "Thermodynamik prüfen",
+                            "777": "Expansionsventil, Verbindungskabel und ggf. SEC-Board prüfen",
+                            "778": "Sensor, Stecker und Verbindungsleitung prüfen",
+                            "779": "Sensor, Stecker und Verbindungsleitung prüfen",
+                            "780": "Sensor, Stecker und Verbindungsleitung prüfen",
+                            "781": "Sensor, Stecker und Verbindungsleitung prüfen",
+                            "782": "Sensor, Stecker und Verbindungsleitung prüfen",
+                            "783": "Verbindungskabel, Entstörkondensatoren und Verkabelung prüfen",
+                            "784": "Komplette Anlage 2 Minuten lang spannungslos schalten. Bei wiederholtem Auftreten Inverter und Verdichter prüfen",
                             "785": "SEC Board austauschen",
-                            "786": "Kabelverbindung HZ/IO SEC-Board pr\u00fcfen",
-                            "787": "St\u00f6rung quittieren. Falls Fehler mehrfach auftritt, autorisiertes Servicepersonal (= Kundendienst) rufen",
-                            "788": "Inverter pr\u00fcfen",
-                            "789": "Verbindungskabel LIN / Kodierwiderstand pr\u00fcfen",
-                            "790": "Verkabelung, Inverter und Verdichter pr\u00fcfen",
-                            "791": "Sofern es sich um die SECKonfiguration handelt, das ModBus-Kabel zwischen HZIO und SEC Board pr\u00fcfen. Ebenso das SEC-Board pr\u00fcfen, ob alles blinkt, wie es soll. Falls es KEINE Konfiguration mit SEC-Board ist (z.B., weil es sich um ein P184-Ger\u00e4t handelt), dann den Kodierungswiderstand der HZIO pr\u00fcfen.",
-                            "792": "Kodierungsstecker auf LINPlatine(n) pr\u00fcfen",
+                            "786": "Kabelverbindung HZ/IO SEC-Board prüfen",
+                            "787": "Störung quittieren. Falls Fehler mehrfach auftritt, autorisiertes Servicepersonal (= Kundendienst) rufen",
+                            "788": "Inverter prüfen",
+                            "789": "Verbindungskabel LIN / Kodierwiderstand prüfen",
+                            "790": "Verkabelung, Inverter und Verdichter prüfen",
+                            "791": "Sofern es sich um die SECKonfiguration handelt, das ModBus-Kabel zwischen HZIO und SEC Board prüfen. Ebenso das SEC-Board prüfen, ob alles blinkt, wie es soll. Falls es KEINE Konfiguration mit SEC-Board ist (z.B., weil es sich um ein P184-Gerät handelt), dann den Kodierungswiderstand der HZIO prüfen.",
+                            "792": "Kodierungsstecker auf LINPlatine(n) prüfen",
                             "793": "Fehler behebt sich selbst",
-                            "739": "F\u00fchler \u201eMischkreis3\u201c, Stecker und Verbindungsleitung \u00fcberpr\u00fcfen.",
-                            "768": "Durchfluss HW und \u00dcberstr\u00f6mer \u00fcberpr\u00fcfen. Fehler beheben.",
-                            "769": "Verkabelung Last und Steuerung der Umw\u00e4lzpumpe \u00fcberpr\u00fcfen. Fehler beheben.",
-                            "794": "Spannungsversorgung Inverter pr\u00fcfen.",
-                            "795": "Spannungsversorgung Inverter pr\u00fcfen.",
-                            "796": "Fall 1: Inverter \u00fcberpr\u00fcfen. Fehler beheben. Fall 2: Durchfluss HW, \u00dcberstr\u00f6mer, Vorlauftemperaturf\u00fchler und Hochdrucksensor \u00fcberpr\u00fcfen. Fehler beheben. Fall 3: Es muss manuell aus- und wieder eingesichert werden.",
-                            "798": "Modbus Verkabelung Ventilator pr\u00fcfen.",
-                            "799": "Modbus Verkabelung ASB-Platine pr\u00fcfen.",
-                            "800": "Energie aus Enthitzer-Speicher abnehmen. Sobald die Temperatur < 80\u00b0C f\u00e4llt, kann die Maschine wieder gestartet werden.",
-                            "802": "Ventilator auf Funktion pr\u00fcfen. Anschlusskabel pr\u00fcfen. F\u00fchler pr\u00fcfen. Schaltraum\u00f6ffnungen auf Verstopfung pr\u00fcfen.",
-                            "803": "Ventilator auf Funktion pr\u00fcfen. Anschlusskabel pr\u00fcfen. F\u00fchler pr\u00fcfen. Schaltraum\u00f6ffnungen auf Verstopfung pr\u00fcfen.",
-                            "806": "Modbus Verkabelung SEC Platine pr\u00fcfen.",
-                            "807": "ModBus-Schnittstelle am Bedienteil, Verbindungskabel zum ModBus-Verteiler sowie ModBus-Verteiler pr\u00fcfen. Modbus Verkabelung pr\u00fcfen."
+                            "739": "Fühler „Mischkreis3“, Stecker und Verbindungsleitung überprüfen.",
+                            "768": "Durchfluss HW und Überströmer überprüfen. Fehler beheben.",
+                            "769": "Verkabelung Last und Steuerung der Umwälzpumpe überprüfen. Fehler beheben.",
+                            "794": "Spannungsversorgung Inverter prüfen.",
+                            "795": "Spannungsversorgung Inverter prüfen.",
+                            "796": "Fall 1: Inverter überprüfen. Fehler beheben. Fall 2: Durchfluss HW, Überströmer, Vorlauftemperaturfühler und Hochdrucksensor überprüfen. Fehler beheben. Fall 3: Es muss manuell aus- und wieder eingesichert werden.",
+                            "798": "Modbus Verkabelung Ventilator prüfen.",
+                            "799": "Modbus Verkabelung ASB-Platine prüfen.",
+                            "800": "Energie aus Enthitzer-Speicher abnehmen. Sobald die Temperatur < 80°C fällt, kann die Maschine wieder gestartet werden.",
+                            "802": "Ventilator auf Funktion prüfen. Anschlusskabel prüfen. Fühler prüfen. Schaltraumöffnungen auf Verstopfung prüfen.",
+                            "803": "Ventilator auf Funktion prüfen. Anschlusskabel prüfen. Fühler prüfen. Schaltraumöffnungen auf Verstopfung prüfen.",
+                            "806": "Modbus Verkabelung SEC Platine prüfen.",
+                            "807": "ModBus-Schnittstelle am Bedienteil, Verbindungskabel zum ModBus-Verteiler sowie ModBus-Verteiler prüfen. Modbus Verkabelung prüfen."
                         }
                     }
                 }
@@ -576,30 +576,30 @@
             "switchoff_reason": {
                 "name": "Abschaltung",
                 "state": {
-                    "0": "W\u00e4rmepumpe St\u00f6rung",
-                    "1": "Anlagen St\u00f6rung",
-                    "2": "Betriebsart Zweiter W\u00e4rmeerzeuger",
+                    "0": "Wärmepumpe Störung",
+                    "1": "Anlagen Störung",
+                    "2": "Betriebsart Zweiter Wärmeerzeuger",
                     "3": "EVU-Sperre",
                     "4": "",
-                    "5": "Lauftabtau (nur LW-Ger\u00e4te)",
+                    "5": "Lauftabtau (nur LW-Geräte)",
                     "6": "Temperatur Einsatzgrenze maximal",
                     "7": "Temperatur Einsatzgrenze minimal",
                     "8": "Untere Einsatzgrenze",
                     "9": "Keine Anforderung",
                     "10": "Externe Energiequelle",
-                    "11": "Durchfluss-W\u00e4rmequelle",
+                    "11": "Durchfluss-Wärmequelle",
                     "12": "Niederdruck-Pause",
-                    "13": "\u00dcberhitzungs-Pause",
+                    "13": "Überhitzungs-Pause",
                     "14": "Inverter-Pause",
                     "15": "Enthitzer-Pause",
                     "16": "Betriebsart Umschaltung",
                     "17": "Sonstige Abschaltung",
-                    "18": "Mindestdurchfluss K\u00fchlung",
+                    "18": "Mindestdurchfluss Kühlung",
                     "19": "PV max",
-                    "20": "Hei\u00dfgas-Pause",
-                    "21": "\u00dcberhitzung Hei\u00dfgas-Pause",
+                    "20": "Heißgas-Pause",
+                    "21": "Überhitzung Heißgas-Pause",
                     "22": "Keine Anforderung",
-                    "23": "Minimale W\u00e4rmequellen-Austrittstemperatur K\u00fchlung",
+                    "23": "Minimale Wärmequellen-Austrittstemperatur Kühlung",
                     "24": "LPC",
                     "25": "Neustart",
                     "27": "Vorlauf max."
@@ -611,30 +611,30 @@
                     "code_1": {
                         "name": "Vorletze Abschaltung",
                         "state": {
-                            "0": "W\u00e4rmepumpe St\u00f6rung",
-                            "1": "Anlagen St\u00f6rung",
-                            "2": "Betriebsart Zweiter W\u00e4rmeerzeuger",
+                            "0": "Wärmepumpe Störung",
+                            "1": "Anlagen Störung",
+                            "2": "Betriebsart Zweiter Wärmeerzeuger",
                             "3": "EVU-Sperre",
                             "4": "",
-                            "5": "Lauftabtau (nur LW-Ger\u00e4te)",
+                            "5": "Lauftabtau (nur LW-Geräte)",
                             "6": "Temperatur Einsatzgrenze maximal",
                             "7": "Temperatur Einsatzgrenze minimal",
                             "8": "Untere Einsatzgrenze",
                             "9": "Keine Anforderung",
                             "10": "Externe Energiequelle",
-                            "11": "Durchfluss-W\u00e4rmequelle",
+                            "11": "Durchfluss-Wärmequelle",
                             "12": "Niederdruck-Pause",
-                            "13": "\u00dcberhitzungs-Pause",
+                            "13": "Überhitzungs-Pause",
                             "14": "Inverter-Pause",
                             "15": "Enthitzer-Pause",
                             "16": "Betriebsart Umschaltung",
                             "17": "Sonstige Abschaltung",
-                            "18": "Mindestdurchfluss K\u00fchlung",
+                            "18": "Mindestdurchfluss Kühlung",
                             "19": "PV max",
-                            "20": "Hei\u00dfgas-Pause",
-                            "21": "\u00dcberhitzung Hei\u00dfgas-Pause",
+                            "20": "Heißgas-Pause",
+                            "21": "Überhitzung Heißgas-Pause",
                             "22": "Keine Anforderung",
-                            "23": "Minimale W\u00e4rmequellen-Austrittstemperatur K\u00fchlung",
+                            "23": "Minimale Wärmequellen-Austrittstemperatur Kühlung",
                             "24": "LPC",
                             "25": "Neustart",
                             "27": "Vorlauf max."
@@ -646,30 +646,30 @@
                     "code_2": {
                         "name": "Vorvorletze Abschaltung",
                         "state": {
-                            "0": "W\u00e4rmepumpe St\u00f6rung",
-                            "1": "Anlagen St\u00f6rung",
-                            "2": "Betriebsart Zweiter W\u00e4rmeerzeuger",
+                            "0": "Wärmepumpe Störung",
+                            "1": "Anlagen Störung",
+                            "2": "Betriebsart Zweiter Wärmeerzeuger",
                             "3": "EVU-Sperre",
                             "4": "",
-                            "5": "Lauftabtau (nur LW-Ger\u00e4te)",
+                            "5": "Lauftabtau (nur LW-Geräte)",
                             "6": "Temperatur Einsatzgrenze maximal",
                             "7": "Temperatur Einsatzgrenze minimal",
                             "8": "Untere Einsatzgrenze",
                             "9": "Keine Anforderung",
                             "10": "Externe Energiequelle",
-                            "11": "Durchfluss-W\u00e4rmequelle",
+                            "11": "Durchfluss-Wärmequelle",
                             "12": "Niederdruck-Pause",
-                            "13": "\u00dcberhitzungs-Pause",
+                            "13": "Überhitzungs-Pause",
                             "14": "Inverter-Pause",
                             "15": "Enthitzer-Pause",
                             "16": "Betriebsart Umschaltung",
                             "17": "Sonstige Abschaltung",
-                            "18": "Mindestdurchfluss K\u00fchlung",
+                            "18": "Mindestdurchfluss Kühlung",
                             "19": "PV max",
-                            "20": "Hei\u00dfgas-Pause",
-                            "21": "\u00dcberhitzung Hei\u00dfgas-Pause",
+                            "20": "Heißgas-Pause",
+                            "21": "Überhitzung Heißgas-Pause",
                             "22": "Keine Anforderung",
-                            "23": "Minimale W\u00e4rmequellen-Austrittstemperatur K\u00fchlung",
+                            "23": "Minimale Wärmequellen-Austrittstemperatur Kühlung",
                             "24": "LPC",
                             "25": "Neustart",
                             "27": "Vorlauf max."
@@ -681,30 +681,30 @@
                     "code_3": {
                         "name": "Viertletzte Abschaltung",
                         "state": {
-                            "0": "W\u00e4rmepumpe St\u00f6rung",
-                            "1": "Anlagen St\u00f6rung",
-                            "2": "Betriebsart Zweiter W\u00e4rmeerzeuger",
+                            "0": "Wärmepumpe Störung",
+                            "1": "Anlagen Störung",
+                            "2": "Betriebsart Zweiter Wärmeerzeuger",
                             "3": "EVU-Sperre",
                             "4": "",
-                            "5": "Lauftabtau (nur LW-Ger\u00e4te)",
+                            "5": "Lauftabtau (nur LW-Geräte)",
                             "6": "Temperatur Einsatzgrenze maximal",
                             "7": "Temperatur Einsatzgrenze minimal",
                             "8": "Untere Einsatzgrenze",
                             "9": "Keine Anforderung",
                             "10": "Externe Energiequelle",
-                            "11": "Durchfluss-W\u00e4rmequelle",
+                            "11": "Durchfluss-Wärmequelle",
                             "12": "Niederdruck-Pause",
-                            "13": "\u00dcberhitzungs-Pause",
+                            "13": "Überhitzungs-Pause",
                             "14": "Inverter-Pause",
                             "15": "Enthitzer-Pause",
                             "16": "Betriebsart Umschaltung",
                             "17": "Sonstige Abschaltung",
-                            "18": "Mindestdurchfluss K\u00fchlung",
+                            "18": "Mindestdurchfluss Kühlung",
                             "19": "PV max",
-                            "20": "Hei\u00dfgas-Pause",
-                            "21": "\u00dcberhitzung Hei\u00dfgas-Pause",
+                            "20": "Heißgas-Pause",
+                            "21": "Überhitzung Heißgas-Pause",
                             "22": "Keine Anforderung",
-                            "23": "Minimale W\u00e4rmequellen-Austrittstemperatur K\u00fchlung",
+                            "23": "Minimale Wärmequellen-Austrittstemperatur Kühlung",
                             "24": "LPC",
                             "25": "Neustart",
                             "27": "Vorlauf max."
@@ -714,50 +714,50 @@
                         "name": "Viertletzter Zeitpunkt"
                     },
                     "code_4": {
-                        "name": "F\u00fcnftletzte Abschaltung",
+                        "name": "Fünftletzte Abschaltung",
                         "state": {
-                            "0": "W\u00e4rmepumpe St\u00f6rung",
-                            "1": "Anlagen St\u00f6rung",
-                            "2": "Betriebsart Zweiter W\u00e4rmeerzeuger",
+                            "0": "Wärmepumpe Störung",
+                            "1": "Anlagen Störung",
+                            "2": "Betriebsart Zweiter Wärmeerzeuger",
                             "3": "EVU-Sperre",
                             "4": "",
-                            "5": "Lauftabtau (nur LW-Ger\u00e4te)",
+                            "5": "Lauftabtau (nur LW-Geräte)",
                             "6": "Temperatur Einsatzgrenze maximal",
                             "7": "Temperatur Einsatzgrenze minimal",
                             "8": "Untere Einsatzgrenze",
                             "9": "Keine Anforderung",
                             "10": "Externe Energiequelle",
-                            "11": "Durchfluss-W\u00e4rmequelle",
+                            "11": "Durchfluss-Wärmequelle",
                             "12": "Niederdruck-Pause",
-                            "13": "\u00dcberhitzungs-Pause",
+                            "13": "Überhitzungs-Pause",
                             "14": "Inverter-Pause",
                             "15": "Enthitzer-Pause",
                             "16": "Betriebsart Umschaltung",
                             "17": "Sonstige Abschaltung",
-                            "18": "Mindestdurchfluss K\u00fchlung",
+                            "18": "Mindestdurchfluss Kühlung",
                             "19": "PV max",
-                            "20": "Hei\u00dfgas-Pause",
-                            "21": "\u00dcberhitzung Hei\u00dfgas-Pause",
+                            "20": "Heißgas-Pause",
+                            "21": "Überhitzung Heißgas-Pause",
                             "22": "Keine Anforderung",
-                            "23": "Minimale W\u00e4rmequellen-Austrittstemperatur K\u00fchlung",
+                            "23": "Minimale Wärmequellen-Austrittstemperatur Kühlung",
                             "24": "LPC",
                             "25": "Neustart",
                             "27": "Vorlauf max."
                         }
                     },
                     "timestamp_4": {
-                        "name": "F\u00fcnftletzter Zeitpunkt"
+                        "name": "Fünftletzter Zeitpunkt"
                     }
                 }
             },
             "status_line_1": {
                 "name": "Status 1",
                 "state": {
-                    "heatpump_running": "Die W\u00e4rmepumpe l\u00e4uft",
-                    "heatpump_idle": "Die W\u00e4rmepumpe ist im Leerlauf",
-                    "heatpump_coming": "Die W\u00e4rmepumpe startet",
-                    "heatpump_shutdown": "Die W\u00e4rmepumpe schaltet ab",
-                    "errorcode_slot_0": "W\u00e4rmepumpe Fehlercode in Schacht 0",
+                    "heatpump_running": "Die Wärmepumpe läuft",
+                    "heatpump_idle": "Die Wärmepumpe ist im Leerlauf",
+                    "heatpump_coming": "Die Wärmepumpe startet",
+                    "heatpump_shutdown": "Die Wärmepumpe schaltet ab",
+                    "errorcode_slot_0": "Wärmepumpe Fehlercode in Schacht 0",
                     "pump_forerun": "Pumpenvorlauf",
                     "defrost": "Taut ab",
                     "waiting_on_lin_connection": "Wartet auf LIN Verbindung",
@@ -778,7 +778,7 @@
                 "state": {
                     "heating": "heizt",
                     "defrost": "abtauen",
-                    "cooling": "k\u00fchlen",
+                    "cooling": "kühlen",
                     "pump_forerun": "Pumpenvorlauf",
                     "thermal_desinfection": "thermische Desinfektion",
                     "swimming_pool_solar": "Pool / Solar",
@@ -786,19 +786,19 @@
                     "cycle_lock": "Einschaltsperre",
                     "lock_time": "Sperrzeit",
                     "domestic_water": "Brauchwasser",
-                    "flow_monitoring": "Durchfluss\u00fcberwachung",
-                    "grid_switch_on_delay": "Verz\u00f6gerung beim Einschalten des Netzes",
+                    "flow_monitoring": "Durchflussüberwachung",
+                    "grid_switch_on_delay": "Verzögerung beim Einschalten des Netzes",
                     "info_bake_out_program": "Information aus Aufheizprogramm",
                     "heating_external_energy_source": "heizen aus externer Energiequelle",
                     "domestic_water_external_energy_source": "Brauchwasser aus externer Energiequelle",
-                    "second_heat_generator_1_active": "zweiter W\u00e4rmeerzeuger 1 aktiv"
+                    "second_heat_generator_1_active": "zweiter Wärmeerzeuger 1 aktiv"
                 }
             },
             "heat_source_output": {
-                "name": "W\u00e4rmequelle Ausgang"
+                "name": "Wärmequelle Ausgang"
             },
             "heat_source_input_temperature": {
-                "name": "W\u00e4rmequelle Eingang"
+                "name": "Wärmequelle Eingang"
             },
             "outdoor_temperature": {
                 "name": "Aussen Temperatur"
@@ -825,7 +825,7 @@
                 "name": "Gesamt Betriebsstunden"
             },
             "heat_amount_counter": {
-                "name": "Z\u00e4hler W\u00e4rmemenge"
+                "name": "Zähler Wärmemenge"
             },
             "hot_gas_temperature": {
                 "name": "Heissgas Temperatur"
@@ -840,10 +840,10 @@
                 "name": "Verdichter"
             },
             "overheating_temperature": {
-                "name": "\u00dcberhitzung"
+                "name": "Überhitzung"
             },
             "overheating_target_temperature": {
-                "name": "\u00dcberhitzung Soll"
+                "name": "Überhitzung Soll"
             },
             "high_pressure": {
                 "name": "Hochdruck"
@@ -852,10 +852,10 @@
                 "name": "Niederdruck"
             },
             "additional_heat_generator_operation_hours": {
-                "name": "Zus\u00e4tzlicher W\u00e4rmeerzeuger Betriebsstunden"
+                "name": "Zusätzlicher Wärmeerzeuger Betriebsstunden"
             },
             "additional_heat_generator2_operation_hours": {
-                "name": "Zus\u00e4tzlicher W\u00e4rmeerzeuger2 Betriebsstunden"
+                "name": "Zusätzlicher Wärmeerzeuger2 Betriebsstunden"
             },
             "analog_out1": {
                 "name": "Analog Ausgang 1"
@@ -870,13 +870,13 @@
                 "name": "Leistungsaufnahme"
             },
             "additional_heat_generator_energy_p1059": {
-                "name": "Zus\u00e4tzlicher W\u00e4rmeerzeuger W\u00e4rmemenge (Firmware vor x.88)"
+                "name": "Zusätzlicher Wärmeerzeuger Wärmemenge (Firmware vor x.88)"
             },
             "additional_heat_generator_energy": {
-                "name": "Zus\u00e4tzlicher W\u00e4rmeerzeuger W\u00e4rmemenge"
+                "name": "Zusätzlicher Wärmeerzeuger Wärmemenge"
             },
             "heat_source_output_temperature": {
-                "name": "W\u00e4rmequelle Ausgang"
+                "name": "Wärmequelle Ausgang"
             },
             "pump_frequency": {
                 "name": "Pumpenfrequenz"
@@ -891,7 +891,7 @@
                 "name": "Betriebsstunden"
             },
             "dhw_heat_amount": {
-                "name": "W\u00e4rmemenge"
+                "name": "Wärmemenge"
             },
             "dhw_energy_input": {
                 "name": "Eingesetzte Energie"
@@ -921,25 +921,25 @@
                 "name": "Vorlauf Soll Temperatur MK3"
             },
             "flow_out_temperature": {
-                "name": "R\u00fccklauf Temperatur"
+                "name": "Rücklauf Temperatur"
             },
             "flow_out_temperature_target": {
-                "name": "R\u00fccklauf Soll Temperatur"
+                "name": "Rücklauf Soll Temperatur"
             },
             "operation_hours_heating": {
                 "name": "Betriebsstunden"
             },
             "heat_amount_heating": {
-                "name": "Z\u00e4hler W\u00e4rmemenge Heizung"
+                "name": "Zähler Wärmemenge Heizung"
             },
             "pool_heat_amount": {
                 "name": "Zähler Wärmemenge Schwimmbad"
             },
             "heat_amount_flow_rate": {
-                "name": "Z\u00e4hler W\u00e4rmemenge Durchfluss"
+                "name": "Zähler Wärmemenge Durchfluss"
             },
             "heat_source_flow_rate": {
-                "name": "Z\u00e4hler W\u00e4rmequelle Durchfluss"
+                "name": "Zähler Wärmequelle Durchfluss"
             },
             "heat_energy_input": {
                 "name": "Eingesetzte Energie Heizung"
@@ -948,7 +948,7 @@
                 "name": "COP"
             },
             "flow_out_temperature_external": {
-                "name": "R\u00fccklauf Temperatur extern"
+                "name": "Rücklauf Temperatur extern"
             },
             "solar_collector_temperature": {
                 "name": "Solar Kollektor"
@@ -969,25 +969,25 @@
                 "name": "Raum Thermostat Soll"
             },
             "pump_flow_delta_target": {
-                "name": "Soleumw\u00e4lzpumpe Delta Ziel"
+                "name": "Soleumwälzpumpe Delta Ziel"
             },
             "pump_flow_delta": {
-                "name": "Soleumw\u00e4lzpumpe Delta"
+                "name": "Soleumwälzpumpe Delta"
             },
             "circulation_pump_delta_target": {
-                "name": "Umw\u00e4lzpumpe Delta Ziel"
+                "name": "Umwälzpumpe Delta Ziel"
             },
             "circulation_pump_delta": {
-                "name": "Umw\u00e4lzpumpe Delta"
+                "name": "Umwälzpumpe Delta"
             },
             "cooling_energy_input": {
-                "name": "Eingesetzte Energie K\u00fchlung"
+                "name": "Eingesetzte Energie Kühlung"
             },
             "pool_energy_input": {
                 "name": "Eingesetzte Energie Schwimmbad"
             },
             "additional_heat_generator_energy_p1140": {
-                "name": "Zus\u00e4tzlicher W\u00e4rmeerzeuger W\u00e4rmemenge (Firmware ab x.88)"
+                "name": "Zusätzlicher Wärmeerzeuger Wärmemenge (Firmware ab x.88)"
             },
             "ventilation_supply_air_temperature": {
                 "name": "Zulufttemperatur"
@@ -1090,34 +1090,34 @@
                 "name": "Heizungs-Zeitschaltplan (Sonntag)"
             },
             "timer_ventilation_schedule_week": {
-                "name": "L\u00fcftungs-Zeitschaltplan (Woche)"
+                "name": "Lüftungs-Zeitschaltplan (Woche)"
             },
             "timer_ventilation_schedule_weekday": {
-                "name": "L\u00fcftungs-Zeitschaltplan (Werktage)"
+                "name": "Lüftungs-Zeitschaltplan (Werktage)"
             },
             "timer_ventilation_schedule_weekend": {
-                "name": "L\u00fcftungs-Zeitschaltplan (Wochenende)"
+                "name": "Lüftungs-Zeitschaltplan (Wochenende)"
             },
             "timer_ventilation_schedule_monday": {
-                "name": "L\u00fcftungs-Zeitschaltplan (Montag)"
+                "name": "Lüftungs-Zeitschaltplan (Montag)"
             },
             "timer_ventilation_schedule_tuesday": {
-                "name": "L\u00fcftungs-Zeitschaltplan (Dienstag)"
+                "name": "Lüftungs-Zeitschaltplan (Dienstag)"
             },
             "timer_ventilation_schedule_wednesday": {
-                "name": "L\u00fcftungs-Zeitschaltplan (Mittwoch)"
+                "name": "Lüftungs-Zeitschaltplan (Mittwoch)"
             },
             "timer_ventilation_schedule_thursday": {
-                "name": "L\u00fcftungs-Zeitschaltplan (Donnerstag)"
+                "name": "Lüftungs-Zeitschaltplan (Donnerstag)"
             },
             "timer_ventilation_schedule_friday": {
-                "name": "L\u00fcftungs-Zeitschaltplan (Freitag)"
+                "name": "Lüftungs-Zeitschaltplan (Freitag)"
             },
             "timer_ventilation_schedule_saturday": {
-                "name": "L\u00fcftungs-Zeitschaltplan (Samstag)"
+                "name": "Lüftungs-Zeitschaltplan (Samstag)"
             },
             "timer_ventilation_schedule_sunday": {
-                "name": "L\u00fcftungs-Zeitschaltplan (Sonntag)"
+                "name": "Lüftungs-Zeitschaltplan (Sonntag)"
             }
         },
         "select": {
@@ -1160,7 +1160,7 @@
                 }
             },
             "timer_ventilation_program": {
-                "name": "L\u00fcftung Zeitprogramm",
+                "name": "Lüftung Zeitprogramm",
                 "state": {
                     "week": "Ganze Woche",
                     "weekday_weekend": "Werktage + Wochenende",
@@ -1182,7 +1182,7 @@
                 "state": {
                     "off": "Aus",
                     "automatic": "Automatisch",
-                    "second_heatsource": "Zweiter W\u00e4rmeerzeuger",
+                    "second_heatsource": "Zweiter Wärmeerzeuger",
                     "party": "Party",
                     "holidays": "Ferien"
                 }
@@ -1192,7 +1192,7 @@
                 "state": {
                     "off": "Aus",
                     "automatic": "Automatisch",
-                    "second_heatsource": "Zweiter W\u00e4rmeerzeuger",
+                    "second_heatsource": "Zweiter Wärmeerzeuger",
                     "party": "Party",
                     "holidays": "Ferien"
                 }
@@ -1239,7 +1239,7 @@
                 "name": "Heizung"
             },
             "cooling_controller": {
-                "name": "K\u00fchlung"
+                "name": "Kühlung"
             }
         },
         "water_heater": {
@@ -1259,7 +1259,7 @@
             "name": "BW"
         },
         "cooling": {
-            "name": "K\u00fchl"
+            "name": "Kühl"
         },
         "ventilation": {
             "name": "Lüft"
@@ -1268,29 +1268,29 @@
     "config": {
         "abort": {
             "cannot_connect": "Verbindung zu Luxtronik unter {host} fehlgeschlagen.\\nFehler: {connect_error}",
-            "cannot_identify": "Verbindung zum Ger\u00e4t unter {host} hergestellt, aber die Seriennummer zur Identifizierung konnte nicht gelesen werden.\\nFehler: {error}",
-            "already_configured": "Dieses Ger\u00e4t ist bereits konfiguriert.",
-            "already_configured_serial": "Die W\u00e4rmepumpe unter {host} meldet die Seriennummer {serial}, die bereits als {existing_title} ({existing_host}) konfiguriert ist. Beide Adressen erreichen dieselbe W\u00e4rmepumpe - pr\u00fcfe bei zwei erwarteten Ger\u00e4ten die Portweiterleitungen auf Duplikate.",
+            "cannot_identify": "Verbindung zum Gerät unter {host} hergestellt, aber die Seriennummer zur Identifizierung konnte nicht gelesen werden.\\nFehler: {error}",
+            "already_configured": "Dieses Gerät ist bereits konfiguriert.",
+            "already_configured_serial": "Die Wärmepumpe unter {host} meldet die Seriennummer {serial}, die bereits als {existing_title} ({existing_host}) konfiguriert ist. Beide Adressen erreichen dieselbe Wärmepumpe - prüfe bei zwei erwarteten Geräten die Portweiterleitungen auf Duplikate.",
             "reconfigure_successful": "Konfiguration erfolgreich aktualisiert.",
-            "unique_id_mismatch": "Das Ger\u00e4t an der neuen Adresse hat eine andere Identit\u00e4t als das aktuell konfigurierte Ger\u00e4t.",
+            "unique_id_mismatch": "Das Gerät an der neuen Adresse hat eine andere Identität als das aktuell konfigurierte Gerät.",
             "already_in_progress": "Der Konfigurationsvorgang ist bereits aktiv.",
-            "devices_configured": "Alle ausgew\u00e4hlten Ger\u00e4te sind bereits konfiguriert.",
+            "devices_configured": "Alle ausgewählten Geräte sind bereits konfiguriert.",
             "options_error": "Beim Laden der Optionen ist ein Fehler aufgetreten.",
-            "no_devices_found": "Keine Ger\u00e4te im Netzwerk gefunden.",
+            "no_devices_found": "Keine Geräte im Netzwerk gefunden.",
             "single_instance_allowed": "Bereits konfiguriert. Nur eine Instanz erlaubt.",
             "unknown": "Unbekannter Fehler."
         },
         "error": {
-            "address": "Ung\u00fcltige Remote-Adresse. Die Adresse muss eine IP-Adresse oder ein aufl\u00f6sbarer Hostname sein.",
-            "address_in_use": "Der gew\u00e4hlte Port wird bereits auf diesem System verwendet.",
-            "cannot_connect": "Verbindung fehlgeschlagen. Bitte Host und Port \u00fcberpr\u00fcfen.",
-            "cannot_identify": "Verbindung zum Ger\u00e4t hergestellt, aber die Seriennummer zur Identifizierung konnte nicht gelesen werden.",
+            "address": "Ungültige Remote-Adresse. Die Adresse muss eine IP-Adresse oder ein auflösbarer Hostname sein.",
+            "address_in_use": "Der gewählte Port wird bereits auf diesem System verwendet.",
+            "cannot_connect": "Verbindung fehlgeschlagen. Bitte Host und Port überprüfen.",
+            "cannot_identify": "Verbindung zum Gerät hergestellt, aber die Seriennummer zur Identifizierung konnte nicht gelesen werden.",
             "unknown": "Unerwarteter Fehler"
         },
         "step": {
             "user": {
-                "title": "Luxtronik W\u00e4rmepumpen-Einrichtung",
-                "description": "Entdeckte Ger\u00e4te bereits konfiguriert: {configured}",
+                "title": "Luxtronik Wärmepumpen-Einrichtung",
+                "description": "Entdeckte Geräte bereits konfiguriert: {configured}",
                 "data": {
                     "host": "Host",
                     "port": "Network Port",
@@ -1300,35 +1300,35 @@
                 "data_description": {
                     "host": "Hostname oder IP-Adresse",
                     "port": "Normalerweise 8889 oder 8888",
-                    "timeout": "Wenn das Netzwerk oder die W\u00e4rmepumpe langsam ist, k\u00f6nnen Sie den Timeout anpassen.",
-                    "max_data_length": "Wenn das Netzwerk oder die W\u00e4rmepumpe langsam ist, k\u00f6nnen Sie die Datenpaketl\u00e4nge anpassen."
+                    "timeout": "Wenn das Netzwerk oder die Wärmepumpe langsam ist, können Sie den Timeout anpassen.",
+                    "max_data_length": "Wenn das Netzwerk oder die Wärmepumpe langsam ist, können Sie die Datenpaketlänge anpassen."
                 }
             },
             "manual_entry": {
                 "title": "Manuelle Luxtronik-Konfiguration",
-                "description": "Keine neuen Ger\u00e4te gefunden oder alle entdeckten Ger\u00e4te sind bereits konfiguriert. Sie k\u00f6nnen Host und Port manuell eingeben."
+                "description": "Keine neuen Geräte gefunden oder alle entdeckten Geräte sind bereits konfiguriert. Sie können Host und Port manuell eingeben."
             },
             "select_devices": {
-                "title": "Ger\u00e4te zur Konfiguration ausw\u00e4hlen",
-                "description": "W\u00e4hlen Sie ein oder mehrere Ger\u00e4te zur Konfiguration aus. Bereits konfigurierte Ger\u00e4te: {configured}",
+                "title": "Geräte zur Konfiguration auswählen",
+                "description": "Wählen Sie ein oder mehrere Geräte zur Konfiguration aus. Bereits konfigurierte Geräte: {configured}",
                 "data": {
-                    "select_device_to_configure": "W\u00e4hlen Sie das Ger\u00e4t aus, das Sie konfigurieren m\u00f6chten"
+                    "select_device_to_configure": "Wählen Sie das Gerät aus, das Sie konfigurieren möchten"
                 }
             },
             "reconfigure": {
                 "title": "Luxtronik-Verbindung neu konfigurieren",
-                "description": "Aktualisieren Sie die Verbindungseinstellungen f\u00fcr die Luxtronik-W\u00e4rmepumpe.",
+                "description": "Aktualisieren Sie die Verbindungseinstellungen für die Luxtronik-Wärmepumpe.",
                 "data": {
                     "host": "Host",
                     "port": "Netzwerk-Port",
                     "timeout": "Netzwerk-Socket-Timeout (Sek.)",
-                    "max_data_length": "Maximale Datenpaketl\u00e4nge"
+                    "max_data_length": "Maximale Datenpaketlänge"
                 },
                 "data_description": {
                     "host": "Hostname oder IP-Adresse",
                     "port": "Normalerweise 8889 oder 8888",
-                    "timeout": "Wenn das Netzwerk oder die W\u00e4rmepumpe langsam ist, k\u00f6nnen Sie den Timeout anpassen.",
-                    "max_data_length": "Wenn das Netzwerk oder die W\u00e4rmepumpe langsam ist, k\u00f6nnen Sie die Datenpaketl\u00e4nge anpassen."
+                    "timeout": "Wenn das Netzwerk oder die Wärmepumpe langsam ist, können Sie den Timeout anpassen.",
+                    "max_data_length": "Wenn das Netzwerk oder die Wärmepumpe langsam ist, können Sie die Datenpaketlänge anpassen."
                 }
             }
         }
@@ -1336,48 +1336,48 @@
     "options": {
         "step": {
             "user": {
-                "title": "Optionen f\u00fcr {name} konfigurieren",
-                "description": "Einstellungen f\u00fcr die Luxtronik-W\u00e4rmepumpe {name}.",
+                "title": "Optionen für {name} konfigurieren",
+                "description": "Einstellungen für die Luxtronik-Wärmepumpe {name}.",
                 "data": {
-                    "ha_sensor_indoor_temperature": "Sensor-ID f\u00fcr die Raumtemperatur",
-                    "ha_sensor_current_power_consumption": "Sensor-ID f\u00fcr den aktuellen Stromverbrauch",
+                    "ha_sensor_indoor_temperature": "Sensor-ID für die Raumtemperatur",
+                    "ha_sensor_current_power_consumption": "Sensor-ID für den aktuellen Stromverbrauch",
                     "update_interval": "Aktualisierungsintervall"
                 },
                 "data_description": {
-                    "ha_sensor_indoor_temperature": "Ein Thermostat zur Heizungssteuerung wird in Home Assistant erstellt. Die tats\u00e4chliche Temperatur wird von einem Home Assistant-Sensor gesetzt.\nWenn Luxtronik mit einem Hardware-Raumthermostat verbunden ist, sollte dieses Feld leer bleiben.",
-                    "ha_sensor_current_power_consumption": "Wenn die eingebaute Messung des aktuellen Stromverbrauchs der W\u00e4rmepumpe ungenau ist, kann stattdessen ein externer Home Assistant-Stromsensor (z. B. eine Smart-Steckdose) f\u00fcr die COP-Berechnungen (Heizung/Warmwasser) verwendet werden. Dies \u00e4ndert nicht, was der Sensor f\u00fcr den aktuellen Stromverbrauch selbst anzeigt.\nLeer lassen, um die eingebaute Messung der W\u00e4rmepumpe zu verwenden.",
-                    "update_interval": "Wie oft die W\u00e4rmepumpe nach neuen Daten abgefragt wird."
+                    "ha_sensor_indoor_temperature": "Ein Thermostat zur Heizungssteuerung wird in Home Assistant erstellt. Die tatsächliche Temperatur wird von einem Home Assistant-Sensor gesetzt.\nWenn Luxtronik mit einem Hardware-Raumthermostat verbunden ist, sollte dieses Feld leer bleiben.",
+                    "ha_sensor_current_power_consumption": "Wenn die eingebaute Messung des aktuellen Stromverbrauchs der Wärmepumpe ungenau ist, kann stattdessen ein externer Home Assistant-Stromsensor (z. B. eine Smart-Steckdose) für die COP-Berechnungen (Heizung/Warmwasser) verwendet werden. Dies ändert nicht, was der Sensor für den aktuellen Stromverbrauch selbst anzeigt.\nLeer lassen, um die eingebaute Messung der Wärmepumpe zu verwenden.",
+                    "update_interval": "Wie oft die Wärmepumpe nach neuen Daten abgefragt wird."
                 }
             }
         }
     },
     "exceptions": {
         "invalid_parameter_name": {
-            "message": "Ung\u00fcltiger Parametername: {parameter}"
+            "message": "Ungültiger Parametername: {parameter}"
         },
         "parameter_not_writable": {
-            "message": "Parameter {parameter} abgelehnt \u2014 nur Parameter mit Pr\u00e4fixen {prefixes} sind beschreibbar"
+            "message": "Parameter {parameter} abgelehnt — nur Parameter mit Präfixen {prefixes} sind beschreibbar"
         },
         "ambiguous_write_target": {
-            "message": "Es sind mehrere Luxtronik-W\u00e4rmepumpen konfiguriert ({count} geladen) \u2014 bitte device_id oder config_entry_id angeben, um das Ziel auszuw\u00e4hlen"
+            "message": "Es sind mehrere Luxtronik-Wärmepumpen konfiguriert ({count} geladen) — bitte device_id oder config_entry_id angeben, um das Ziel auszuwählen"
         },
         "invalid_write_target": {
-            "message": "Es konnte keine geladene Luxtronik-W\u00e4rmepumpe f\u00fcr das Ziel {target} ermittelt werden"
+            "message": "Es konnte keine geladene Luxtronik-Wärmepumpe für das Ziel {target} ermittelt werden"
         },
         "invalid_timer_schedule": {
-            "message": "Ung\u00fcltiger Zeitschaltplan \"{value}\": erwartet werden \"HH:MM-HH:MM\"-Eintr\u00e4ge, getrennt durch \"/\", mit maximal {max_rows} Eintr\u00e4gen"
+            "message": "Ungültiger Zeitschaltplan \"{value}\": erwartet werden \"HH:MM-HH:MM\"-Einträge, getrennt durch \"/\", mit maximal {max_rows} Einträgen"
         },
         "write_confirmation_mismatch": {
-            "message": "Die Luxtronik-W\u00e4rmepumpe hat die geschriebenen Werte nicht best\u00e4tigt: {details}"
+            "message": "Die Luxtronik-Wärmepumpe hat die geschriebenen Werte nicht bestätigt: {details}"
         },
         "write_confirmation_unavailable": {
-            "message": "{parameters} wurde(n) an die Luxtronik-W\u00e4rmepumpe geschrieben, aber die best\u00e4tigende Aktualisierung ist fehlgeschlagen \u2014 das Ergebnis konnte nicht best\u00e4tigt werden"
+            "message": "{parameters} wurde(n) an die Luxtronik-Wärmepumpe geschrieben, aber die bestätigende Aktualisierung ist fehlgeschlagen — das Ergebnis konnte nicht bestätigt werden"
         }
     },
     "issues": {
         "connection_failed": {
-            "title": "Verbindung zur Luxtronik-W\u00e4rmepumpe fehlgeschlagen",
-            "description": "Die Integration konnte keine Verbindung zur Luxtronik-W\u00e4rmepumpe unter **{host}:{port}** herstellen.\n\nFehler: `{error}`\n\nBitte \u00fcberpr\u00fcfen Sie, ob die W\u00e4rmepumpe eingeschaltet ist, die Netzwerkverbindung funktioniert und Host/Port korrekt sind. Sie k\u00f6nnen die Verbindungseinstellungen \u00fcber die Option **Neu konfigurieren** im Integrationsmen\u00fc aktualisieren."
+            "title": "Verbindung zur Luxtronik-Wärmepumpe fehlgeschlagen",
+            "description": "Die Integration konnte keine Verbindung zur Luxtronik-Wärmepumpe unter **{host}:{port}** herstellen.\n\nFehler: `{error}`\n\nBitte überprüfen Sie, ob die Wärmepumpe eingeschaltet ist, die Netzwerkverbindung funktioniert und Host/Port korrekt sind. Sie können die Verbindungseinstellungen über die Option **Neu konfigurieren** im Integrationsmenü aktualisieren."
         }
     }
 }

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -1356,10 +1356,10 @@
             "message": "Invalid parameter name: {parameter}"
         },
         "parameter_not_writable": {
-            "message": "Parameter {parameter} rejected \u2014 only parameters with prefixes {prefixes} are writable"
+            "message": "Parameter {parameter} rejected — only parameters with prefixes {prefixes} are writable"
         },
         "ambiguous_write_target": {
-            "message": "Multiple Luxtronik heat pumps are configured ({count} loaded) \u2014 specify device_id or config_entry_id to select which one to write to"
+            "message": "Multiple Luxtronik heat pumps are configured ({count} loaded) — specify device_id or config_entry_id to select which one to write to"
         },
         "invalid_write_target": {
             "message": "Could not resolve a loaded Luxtronik heat pump for target {target}"
@@ -1371,7 +1371,7 @@
             "message": "Luxtronik heat pump did not confirm the written value(s): {details}"
         },
         "write_confirmation_unavailable": {
-            "message": "Wrote {parameters} to the Luxtronik heat pump, but the confirming refresh failed \u2014 the result could not be confirmed"
+            "message": "Wrote {parameters} to the Luxtronik heat pump, but the confirming refresh failed — the result could not be confirmed"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -64,7 +64,7 @@
                 "name": "Dienst op afstand"
             },
             "efficiency_pump": {
-                "name": "Effici\u00ebntie Pomp"
+                "name": "Efficiëntie Pomp"
             },
             "electrical_power_limitation_switch": {
                 "name": "Stroom limitatie"
@@ -197,7 +197,7 @@
                 "name": "DHW doel frequentie"
             },
             "heating_room_temperature_impact_factor": {
-                "name": "Be\u00efnvloedende factor voor de kamertemperatuur"
+                "name": "Beïnvloedende factor voor de kamertemperatuur"
             },
             "heating_maximum_circulation_pump_speed": {
                 "name": "Maximale pompcirculatiesnelheid (verwarmen)"
@@ -212,16 +212,16 @@
                 "name": "Verlagen naar buitentemperatuur"
             },
             "efficiency_pump_nominal_voltage": {
-                "name": "Effici\u00ebntie pomp nominaal spanning"
+                "name": "Efficiëntie pomp nominaal spanning"
             },
             "efficiency_pump_nominal_percentage": {
-                "name": "Effici\u00ebntie pomp nominaal percentage"
+                "name": "Efficiëntie pomp nominaal percentage"
             },
             "efficiency_pump_minimal_voltage": {
-                "name": "Effici\u00ebntie pomp minimaal spanning"
+                "name": "Efficiëntie pomp minimaal spanning"
             },
             "efficiency_pump_minimal_percentage": {
-                "name": "Effici\u00ebntie pomp minimaal percentage"
+                "name": "Efficiëntie pomp minimaal percentage"
             },
             "cooling_threshold_temperature": {
                 "name": "Minimale buitentemperatuur"
@@ -301,9 +301,9 @@
                     "707": "Warmtepompcodering",
                     "708": "Vals terugspoelen",
                     "709": "Verkeerd vooruit",
-                    "710": "F\u00fchler Heet Gas",
+                    "710": "Fühler Heet Gas",
                     "711": "Vrees buitentemperatuur.",
-                    "712": "F\u00fchler warm water",
+                    "712": "Fühler warm water",
                     "713": "Volle warmtebron aan",
                     "714": "Warm gas voor huishoudelijk gebruik - automatisch resetten na time-out",
                     "715": "Hogedrukuitschakeling - RESET automatisch",
@@ -317,7 +317,7 @@
                     "723": "Temp.verschil warm water",
                     "724": "Tempdiff ontdooien",
                     "725": "Fout SWW-systeem",
-                    "726": "F\u00fchler mengcircuit 1",
+                    "726": "Fühler mengcircuit 1",
                     "727": "Pekeldruk",
                     "728": "Warmtebron uit",
                     "729": "Roterend veldfout",
@@ -325,10 +325,10 @@
                     "732": "Koelingsstoring",
                     "733": "Anodefout",
                     "734": "Anodestoring",
-                    "735": "F\u00fchler externe energiebron",
-                    "736": "F\u00fchler zonnecollector",
-                    "737": "F\u00fchler zonne-opslag",
-                    "738": "F\u00fchler Mischkreis2",
+                    "735": "Fühler externe energiebron",
+                    "736": "Fühler zonnecollector",
+                    "737": "Fühler zonne-opslag",
+                    "738": "Fühler Mischkreis2",
                     "750": "Fout retourneert extern",
                     "751": "Fasebewakingsfout",
                     "752": "Fasebewaking / stroomfout",
@@ -339,9 +339,9 @@
                     "759": "Bericht over thermische desinfectie",
                     "760": "Fout ontdooien",
                     "761": "LIN-verbinding onderbroken",
-                    "762": "F\u00fchler-inlaatcompressor",
-                    "763": "F\u00fchler-inlaatverdamper",
-                    "764": "F\u00fchler compressorverwarming",
+                    "762": "Fühler-inlaatcompressor",
+                    "763": "Fühler-inlaatverdamper",
+                    "764": "Fühler compressorverwarming",
                     "765": "oververhitting",
                     "766": "Bedrijfslimieten compressor",
                     "767": "Veiligheidstemperatuurbegrenzer verwarmingselement",
@@ -351,9 +351,9 @@
                     "777": "Expansieklep",
                     "778": "Vrees lage druk",
                     "779": "Angstaanjagende hoge druk",
-                    "780": "F\u00fchler EVI",
+                    "780": "Fühler EVI",
                     "781": "Vloeistofdetector, voor Ex-klep",
-                    "782": "F\u00fchler EVI (Enhanced Vapor Injection) zuiggas",
+                    "782": "Fühler EVI (Enhanced Vapor Injection) zuiggas",
                     "783": "Communicatie SEC-omvormer",
                     "784": "VSS geblokkeerd",
                     "785": "SEC-kaart defect",
@@ -391,7 +391,7 @@
                         "state": {
                             "701": "Lagedrukpressostaat in het koelcircuit heeft (LW) meerdere keren of (SW) langer dan 20 seconden geactiveerd.",
                             "702": "Alleen mogelijk met L/W-apparaten: Lage druk in het koelcircuit heeft gereageerd. Automatische HP-herstart na enige tijd.",
-                            "703": "Alleen mogelijk met L/W-apparaten: Als de warmtepomp draait en de temperatuur in de aanvoer < 5 \u00b0C is, wordt vorstbeveiliging gedetecteerd.",
+                            "703": "Alleen mogelijk met L/W-apparaten: Als de warmtepomp draait en de temperatuur in de aanvoer < 5 °C is, wordt vorstbeveiliging gedetecteerd.",
                             "704": "Maximumtemperatuur in het heetgaskoelcircuit overschreden. Automatische HD-herstart na hh:mm.",
                             "705": "Alleen mogelijk met L/W-apparaten: Motorbeveiliging van de ventilator heeft gereageerd.",
                             "706": "Alleen mogelijk met S/W- en W/W-apparaten: Motorbeveiliging van de pekel- of bronwatercirculatiepomp of de compressor heeft gereageerd.",
@@ -399,11 +399,11 @@
                             "708": "Breek of kortsluiting van de retoursensor.",
                             "709": "Breek of kortsluiting van de flowsensor.\nGeen storingsuitschakeling voor S/W- en W/W-apparaten.",
                             "710": "Breek of kortsluiting van de heetgassensor in het koelcircuit.",
-                            "711": "Buiten- of kortsluiting van de buitentemperatuursensor.\nGeen storingsuitschakeling. Vaste waarde op -5 \u00b0C.",
+                            "711": "Buiten- of kortsluiting van de buitentemperatuursensor.\nGeen storingsuitschakeling. Vaste waarde op -5 °C.",
                             "712": "Breek of kortsluiting van de warmwatersensor.\nGeen storingsuitschakeling.",
                             "713": "Breek of kortsluiting van de warmtebronsensor (Entry).",
                             "714": "Thermische bedrijfslimiet van de HP overschreden.\nWaterverwarming geblokkeerd voor hh:mm.",
-                            "715": "Hochdruckpressostat im K\u00e4ltekreis hat angesprochen. Nach einiger Zeit automatischer WP-Neuanlauf.",
+                            "715": "Hochdruckpressostat im Kältekreis hat angesprochen. Nach einiger Zeit automatischer WP-Neuanlauf.",
                             "716": "Hogedrukpressostaat in het koelcircuit is meerdere keren geactiveerd.",
                             "717": "Debietschakelaar op W/W-apparaten is geactiveerd tijdens de voorwastijd of werking.",
                             "718": "Alleen mogelijk met L/W-apparaten: Buitentemperatuur heeft de toegestane maximale waarde overschreden.",
@@ -419,25 +419,25 @@
                             "728": "Breek of kortsluiting van de warmtebronsensor bij de WQ-uitlaat.",
                             "729": "Compressor zonder stroom na inschakelen.",
                             "730": "Het uitbakprogramma kon een VL-temperatuurniveau niet bereiken binnen het opgegeven tijdsinterval. Het uitbakprogramma gaat door.",
-                            "732": "De verwarmingswatertemperatuur is meerdere malen onder de 16 \u00b0C gedaald.",
+                            "732": "De verwarmingswatertemperatuur is meerdere malen onder de 16 °C gedaald.",
                             "733": "Storingssignaalingang van de externe stroomanode heeft gereageerd.",
                             "734": "Fout 733 is al meer dan twee weken aanwezig en de warmwaterproductie is geblokkeerd.",
-                            "735": "Alleen mogelijk als de Comfort-uitbreidingskaart is ge\u00efnstalleerd. Breuk of kortsluiting van de externe energiebronsensor.",
-                            "736": "Alleen mogelijk als de Comfort-uitbreidingskaart is ge\u00efnstalleerd. Breuk of kortsluiting van de zonnecollectorsensor.",
-                            "737": "Alleen mogelijk als de Comfort-uitbreidingskaart is ge\u00efnstalleerd. Breuk of kortsluiting van de zonneboilersensor.",
-                            "738": "Alleen mogelijk als de Comfort-uitbreidingskaart is ge\u00efnstalleerd: Breuk of kortsluiting van de mengcircuitsensor 2.",
+                            "735": "Alleen mogelijk als de Comfort-uitbreidingskaart is geïnstalleerd. Breuk of kortsluiting van de externe energiebronsensor.",
+                            "736": "Alleen mogelijk als de Comfort-uitbreidingskaart is geïnstalleerd. Breuk of kortsluiting van de zonnecollectorsensor.",
+                            "737": "Alleen mogelijk als de Comfort-uitbreidingskaart is geïnstalleerd. Breuk of kortsluiting van de zonneboilersensor.",
+                            "738": "Alleen mogelijk als de Comfort-uitbreidingskaart is geïnstalleerd: Breuk of kortsluiting van de mengcircuitsensor 2.",
                             "750": "Breek of kortsluiting van de externe retoursensor.",
                             "751": "Fasevolgorderelais heeft gereageerd.",
                             "752": "Fasevolgorderelais of stromingsschakelaar heeft gereageerd.",
                             "755": "Een slaaf heeft langer dan 5 minuten niet gereageerd.",
                             "756": "Een master heeft langer dan 5 minuten niet gereageerd.",
                             "757": "Lagedrukpressostaat op tapwaterapparaat heeft meerdere keren of langer dan 20 seconden gereageerd.",
-                            "758": "De ontdooiing werd 5 keer achter elkaar be\u00ebindigd omdat de aanvoertemperatuur te laag was.",
+                            "758": "De ontdooiing werd 5 keer achter elkaar beëindigd omdat de aanvoertemperatuur te laag was.",
                             "759": "Thermische desinfectie kon 3 keer achter elkaar niet correct worden uitgevoerd.",
                             "760": "Het ontdooien werd 5 keer achter elkaar voltooid gedurende de maximale tijd dat sterke wind de verdamper treft.",
                             "761": "LIN time-out",
-                            "762": "Volledige fout T\u00fc (Inlaatcompressor).",
-                            "763": "Brandstoffout T\u00fc1 (Inlaatverdamper).",
+                            "762": "Volledige fout Tü (Inlaatcompressor).",
+                            "763": "Brandstoffout Tü1 (Inlaatverdamper).",
                             "764": "Fout sensor verwarming compressor.",
                             "765": "Oververhitting onder 2K gedurende meer dan 5 minuten.",
                             "766": "Bedien 5 minuten buiten het bedrijfsbereik van de compressor.",
@@ -464,7 +464,7 @@
                             "793": "Temperatuurfout in omvormer",
                             "minus_1": "Onbekende fout",
                             "731": "De voor de thermische desinfectie nodige temperatuur kon binnen de ingestelde schakeltijden niet bereikt worden.",
-                            "739": "Alleen mogelijk bij ingebouwde uitbreidingsprintplaat: breuk of kortsluiting in de voeler \u201cmenggroep3\u201d.",
+                            "739": "Alleen mogelijk bij ingebouwde uitbreidingsprintplaat: breuk of kortsluiting in de voeler “menggroep3”.",
                             "768": "Onvoldoende doorstroming bij LW160H(A)V tijdens de ontdooiing.",
                             "769": "Na 10 s compressorlooptijd te geringe doorstroming.",
                             "794": "Overspanning op de inverter.",
@@ -473,9 +473,9 @@
                             "797": "Verwarmingselementregeling wordt niet ondersteund.",
                             "798": "Geen ModBus-communicatie met de ventilator sinds ten minste 10 seconden. Automatische reset.",
                             "799": "Geen ModBus-communicatie met de ASB-printplaat sinds ten minste 10 seconden. Automatische reset.",
-                            "800": "Uitschakeling wordt geactiveerd wanneer de temperatuur van de desuperheater \u2265 80\u00b0C is. Apparaat is uitgeschakeld en D0_Pause is in shutdowns geschreven. Het apparaat wordt weer vrijgegeven voor gebruik na 2 uur. Als het uitschakelen 5 keer binnen 24 uur plaatsvindt, wordt fout 800 naar het storingsgeheugen geschreven.",
-                            "802": "Uitschakeling wordt geactiveerd, wanneer de temperatuur in de elektrische schakelkast \u2265 80\u00b0C is. Als de temperatuur onder 70\u00b0C daalt, start de warmtepomp weer op. Automatische reset.",
-                            "803": "Fout 802 is driemaal binnen 24 uur geactiveerd. Reset handmatig noodzakelijk. Als de temperatuur in de elektrische schakelkast nog \u2265 80\u00b0C is, wordt de fout meteen weer geactiveerd.",
+                            "800": "Uitschakeling wordt geactiveerd wanneer de temperatuur van de desuperheater ≥ 80°C is. Apparaat is uitgeschakeld en D0_Pause is in shutdowns geschreven. Het apparaat wordt weer vrijgegeven voor gebruik na 2 uur. Als het uitschakelen 5 keer binnen 24 uur plaatsvindt, wordt fout 800 naar het storingsgeheugen geschreven.",
+                            "802": "Uitschakeling wordt geactiveerd, wanneer de temperatuur in de elektrische schakelkast ≥ 80°C is. Als de temperatuur onder 70°C daalt, start de warmtepomp weer op. Automatische reset.",
+                            "803": "Fout 802 is driemaal binnen 24 uur geactiveerd. Reset handmatig noodzakelijk. Als de temperatuur in de elektrische schakelkast nog ≥ 80°C is, wordt de fout meteen weer geactiveerd.",
                             "806": "SEC-printplaat heeft sinds minstens 10 seconden geen ModBus-communicatie of opvraging is 10 keer achter elkaar mislukt. Automatische reset.",
                             "807": "Alle voor het desbetreffende apparaat mogelijke ModBus-communicatiestoringen met apparaatcomponenten zijn minstens 10 seconden lang tegelijk aanwezig. Automatische reset."
                         }
@@ -556,7 +556,7 @@
                             "791": "Als het de SEC-configuratie is, controleer dan de ModBus-kabel tussen HZIO en SEC-bord. Controleer ook het SEC-bord om te zien of alles knippert zoals het zou moeten. Als er GEEN configuratie is met SEC-bord is (b.v. omdat het een P184-apparaat is), controleer dan de coderingsweerstand van de HZIO.",
                             "792": "Controleer codeerstekker op LIN-kaart",
                             "793": "Fout corrigeert zichzelf",
-                            "739": "Voeler \u201cmenggroep3\u201d, stekker en verbindingskabel controleren.",
+                            "739": "Voeler “menggroep3”, stekker en verbindingskabel controleren.",
                             "768": "Hydrauliek controleren, pomp controleren, doorstroming controleren.",
                             "769": "PWM-kabel controleren, pomp controleren.",
                             "794": "Stroomvoorziening inverter controleren.",
@@ -564,7 +564,7 @@
                             "796": "Geval 1: Inverter controleren. Storing verhelpen. Geval 2: Debiet HW, overstromer, aanvoertemperatuursensor en hogedruksensor controleren. Storing verhelpen. Geval 3: Er moet handmatig uit- en weer ingeschakeld worden.",
                             "798": "Kabelverbinding tussen ModBus en ventilator controleren.",
                             "799": "Kabelverbinding tussen ModBus en ASB-printplaat controleren.",
-                            "800": "Energie uit onthitter-buffer afnemen. Zodra de temperatuur < 80\u00b0C daalt, kan de machine weer gestart worden.",
+                            "800": "Energie uit onthitter-buffer afnemen. Zodra de temperatuur < 80°C daalt, kan de machine weer gestart worden.",
                             "802": "Ventilator op werking controleren. Aansluitkabel controleren. Sensor controleren. Elektrische schakelkastopeningen op verstopping controleren.",
                             "803": "Ventilator op werking controleren. Aansluitkabel controleren. Sensor controleren. Elektrische schakelkastopeningen op verstopping controleren.",
                             "806": "Kabelverbinding tussen ModBus en SEC-printplaat controleren.",
@@ -1277,7 +1277,7 @@
             "devices_configured": "Alle geselecteerde apparaten zijn al geconfigureerd.",
             "options_error": "Er is een fout opgetreden bij het laden van de opties.",
             "no_devices_found": "Geen apparaten gevonden op het netwerk",
-            "single_instance_allowed": "Al geconfigureerd. Slechts \u00e9\u00e9n configuratie toegestaan.",
+            "single_instance_allowed": "Al geconfigureerd. Slechts één configuratie toegestaan.",
             "unknown": "Onbekende fout"
         },
         "error": {
@@ -1356,10 +1356,10 @@
             "message": "Ongeldige parameternaam: {parameter}"
         },
         "parameter_not_writable": {
-            "message": "Parameter {parameter} geweigerd \u2014 alleen parameters met prefixen {prefixes} zijn schrijfbaar"
+            "message": "Parameter {parameter} geweigerd — alleen parameters met prefixen {prefixes} zijn schrijfbaar"
         },
         "ambiguous_write_target": {
-            "message": "Er zijn meerdere Luxtronik-warmtepompen geconfigureerd ({count} geladen) \u2014 geef device_id of config_entry_id op om te bepalen welke moet worden beschreven"
+            "message": "Er zijn meerdere Luxtronik-warmtepompen geconfigureerd ({count} geladen) — geef device_id of config_entry_id op om te bepalen welke moet worden beschreven"
         },
         "invalid_write_target": {
             "message": "Kon geen geladen Luxtronik-warmtepomp vinden voor doel {target}"
@@ -1371,7 +1371,7 @@
             "message": "De Luxtronik-warmtepomp heeft de geschreven waarde(n) niet bevestigd: {details}"
         },
         "write_confirmation_unavailable": {
-            "message": "{parameters} is/zijn naar de Luxtronik-warmtepomp geschreven, maar de bevestigende vernieuwing is mislukt \u2014 het resultaat kon niet worden bevestigd"
+            "message": "{parameters} is/zijn naar de Luxtronik-warmtepomp geschreven, maar de bevestigende vernieuwing is mislukt — het resultaat kon niet worden bevestigd"
         }
     },
     "issues": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -11,19 +11,19 @@
                 "name": "Kompresor"
             },
             "pump_flow": {
-                "name": "Przep\u0142yw pompy"
+                "name": "Przepływ pompy"
             },
             "compressor_heater": {
-                "name": "Grza\u0142ka spr\u0119\u017carki"
+                "name": "Grzałka sprężarki"
             },
             "defrost_valve": {
-                "name": "Zaw\u00f3r odszraniania"
+                "name": "Zawór odszraniania"
             },
             "additional_heat_generator": {
-                "name": "Dodatkowy generator ciep\u0142a"
+                "name": "Dodatkowy generator ciepła"
             },
             "additional_heat_generator2": {
-                "name": "Dodatkowy generator ciep\u0142a 2"
+                "name": "Dodatkowy generator ciepła 2"
             },
             "disturbance_output": {
                 "name": "Stan systemu"
@@ -35,28 +35,28 @@
                 "name": "Dodatkowa pompa obiegowa"
             },
             "dhw_recirculation_pump": {
-                "name": "Pompa obiegowa ciep\u0142ej wody"
+                "name": "Pompa obiegowa ciepłej wody"
             },
             "dhw_circulation_pump": {
-                "name": "Pompa obiegowa ciep\u0142ej wody"
+                "name": "Pompa obiegowa ciepłej wody"
             },
             "dhw_charging_pump": {
-                "name": "Pompa \u0142aduj\u0105ca ciep\u0142\u0105 wod\u0119"
+                "name": "Pompa ładująca ciepłą wodę"
             },
             "solar_pump": {
                 "name": "Pompa solarna"
             },
             "approval_cooling": {
-                "name": "Zatwierdzenie ch\u0142odzenia"
+                "name": "Zatwierdzenie chłodzenia"
             },
             "defrost_end_flow_okay": {
-                "name": "Koniec odszraniania / Przep\u0142yw w porz\u0105dku"
+                "name": "Koniec odszraniania / Przepływ w porządku"
             },
             "motor_protection": {
                 "name": "Ochrona silnika"
             },
             "compressor2": {
-                "name": "Spr\u0119\u017carka 2"
+                "name": "Sprężarka 2"
             }
         },
         "switch": {
@@ -82,13 +82,13 @@
                 "name": "Optymalizacja pompy"
             },
             "heating_threshold": {
-                "name": "Pr\u00f3g ogrzewania"
+                "name": "Próg ogrzewania"
             },
             "domestic_water": {
-                "name": "Tryb AUTO ciep\u0142ej wody"
+                "name": "Tryb AUTO ciepłej wody"
             },
             "cooling": {
-                "name": "Ch\u0142odzenie"
+                "name": "Chłodzenie"
             },
             "pump_vent_hup": {
                 "name": "Wentylacja HUP"
@@ -102,21 +102,21 @@
         },
         "update": {
             "firmware": {
-                "name": "Oprogramowanie sprz\u0119towe"
+                "name": "Oprogramowanie sprzętowe"
             }
         },
         "number": {
             "release_second_heat_generator": {
-                "name": "Zwolni\u0107 drugi generator ciep\u0142a"
+                "name": "Zwolnić drugi generator ciepła"
             },
             "release_time_second_heat_generator": {
-                "name": "Czas zwolnienia drugiego generatora ciep\u0142a"
+                "name": "Czas zwolnienia drugiego generatora ciepła"
             },
             "pump_optimization": {
                 "name": "Optymalizacja pompy"
             },
             "heating_threshold": {
-                "name": "Pr\u00f3g ogrzewania"
+                "name": "Próg ogrzewania"
             },
             "electrical_power_limitation_value": {
                 "name": "Limit mocy"
@@ -125,124 +125,124 @@
                 "name": "Limit mocy cieplnej: Ogrzewanie"
             },
             "thermal_power_limitation_water": {
-                "name": "Limit mocy cieplnej: Ciep\u0142a woda"
+                "name": "Limit mocy cieplnej: Ciepła woda"
             },
             "thermal_power_limitation_cooling": {
-                "name": "Limit mocy cieplnej: Ch\u0142odzenie"
+                "name": "Limit mocy cieplnej: Chłodzenie"
             },
             "heating_target_correction": {
                 "name": "Korekcja celu grzewczego"
             },
             "heating_min_flow_out_temperature": {
-                "name": "Min. docelowy odp\u0142yw"
+                "name": "Min. docelowy odpływ"
             },
             "heating_curve_end_temperature": {
-                "name": "Punkt ko\u0144cowy krzywej grzewczej"
+                "name": "Punkt końcowy krzywej grzewczej"
             },
             "heating_curve_parallel_shift_temperature": {
-                "name": "R\u00f3wnoleg\u0142e przesuni\u0119cie krzywej grzewczej"
+                "name": "Równoległe przesunięcie krzywej grzewczej"
             },
             "heating_curve_night_temperature": {
                 "name": "Nocna redukcja krzywej grzewczej"
             },
             "heating_curve_circuit1_end_temperature": {
-                "name": "Obw\u00f3d mieszany 1 punkt ko\u0144cowy krzywej grzewczej"
+                "name": "Obwód mieszany 1 punkt końcowy krzywej grzewczej"
             },
             "heating_curve_circuit1_parallel_shift_temperature": {
-                "name": "Obw\u00f3d mieszany 1 r\u00f3wnoleg\u0142e przesuni\u0119cie krzywej grzewczej"
+                "name": "Obwód mieszany 1 równoległe przesunięcie krzywej grzewczej"
             },
             "heating_curve_circuit1_night_temperature": {
-                "name": "Obw\u00f3d mieszany 1 nocna redukcja krzywej grzewczej"
+                "name": "Obwód mieszany 1 nocna redukcja krzywej grzewczej"
             },
             "heating_curve_circuit2_end_temperature": {
-                "name": "Obw\u00f3d mieszany 2 punkt ko\u0144cowy krzywej grzewczej"
+                "name": "Obwód mieszany 2 punkt końcowy krzywej grzewczej"
             },
             "heating_curve_circuit2_parallel_shift_temperature": {
-                "name": "Obw\u00f3d mieszany 2 r\u00f3wnoleg\u0142e przesuni\u0119cie krzywej grzewczej"
+                "name": "Obwód mieszany 2 równoległe przesunięcie krzywej grzewczej"
             },
             "heating_curve_circuit2_night_temperature": {
-                "name": "Obw\u00f3d mieszany 2 nocna redukcja krzywej grzewczej"
+                "name": "Obwód mieszany 2 nocna redukcja krzywej grzewczej"
             },
             "heating_curve_circuit3_end_temperature": {
-                "name": "Obw\u00f3d mieszany 3 punkt ko\u0144cowy krzywej grzewczej"
+                "name": "Obwód mieszany 3 punkt końcowy krzywej grzewczej"
             },
             "heating_curve_circuit3_parallel_shift_temperature": {
-                "name": "Obw\u00f3d mieszany 3 r\u00f3wnoleg\u0142e przesuni\u0119cie krzywej grzewczej"
+                "name": "Obwód mieszany 3 równoległe przesunięcie krzywej grzewczej"
             },
             "heating_curve_circuit3_night_temperature": {
-                "name": "Obw\u00f3d mieszany 3 nocna redukcja krzywej grzewczej"
+                "name": "Obwód mieszany 3 nocna redukcja krzywej grzewczej"
             },
             "dhw_target_temperature": {
-                "name": "Temperatura docelowa ciep\u0142ej wody"
+                "name": "Temperatura docelowa ciepłej wody"
             },
             "dhw_thermal_desinfection_target": {
                 "name": "Temperatura docelowa dezynfekcji termicznej"
             },
             "solar_pump_max_temperature_collector": {
-                "name": "Maks. temperatura kolektora s\u0142onecznego"
+                "name": "Maks. temperatura kolektora słonecznego"
             },
             "solar_pump_off_max_difference_temperature_boiler": {
-                "name": "Wy\u0142\u0105czenie maks. kolektor r\u00f3\u017cnicowy/kocio\u0142 (pompa solarna)"
+                "name": "Wyłączenie maks. kolektor różnicowy/kocioł (pompa solarna)"
             },
             "solar_pump_off_difference_temperature": {
-                "name": "R\u00f3\u017cnica wy\u0142\u0105czania kolektora/kot\u0142a (pompa solarna)"
+                "name": "Różnica wyłączania kolektora/kotła (pompa solarna)"
             },
             "solar_pump_on_difference_temperature": {
-                "name": "R\u00f3\u017cnica w\u0142\u0105czania kolektora/kot\u0142a (pompa solarna)"
+                "name": "Różnica włączania kolektora/kotła (pompa solarna)"
             },
             "dhw_hysteresis": {
-                "name": "Histereza ciep\u0142ej wody"
+                "name": "Histereza ciepłej wody"
             },
             "dhw_manual_frequency": {
-                "name": "DHW cz\u0119stotliwo\u015b\u0107 docelowa"
+                "name": "DHW częstotliwość docelowa"
             },
             "heating_room_temperature_impact_factor": {
-                "name": "Wsp\u00f3\u0142czynnik wp\u0142ywu temperatury pokojowej"
+                "name": "Współczynnik wpływu temperatury pokojowej"
             },
             "heating_maximum_circulation_pump_speed": {
-                "name": "Maksymalna pr\u0119dko\u015b\u0107 pompy obiegowej (ogrzewanie)"
+                "name": "Maksymalna prędkość pompy obiegowej (ogrzewanie)"
             },
             "heating_max_flow_out_increase_temperature": {
-                "name": "Maks. docelowy wzrost odp\u0142ywu"
+                "name": "Maks. docelowy wzrost odpływu"
             },
             "heating_hysteresis": {
                 "name": "Ogrzewanie histerezy"
             },
             "heating_night_lowering_to_temperature": {
-                "name": "Obni\u017cenie temperatury ogrzewania w nocy"
+                "name": "Obniżenie temperatury ogrzewania w nocy"
             },
             "efficiency_pump_nominal_voltage": {
-                "name": "Nominalne napi\u0119cie pompy wydajno\u015bciowej"
+                "name": "Nominalne napięcie pompy wydajnościowej"
             },
             "efficiency_pump_nominal_percentage": {
-                "name": "Nominalne procento pompy wydajno\u015bciowej"
+                "name": "Nominalne procento pompy wydajnościowej"
             },
             "efficiency_pump_minimal_voltage": {
-                "name": "Minimalne napi\u0119cie pompy wydajno\u015bciowej"
+                "name": "Minimalne napięcie pompy wydajnościowej"
             },
             "efficiency_pump_minimal_percentage": {
-                "name": "Minimalne procento pompy wydajno\u015bciowej"
+                "name": "Minimalne procento pompy wydajnościowej"
             },
             "cooling_start_delay_hours": {
-                "name": "Op\u00f3\u017anienie startu"
+                "name": "Opóźnienie startu"
             },
             "cooling_stop_delay_hours": {
-                "name": "Op\u00f3\u017anienie zatrzymania"
+                "name": "Opóźnienie zatrzymania"
             },
             "cooling_target_temperature_mk1": {
-                "name": "Docelowa temperatura ch\u0142odzenia"
+                "name": "Docelowa temperatura chłodzenia"
             },
             "cooling_target_temperature_mk2": {
-                "name": "Docelowa temperatura ch\u0142odzenia"
+                "name": "Docelowa temperatura chłodzenia"
             },
             "cooling_target_temperature_mk3": {
-                "name": "Docelowa temperatura ch\u0142odzenia"
+                "name": "Docelowa temperatura chłodzenia"
             },
             "cooling_min_flow_out_temperature": {
-                "name": "Minimalna temperatura zasilania ch\u0142odzenia"
+                "name": "Minimalna temperatura zasilania chłodzenia"
             },
             "heating_flow_out_temperature_target": {
-                "name": "R\u0119czna docelowa temperatura wyp\u0142ywu"
+                "name": "Ręczna docelowa temperatura wypływu"
             },
             "pump_vent_timer_h": {
                 "name": "Czas pracy odpowietrzania"
@@ -260,23 +260,23 @@
                 "name": "Czas optimizacji pompy"
             },
             "heat_source_input_temperature_min": {
-                "name": "Minimalna temperatura wej\u015bcia \u017ar\u00f3d\u0142a ciep\u0142a"
+                "name": "Minimalna temperatura wejścia źródła ciepła"
             },
             "cooling_threshold_temperature": {
-                "name": "Temperatura progu ch\u0142odzenia"
+                "name": "Temperatura progu chłodzenia"
             }
         },
         "sensor": {
             "status": {
-                "name": "Pompa ciep\u0142a",
+                "name": "Pompa ciepła",
                 "state": {
                     "heating": "Ogrzewanie",
-                    "hot_water": "Ciep\u0142a woda",
+                    "hot_water": "Ciepła woda",
                     "swimming_pool_solar": "Basen / Solar",
                     "evu": "Blokada sieci - brak zasilania",
-                    "defrost": "Rozmra\u017canie",
-                    "heating_external_source": "Zewn\u0119trzne \u017ar\u00f3d\u0142o ogrzewania",
-                    "cooling": "Ch\u0142odzenie",
+                    "defrost": "Rozmrażanie",
+                    "heating_external_source": "Zewnętrzne źródło ogrzewania",
+                    "cooling": "Chłodzenie",
                     "no_request": "Brak zapotrzebowania"
                 }
             },
@@ -284,103 +284,103 @@
                 "name": "Status SmartGrid",
                 "state": {
                     "evu_locked": "Zablokowane EVU",
-                    "reduced_operation": "Praca obni\u017cona",
+                    "reduced_operation": "Praca obniżona",
                     "normal_operation": "Praca normalna",
-                    "increased_operation": "Praca zwi\u0119kszona"
+                    "increased_operation": "Praca zwiększona"
                 }
             },
             "error_reason": {
-                "name": "Ostatni b\u0142\u0105d",
+                "name": "Ostatni błąd",
                 "state": {
-                    "701": "B\u0142\u0105d niskiego ci\u015bnienia.",
-                    "702": "Zatrzymanie przy niskim ci\u015bnieniu\nRESETUJ automat.",
-                    "703": "\u015brodek przeciw zamarzaniu\nProsz\u0119 wezwa\u0107 montera",
-                    "704": "B\u0142\u0105d gor\u0105cego gazu\nZresetuj w gg:mm",
-                    "705": "Zabezpieczenie silnika VEN\nProsz\u0119 wezwa\u0107 instalatora",
-                    "706": "Zabezpieczenie silnika BCP\nProsz\u0119 wezwa\u0107 instalatora",
-                    "707": "Kodowanie HP\nProsz\u0119 wezwa\u0107 instalatora",
-                    "708": "Czujnik powrotu\nProsz\u0119 wezwa\u0107 instalatora",
-                    "709": "Czujnik przep\u0142ywu\nProsz\u0119 wezwa\u0107 instalatora",
-                    "710": "Czujnik gor\u0105cego gazu\nProsz\u0119 wezwa\u0107 instalatora",
-                    "711": "Temperatura zewn\u0119trzna czujnik\nProsz\u0119 wezwa\u0107 instalatora",
-                    "712": "Czujnik ciep\u0142ej wody u\u017cytkowej.\nProsz\u0119 wezwa\u0107 instalatora",
-                    "713": "Czujnik HS-on\nProsz\u0119 wezwa\u0107 instalatora",
-                    "714": "Gor\u0105cy gaz SW\nResetuj w gg:mm",
-                    "715": "Wy\u0142\u0105czenie wysokiego ci\u015bnienia\nRESET auto.",
-                    "716": "Usterka wysokiego ci\u015bnienia\nProsz\u0119 wezwa\u0107 instalatora",
-                    "717": "Przep\u0142yw HS\nProsz\u0119 wezwa\u0107 instalatora",
+                    "701": "Błąd niskiego ciśnienia.",
+                    "702": "Zatrzymanie przy niskim ciśnieniu\nRESETUJ automat.",
+                    "703": "środek przeciw zamarzaniu\nProszę wezwać montera",
+                    "704": "Błąd gorącego gazu\nZresetuj w gg:mm",
+                    "705": "Zabezpieczenie silnika VEN\nProszę wezwać instalatora",
+                    "706": "Zabezpieczenie silnika BCP\nProszę wezwać instalatora",
+                    "707": "Kodowanie HP\nProszę wezwać instalatora",
+                    "708": "Czujnik powrotu\nProszę wezwać instalatora",
+                    "709": "Czujnik przepływu\nProszę wezwać instalatora",
+                    "710": "Czujnik gorącego gazu\nProszę wezwać instalatora",
+                    "711": "Temperatura zewnętrzna czujnik\nProszę wezwać instalatora",
+                    "712": "Czujnik ciepłej wody użytkowej.\nProszę wezwać instalatora",
+                    "713": "Czujnik HS-on\nProszę wezwać instalatora",
+                    "714": "Gorący gaz SW\nResetuj w gg:mm",
+                    "715": "Wyłączenie wysokiego ciśnienia\nRESET auto.",
+                    "716": "Usterka wysokiego ciśnienia\nProszę wezwać instalatora",
+                    "717": "Przepływ HS\nProszę wezwać instalatora",
                     "718": "Maks. temp. zew.\nRESET auto. w gg:mm",
                     "719": "Min. temp. zew.\nRESET auto. w gg:mm",
                     "720": "Temperatura HS\nRESET AUTO. w gg:mm",
-                    "721": "Wy\u0142\u0105czenie przy niskim ci\u015bnieniu\nRESET auto.",
-                    "722": "Tempdiff HW\nProsz\u0119 wezwa\u0107 instalatora",
-                    "723": "Tempdiff SW\nProsz\u0119 wezwa\u0107 instalatora",
-                    "724": "Rozmra\u017canie Tempdiff\nProsz\u0119 wezwa\u0107 instalatora",
-                    "725": "B\u0142\u0105d systemowy SW\nProsz\u0119 wezwa\u0107 instalatora",
-                    "726": "Czujnik obiegu mieszania 1\nProsz\u0119 wezwa\u0107 instalatora",
-                    "727": "Ci\u015bnienie solanki\nProsz\u0119 wezwa\u0107 instalatora",
-                    "728": "Czujnik HS wy\u0142\u0105czony\nProsz\u0119 wezwa\u0107 instalatora",
-                    "729": "B\u0142\u0105d pola wiruj\u0105cego\nProsz\u0119 wezwa\u0107 instalatora",
-                    "732": "Usterka ch\u0142odzenia\nProsz\u0119 wezwa\u0107 instalatora",
-                    "733": "Usterka anody\nProsz\u0119 wezwa\u0107 instalatora",
-                    "734": "Usterka anody\nProsz\u0119 wezwa\u0107 instalatora",
-                    "735": "B\u0142\u0105d zew. Pl\nProsz\u0119 zadzwoni\u0107 do montera",
-                    "736": "B\u0142\u0105d kolektora s\u0142onecznego\nProsz\u0119 wezwa\u0107 instalatora",
-                    "737": "B\u0142\u0105d zasobnika solarnego\nProsz\u0119 wezwa\u0107 instalatora",
-                    "738": "B\u0142\u0105d mieszania ko\u0142a 2\nProsz\u0119 wezwa\u0107 instalatora",
-                    "750": "Czujnik powrotu zewn\u0119trzny\nProsz\u0119 wezwa\u0107 instalatora",
-                    "751": "B\u0142\u0105d monitorowania fazy",
-                    "752": "B\u0142\u0105d przep\u0142ywu",
-                    "755": "Utracono po\u0142\u0105czenie z modu\u0142em slave\nZadzwo\u0144 do instalatora",
-                    "756": "Utracono po\u0142\u0105czenie z masterem\nZadzwo\u0144 do instalatora",
-                    "757": "Usterka niskiego ci\u015bnienia w urz\u0105dzeniu SW",
-                    "758": "Usterka rozmra\u017cania",
+                    "721": "Wyłączenie przy niskim ciśnieniu\nRESET auto.",
+                    "722": "Tempdiff HW\nProszę wezwać instalatora",
+                    "723": "Tempdiff SW\nProszę wezwać instalatora",
+                    "724": "Rozmrażanie Tempdiff\nProszę wezwać instalatora",
+                    "725": "Błąd systemowy SW\nProszę wezwać instalatora",
+                    "726": "Czujnik obiegu mieszania 1\nProszę wezwać instalatora",
+                    "727": "Ciśnienie solanki\nProszę wezwać instalatora",
+                    "728": "Czujnik HS wyłączony\nProszę wezwać instalatora",
+                    "729": "Błąd pola wirującego\nProszę wezwać instalatora",
+                    "732": "Usterka chłodzenia\nProszę wezwać instalatora",
+                    "733": "Usterka anody\nProszę wezwać instalatora",
+                    "734": "Usterka anody\nProszę wezwać instalatora",
+                    "735": "Błąd zew. Pl\nProszę zadzwonić do montera",
+                    "736": "Błąd kolektora słonecznego\nProszę wezwać instalatora",
+                    "737": "Błąd zasobnika solarnego\nProszę wezwać instalatora",
+                    "738": "Błąd mieszania koła 2\nProszę wezwać instalatora",
+                    "750": "Czujnik powrotu zewnętrzny\nProszę wezwać instalatora",
+                    "751": "Błąd monitorowania fazy",
+                    "752": "Błąd przepływu",
+                    "755": "Utracono połączenie z modułem slave\nZadzwoń do instalatora",
+                    "756": "Utracono połączenie z masterem\nZadzwoń do instalatora",
+                    "757": "Usterka niskiego ciśnienia w urządzeniu SW",
+                    "758": "Usterka rozmrażania",
                     "759": "Komunikat TDI",
-                    "760": "B\u0142\u0105d rozmra\u017cania",
-                    "761": "Przekroczenie limitu czasu LIN/utracono po\u0142\u0105czenie LIN",
+                    "760": "Błąd rozmrażania",
+                    "761": "Przekroczenie limitu czasu LIN/utracono połączenie LIN",
                     "762": "czujnik (wlot parownika)",
-                    "763": "czujnik (wlot spr\u0119\u017carki)",
-                    "764": "Czujnik Grza\u0142ka spr\u0119\u017carki",
+                    "763": "czujnik (wlot sprężarki)",
+                    "764": "Czujnik Grzałka sprężarki",
                     "765": "Przegrzanie",
-                    "766": "zakres funkcjonalny spr\u0119\u017carki",
+                    "766": "zakres funkcjonalny sprężarki",
                     "767": "STB E-Rod",
-                    "768": "Monitorowanie przep\u0142ywu",
-                    "769": "Sterowanie pomp\u0105",
+                    "768": "Monitorowanie przepływu",
+                    "769": "Sterowanie pompą",
                     "770": "Niskie przegrzanie",
                     "771": "Wysokie przegrzanie",
                     "776": "granica zastosowania-CP",
-                    "777": "Zaw\u00f3r rozpr\u0119\u017cny",
-                    "778": "Czujnik niskiego ci\u015bnienia",
-                    "779": "Czujnik wysokiego ci\u015bnienia",
+                    "777": "Zawór rozprężny",
+                    "778": "Czujnik niskiego ciśnienia",
+                    "779": "Czujnik wysokiego ciśnienia",
                     "780": "Czujnik EVI",
                     "781": "Temperatura cieczy czujnik przed EXV",
                     "782": "Temp. gazu zasysanego EVI czujnik",
-                    "783": "Komunikacja SEC \u2013 Falownik",
+                    "783": "Komunikacja SEC – Falownik",
                     "784": "Blokada VSS",
-                    "785": "Uszkodzona p\u0142yta SEC",
+                    "785": "Uszkodzona płyta SEC",
                     "787": "Alarm VD",
-                    "788": "Powa\u017cna usterka VSS",
+                    "788": "Poważna usterka VSS",
                     "789": "Nie znaleziono LIN/kodowania",
-                    "790": "Powa\u017cna usterka VSS",
-                    "791": "Utracono komunikacj\u0119 ModBus",
-                    "792": "Utracono po\u0142\u0105czenie LIN",
-                    "793": "Powa\u017cna usterka VSS",
-                    "730": "B\u0142\u0105d programu wygrzewania jastrychu\nProsz\u0119 wezwa\u0107 instalatora",
+                    "790": "Poważna usterka VSS",
+                    "791": "Utracono komunikację ModBus",
+                    "792": "Utracono połączenie LIN",
+                    "793": "Poważna usterka VSS",
+                    "730": "Błąd programu wygrzewania jastrychu\nProszę wezwać instalatora",
                     "731": "Przekroczenie czasu TDI",
-                    "739": "Czujnik obwodu mieszaj\u0105cego 3\nProsz\u0119 wezwa\u0107 instalatora",
+                    "739": "Czujnik obwodu mieszającego 3\nProszę wezwać instalatora",
                     "786": "Komunikacja SEC - HZ/IO",
-                    "794": "Przepi\u0119cie",
-                    "795": "Zbyt niskie napi\u0119cie",
-                    "796": "Wy\u0142\u0105czenie bezpiecze\u0144stwa",
-                    "797": "MLRH nie jest obs\u0142ugiwane",
+                    "794": "Przepięcie",
+                    "795": "Zbyt niskie napięcie",
+                    "796": "Wyłączenie bezpieczeństwa",
+                    "797": "MLRH nie jest obsługiwane",
                     "798": "ModBus wentylator",
                     "799": "ModBus ASB",
-                    "800": "B\u0142\u0105d desuperheatera",
+                    "800": "Błąd desuperheatera",
                     "802": "Wentylator skrzynki rozdzielczej",
                     "803": "Wentylator skrzynki rozdzielczej",
                     "806": "ModBus SEC",
-                    "807": "Utracone po\u0142\u0105czenie ModBus",
-                    "minus_1": "Nieznany b\u0142\u0105d"
+                    "807": "Utracone połączenie ModBus",
+                    "minus_1": "Nieznany błąd"
                 },
                 "state_attributes": {
                     "timestamp": {
@@ -389,217 +389,217 @@
                     "cause": {
                         "name": "Przyczyna",
                         "state": {
-                            "701": "Presostat niskiego ci\u015bnienia w obiegu ch\u0142odniczym zadzia\u0142a\u0142 wielokrotnie (LW) lub d\u0142u\u017cej ni\u017c 20 sekund (SW).",
-                            "702": "Tylko w urz\u0105dzeniach L/W: Niskie ci\u015bnienie w obiegu ch\u0142odniczym zadzia\u0142a\u0142o. Po pewnym czasie automatyczny restart pompy ciep\u0142a.",
-                            "703": "Tylko w urz\u0105dzeniach L/W: Je\u015bli pompa ciep\u0142a pracuje i temperatura zasilania < 5 \u00b0C, rozpoznawana jest ochrona przed zamarzaniem.",
-                            "704": "Przekroczono maksymaln\u0105 temperatur\u0119 gor\u0105cego gazu w obiegu ch\u0142odniczym. Automatyczny restart pompy ciep\u0142a po gg:mm.",
-                            "705": "Tylko w urz\u0105dzeniach L/W: Zadzia\u0142a\u0142o zabezpieczenie silnika wentylatora.",
-                            "706": "Tylko w urz\u0105dzeniach S/W i W/W: Zadzia\u0142a\u0142o zabezpieczenie silnika pompy solanki, wody studziennej lub spr\u0119\u017carki.",
-                            "707": "Przerwa lub zwarcie w mostku koduj\u0105cym w pompie ciep\u0142a po pierwszym uruchomieniu.",
+                            "701": "Presostat niskiego ciśnienia w obiegu chłodniczym zadziałał wielokrotnie (LW) lub dłużej niż 20 sekund (SW).",
+                            "702": "Tylko w urządzeniach L/W: Niskie ciśnienie w obiegu chłodniczym zadziałało. Po pewnym czasie automatyczny restart pompy ciepła.",
+                            "703": "Tylko w urządzeniach L/W: Jeśli pompa ciepła pracuje i temperatura zasilania < 5 °C, rozpoznawana jest ochrona przed zamarzaniem.",
+                            "704": "Przekroczono maksymalną temperaturę gorącego gazu w obiegu chłodniczym. Automatyczny restart pompy ciepła po gg:mm.",
+                            "705": "Tylko w urządzeniach L/W: Zadziałało zabezpieczenie silnika wentylatora.",
+                            "706": "Tylko w urządzeniach S/W i W/W: Zadziałało zabezpieczenie silnika pompy solanki, wody studziennej lub sprężarki.",
+                            "707": "Przerwa lub zwarcie w mostku kodującym w pompie ciepła po pierwszym uruchomieniu.",
                             "708": "Przerwa lub zwarcie czujnika powrotu.",
-                            "709": "Przerwa lub zwarcie czujnika zasilania.\nBrak wy\u0142\u0105czenia awaryjnego w urz\u0105dzeniach S/W i W/W.",
-                            "710": "Przerwa lub zwarcie czujnika gor\u0105cego gazu w obiegu ch\u0142odniczym.",
-                            "711": "Przerwa lub zwarcie czujnika temperatury zewn\u0119trznej.\nBrak wy\u0142\u0105czenia awaryjnego. Warto\u015b\u0107 sta\u0142a na -5 \u00b0C.",
-                            "712": "Przerwa lub zwarcie czujnika ciep\u0142ej wody.\nBrak wy\u0142\u0105czenia awaryjnego.",
-                            "713": "Przerwa lub zwarcie czujnika \u017ar\u00f3d\u0142a ciep\u0142a (wej\u015bcie).",
-                            "714": "Przekroczono granice termiczne pracy pompy ciep\u0142a.\nPrzygotowywanie ciep\u0142ej wody zablokowane na gg:mm.",
-                            "715": "Presostat wysokiego ci\u015bnienia w obiegu ch\u0142odniczym zadzia\u0142a\u0142. Po pewnym czasie automatyczny restart pompy ciep\u0142a.",
-                            "716": "Presostat wysokiego ci\u015bnienia w obiegu ch\u0142odniczym zadzia\u0142a\u0142 wielokrotnie.",
-                            "717": "Wy\u0142\u0105cznik przep\u0142ywu w urz\u0105dzeniach W/W zadzia\u0142a\u0142 podczas czasu wst\u0119pnego p\u0142ukania lub pracy.",
-                            "718": "Tylko w urz\u0105dzeniach L/W: Temperatura zewn\u0119trzna przekroczy\u0142a dopuszczaln\u0105 warto\u015b\u0107 maksymaln\u0105.",
-                            "719": "Tylko w urz\u0105dzeniach L/W: Temperatura zewn\u0119trzna spad\u0142a poni\u017cej dopuszczalnej warto\u015bci minimalnej.",
-                            "720": "Tylko w urz\u0105dzeniach S/W i W/W: Temperatura na wyj\u015bciu parownika wielokrotnie spad\u0142a poni\u017cej warto\u015bci bezpiecznej. Automatyczny restart pompy ciep\u0142a po gg:mm.",
-                            "721": "Presostat niskiego ci\u015bnienia w obiegu ch\u0142odniczym zadzia\u0142a\u0142. Po pewnym czasie automatyczny restart pompy ciep\u0142a (SW i WW).",
-                            "722": "R\u00f3\u017cnica temperatur w trybie grzewczym jest ujemna (=b\u0142\u0119dna).",
-                            "723": "R\u00f3\u017cnica temperatur w trybie ciep\u0142ej wody jest ujemna (=b\u0142\u0119dna).",
-                            "724": "R\u00f3\u017cnica temperatur w obiegu grzewczym podczas rozmra\u017cania > 15 K (=zagro\u017cenie zamarzaniem).",
-                            "725": "Awaria przygotowywania ciep\u0142ej wody, \u017c\u0105dana temperatura zasobnika jest znacznie ni\u017csza.",
-                            "726": "Przerwa lub zwarcie czujnika obiegu mieszaj\u0105cego 1.",
-                            "727": "Presostat ci\u015bnienia solanki zadzia\u0142a\u0142 podczas czasu wst\u0119pnego p\u0142ukania lub pracy.",
-                            "728": "Przerwa lub zwarcie czujnika \u017ar\u00f3d\u0142a ciep\u0142a na wyj\u015bciu.",
-                            "729": "Spr\u0119\u017carka bez mocy po w\u0142\u0105czeniu.",
-                            "730": "Program wygrzewania jastrychu nie osi\u0105gn\u0105\u0142 zadanego poziomu temperatury zasilania w wyznaczonym czasie. Program wygrzewania jastrychu jest kontynuowany.",
-                            "732": "Temperatura wody grzewczej wielokrotnie spad\u0142a poni\u017cej 16 \u00b0C.",
-                            "733": "Wej\u015bcie alarmowe anody obcego pr\u0105du zadzia\u0142a\u0142o.",
-                            "734": "B\u0142\u0105d 733 utrzymuje si\u0119 od ponad dw\u00f3ch tygodni, przygotowywanie ciep\u0142ej wody jest zablokowane.",
-                            "735": "Tylko z zainstalowan\u0105 p\u0142yt\u0105 Comfort/rozszerzenia: Przerwa lub zwarcie czujnika zewn\u0119trznego \u017ar\u00f3d\u0142a energii.",
-                            "736": "Tylko z zainstalowan\u0105 p\u0142yt\u0105 Comfort/rozszerzenia: Przerwa lub zwarcie czujnika kolektora s\u0142onecznego.",
-                            "737": "Tylko z zainstalowan\u0105 p\u0142yt\u0105 Comfort/rozszerzenia: Przerwa lub zwarcie czujnika zasobnika solarnego.",
-                            "738": "Tylko z zainstalowan\u0105 p\u0142yt\u0105 Comfort/rozszerzenia: Przerwa lub zwarcie czujnika obiegu mieszaj\u0105cego 2.",
-                            "750": "Przerwa lub zwarcie zewn\u0119trznego czujnika powrotu.",
-                            "751": "Przeka\u017anik kolejno\u015bci faz zadzia\u0142a\u0142.",
-                            "752": "Przeka\u017anik kolejno\u015bci faz lub wy\u0142\u0105cznik przep\u0142ywu zadzia\u0142a\u0142.",
-                            "755": "Modu\u0142 slave nie odpowiada\u0142 przez ponad 5 minut.",
-                            "756": "Modu\u0142 master nie odpowiada\u0142 przez ponad 5 minut.",
-                            "757": "Presostat niskiego ci\u015bnienia w urz\u0105dzeniu do ciep\u0142ej wody zadzia\u0142a\u0142 wielokrotnie lub d\u0142u\u017cej ni\u017c 20 sekund.",
-                            "758": "Rozmra\u017canie zosta\u0142o 5-krotnie z rz\u0119du zako\u0144czone z powodu zbyt niskiej temperatury zasilania.",
-                            "759": "Dezynfekcja termiczna nie mog\u0142a zosta\u0107 prawid\u0142owo przeprowadzona 3-krotnie z rz\u0119du.",
-                            "760": "Rozmra\u017canie zosta\u0142o 5-krotnie z rz\u0119du zako\u0144czone po maksymalnym czasie (silny wiatr na parownik).",
+                            "709": "Przerwa lub zwarcie czujnika zasilania.\nBrak wyłączenia awaryjnego w urządzeniach S/W i W/W.",
+                            "710": "Przerwa lub zwarcie czujnika gorącego gazu w obiegu chłodniczym.",
+                            "711": "Przerwa lub zwarcie czujnika temperatury zewnętrznej.\nBrak wyłączenia awaryjnego. Wartość stała na -5 °C.",
+                            "712": "Przerwa lub zwarcie czujnika ciepłej wody.\nBrak wyłączenia awaryjnego.",
+                            "713": "Przerwa lub zwarcie czujnika źródła ciepła (wejście).",
+                            "714": "Przekroczono granice termiczne pracy pompy ciepła.\nPrzygotowywanie ciepłej wody zablokowane na gg:mm.",
+                            "715": "Presostat wysokiego ciśnienia w obiegu chłodniczym zadziałał. Po pewnym czasie automatyczny restart pompy ciepła.",
+                            "716": "Presostat wysokiego ciśnienia w obiegu chłodniczym zadziałał wielokrotnie.",
+                            "717": "Wyłącznik przepływu w urządzeniach W/W zadziałał podczas czasu wstępnego płukania lub pracy.",
+                            "718": "Tylko w urządzeniach L/W: Temperatura zewnętrzna przekroczyła dopuszczalną wartość maksymalną.",
+                            "719": "Tylko w urządzeniach L/W: Temperatura zewnętrzna spadła poniżej dopuszczalnej wartości minimalnej.",
+                            "720": "Tylko w urządzeniach S/W i W/W: Temperatura na wyjściu parownika wielokrotnie spadła poniżej wartości bezpiecznej. Automatyczny restart pompy ciepła po gg:mm.",
+                            "721": "Presostat niskiego ciśnienia w obiegu chłodniczym zadziałał. Po pewnym czasie automatyczny restart pompy ciepła (SW i WW).",
+                            "722": "Różnica temperatur w trybie grzewczym jest ujemna (=błędna).",
+                            "723": "Różnica temperatur w trybie ciepłej wody jest ujemna (=błędna).",
+                            "724": "Różnica temperatur w obiegu grzewczym podczas rozmrażania > 15 K (=zagrożenie zamarzaniem).",
+                            "725": "Awaria przygotowywania ciepłej wody, żądana temperatura zasobnika jest znacznie niższa.",
+                            "726": "Przerwa lub zwarcie czujnika obiegu mieszającego 1.",
+                            "727": "Presostat ciśnienia solanki zadziałał podczas czasu wstępnego płukania lub pracy.",
+                            "728": "Przerwa lub zwarcie czujnika źródła ciepła na wyjściu.",
+                            "729": "Sprężarka bez mocy po włączeniu.",
+                            "730": "Program wygrzewania jastrychu nie osiągnął zadanego poziomu temperatury zasilania w wyznaczonym czasie. Program wygrzewania jastrychu jest kontynuowany.",
+                            "732": "Temperatura wody grzewczej wielokrotnie spadła poniżej 16 °C.",
+                            "733": "Wejście alarmowe anody obcego prądu zadziałało.",
+                            "734": "Błąd 733 utrzymuje się od ponad dwóch tygodni, przygotowywanie ciepłej wody jest zablokowane.",
+                            "735": "Tylko z zainstalowaną płytą Comfort/rozszerzenia: Przerwa lub zwarcie czujnika zewnętrznego źródła energii.",
+                            "736": "Tylko z zainstalowaną płytą Comfort/rozszerzenia: Przerwa lub zwarcie czujnika kolektora słonecznego.",
+                            "737": "Tylko z zainstalowaną płytą Comfort/rozszerzenia: Przerwa lub zwarcie czujnika zasobnika solarnego.",
+                            "738": "Tylko z zainstalowaną płytą Comfort/rozszerzenia: Przerwa lub zwarcie czujnika obiegu mieszającego 2.",
+                            "750": "Przerwa lub zwarcie zewnętrznego czujnika powrotu.",
+                            "751": "Przekaźnik kolejności faz zadziałał.",
+                            "752": "Przekaźnik kolejności faz lub wyłącznik przepływu zadziałał.",
+                            "755": "Moduł slave nie odpowiadał przez ponad 5 minut.",
+                            "756": "Moduł master nie odpowiadał przez ponad 5 minut.",
+                            "757": "Presostat niskiego ciśnienia w urządzeniu do ciepłej wody zadziałał wielokrotnie lub dłużej niż 20 sekund.",
+                            "758": "Rozmrażanie zostało 5-krotnie z rzędu zakończone z powodu zbyt niskiej temperatury zasilania.",
+                            "759": "Dezynfekcja termiczna nie mogła zostać prawidłowo przeprowadzona 3-krotnie z rzędu.",
+                            "760": "Rozmrażanie zostało 5-krotnie z rzędu zakończone po maksymalnym czasie (silny wiatr na parownik).",
                             "761": "Przekroczenie limitu czasu LIN.",
-                            "762": "B\u0142\u0105d czujnika T\u00fc (wlot spr\u0119\u017carki).",
-                            "763": "B\u0142\u0105d czujnika T\u00fc1 (wlot parownika).",
-                            "764": "B\u0142\u0105d czujnika grzejnika spr\u0119\u017carki.",
-                            "765": "Przegrzanie poni\u017cej 2K d\u0142u\u017cej ni\u017c 5 minut.",
-                            "766": "Praca 5 minut poza zakresem zastosowania spr\u0119\u017carki.",
-                            "767": "STB grza\u0142ki na SEC zosta\u0142 aktywowany.",
-                            "770": "Przegrzanie utrzymuje si\u0119 d\u0142ugotrwale poni\u017cej warto\u015bci granicznej.",
-                            "771": "Przegrzanie utrzymuje si\u0119 d\u0142ugotrwale powy\u017cej warto\u015bci granicznej.",
-                            "776": "Spr\u0119\u017carka pracuje d\u0142ugotrwale poza swoim zakresem zastosowania.",
-                            "777": "Zaw\u00f3r rozpr\u0119\u017cny uszkodzony.",
-                            "778": "Czujnik niskiego ci\u015bnienia uszkodzony.",
-                            "779": "Czujnik wysokiego ci\u015bnienia uszkodzony.",
+                            "762": "Błąd czujnika Tü (wlot sprężarki).",
+                            "763": "Błąd czujnika Tü1 (wlot parownika).",
+                            "764": "Błąd czujnika grzejnika sprężarki.",
+                            "765": "Przegrzanie poniżej 2K dłużej niż 5 minut.",
+                            "766": "Praca 5 minut poza zakresem zastosowania sprężarki.",
+                            "767": "STB grzałki na SEC został aktywowany.",
+                            "770": "Przegrzanie utrzymuje się długotrwale poniżej wartości granicznej.",
+                            "771": "Przegrzanie utrzymuje się długotrwale powyżej wartości granicznej.",
+                            "776": "Sprężarka pracuje długotrwale poza swoim zakresem zastosowania.",
+                            "777": "Zawór rozprężny uszkodzony.",
+                            "778": "Czujnik niskiego ciśnienia uszkodzony.",
+                            "779": "Czujnik wysokiego ciśnienia uszkodzony.",
                             "780": "Czujnik EVI uszkodzony.",
-                            "781": "Czujnik temperatury cieczy przed zaworem rozpr\u0119\u017cnym uszkodzony.",
+                            "781": "Czujnik temperatury cieczy przed zaworem rozprężnym uszkodzony.",
                             "782": "Czujnik temperatury gazu zasysanego EVI uszkodzony.",
-                            "783": "Komunikacja mi\u0119dzy SEC a falownikiem zak\u0142\u00f3cona.",
+                            "783": "Komunikacja między SEC a falownikiem zakłócona.",
                             "784": "Falownik zablokowany.",
-                            "785": "Wykryto b\u0142\u0105d na p\u0142ycie SEC.",
-                            "786": "Komunikacja mi\u0119dzy p\u0142ytk\u0105 SEC a HZ/IO zak\u0142\u00f3cona przez p\u0142ytk\u0119 SEC.",
-                            "787": "Spr\u0119\u017carka zg\u0142asza b\u0142\u0105d.",
-                            "788": "B\u0142\u0105d w falowniku.",
-                            "789": "Panel sterowania nie m\u00f3g\u0142 wykry\u0107 kodowania. Albo po\u0142\u0105czenie LIN jest przerwane, albo rezystor koduj\u0105cy nie jest rozpoznawany.",
-                            "790": "B\u0142\u0105d w zasilaniu falownika/spr\u0119\u017carki.",
-                            "791": "P\u0142yta SEC nie jest dost\u0119pna od d\u0142u\u017cszego czasu. 791 jest wyzwalany, gdy znaleziono p\u0142yt\u0119 HZIO (bez osobnego kodowania), ale nie rozpoznano na niej p\u0142yty SEC.",
-                            "792": "Nie znaleziono p\u0142yty g\u0142\u00f3wnej ani \u017cadnej konfiguracji.",
-                            "793": "B\u0142\u0105d temperatury w falowniku.",
-                            "minus_1": "Nieznany b\u0142\u0105d",
-                            "731": "Temperatura wymagana do dezynfekcji termicznej nie zosta\u0142a osi\u0105gni\u0119ta w ustawionym czasie prze\u0142\u0105czania.",
-                            "739": "Tylko przy zamontowanej p\u0142ytce rozszerze\u0144: przerwa lub zwarcie czujnika \u201eobwodu mieszaj\u0105cego 3\u201d.",
-                            "794": "Przepi\u0119cie na falowniku.",
-                            "795": "Zbyt niskie napi\u0119cie na falowniku.",
-                            "796": "Uruchomiono wej\u015bcie bezpiecze\u0144stwa. Przypadek 1: usterka falownika. Reset automatyczny. Przypadek 2: zadzia\u0142a\u0142y presostaty wysokiego ci\u015bnienia w obiegu ch\u0142odniczym. Reset automatyczny. Przypadek 3: tylko komunikat LWDV spowodowany wahaniami napi\u0119cia przekraczaj\u0105cymi dopuszczaln\u0105 norm\u0119.",
-                            "797": "Regulacja grza\u0142ki elektrycznej nie jest obs\u0142ugiwana.",
+                            "785": "Wykryto błąd na płycie SEC.",
+                            "786": "Komunikacja między płytką SEC a HZ/IO zakłócona przez płytkę SEC.",
+                            "787": "Sprężarka zgłasza błąd.",
+                            "788": "Błąd w falowniku.",
+                            "789": "Panel sterowania nie mógł wykryć kodowania. Albo połączenie LIN jest przerwane, albo rezystor kodujący nie jest rozpoznawany.",
+                            "790": "Błąd w zasilaniu falownika/sprężarki.",
+                            "791": "Płyta SEC nie jest dostępna od dłuższego czasu. 791 jest wyzwalany, gdy znaleziono płytę HZIO (bez osobnego kodowania), ale nie rozpoznano na niej płyty SEC.",
+                            "792": "Nie znaleziono płyty głównej ani żadnej konfiguracji.",
+                            "793": "Błąd temperatury w falowniku.",
+                            "minus_1": "Nieznany błąd",
+                            "731": "Temperatura wymagana do dezynfekcji termicznej nie została osiągnięta w ustawionym czasie przełączania.",
+                            "739": "Tylko przy zamontowanej płytce rozszerzeń: przerwa lub zwarcie czujnika „obwodu mieszającego 3”.",
+                            "794": "Przepięcie na falowniku.",
+                            "795": "Zbyt niskie napięcie na falowniku.",
+                            "796": "Uruchomiono wejście bezpieczeństwa. Przypadek 1: usterka falownika. Reset automatyczny. Przypadek 2: zadziałały presostaty wysokiego ciśnienia w obiegu chłodniczym. Reset automatyczny. Przypadek 3: tylko komunikat LWDV spowodowany wahaniami napięcia przekraczającymi dopuszczalną normę.",
+                            "797": "Regulacja grzałki elektrycznej nie jest obsługiwana.",
                             "798": "Brak komunikacji ModBus z wentylatorem od co najmniej 10 sekund. Reset automatyczny.",
-                            "799": "Brak komunikacji ModBus z p\u0142ytk\u0105 ASB od co najmniej 10 sekund. Reset automatyczny.",
-                            "800": "Wy\u0142\u0105czenie nast\u0119puje, gdy temperatura desuperheatera osi\u0105gnie \u2265 80\u00b0C. Urz\u0105dzenie zostaje wy\u0142\u0105czone i zapisywana jest warto\u015b\u0107 D0_Pause w historii wy\u0142\u0105cze\u0144. Urz\u0105dzenie jest ponownie dopuszczane do pracy po 2 godzinach. Je\u015bli wy\u0142\u0105czenie wyst\u0105pi 5 razy w ci\u0105gu 24 godzin, b\u0142\u0105d 800 zostaje zapisany w pami\u0119ci b\u0142\u0119d\u00f3w.",
-                            "802": "Wy\u0142\u0105czenie nast\u0119puje, gdy temperatura w skrzynce elektrycznej osi\u0105gnie \u2265 80\u00b0C. Gdy temperatura spadnie poni\u017cej 70\u00b0C, pompa ciep\u0142a uruchamia si\u0119 ponownie. Reset automatyczny.",
-                            "803": "B\u0142\u0105d 802 wyst\u0105pi\u0142 3 razy w ci\u0105gu 24 godzin. Wymagany r\u0119czny reset. Je\u015bli temperatura w skrzynce elektrycznej nadal wynosi \u2265 80\u00b0C, b\u0142\u0105d zostanie natychmiast wywo\u0142any ponownie.",
-                            "806": "P\u0142ytka SEC nie ma komunikacji ModBus od co najmniej 10 sekund lub zapytanie nie powiod\u0142o si\u0119 10 razy z rz\u0119du. Reset automatyczny.",
-                            "807": "Wszystkie mo\u017cliwe usterki komunikacji ModBus z komponentami urz\u0105dzenia wyst\u0119puj\u0105 jednocze\u015bnie od co najmniej 10 sekund. Reset automatyczny.",
-                            "768": "5-krotnie z rz\u0119du zbyt ma\u0142y przep\u0142yw przed rozmra\u017caniem.",
-                            "769": "Brak prawid\u0142owego sygna\u0142u przep\u0142ywu z pompy obiegowej. Reset automatyczny."
+                            "799": "Brak komunikacji ModBus z płytką ASB od co najmniej 10 sekund. Reset automatyczny.",
+                            "800": "Wyłączenie następuje, gdy temperatura desuperheatera osiągnie ≥ 80°C. Urządzenie zostaje wyłączone i zapisywana jest wartość D0_Pause w historii wyłączeń. Urządzenie jest ponownie dopuszczane do pracy po 2 godzinach. Jeśli wyłączenie wystąpi 5 razy w ciągu 24 godzin, błąd 800 zostaje zapisany w pamięci błędów.",
+                            "802": "Wyłączenie następuje, gdy temperatura w skrzynce elektrycznej osiągnie ≥ 80°C. Gdy temperatura spadnie poniżej 70°C, pompa ciepła uruchamia się ponownie. Reset automatyczny.",
+                            "803": "Błąd 802 wystąpił 3 razy w ciągu 24 godzin. Wymagany ręczny reset. Jeśli temperatura w skrzynce elektrycznej nadal wynosi ≥ 80°C, błąd zostanie natychmiast wywołany ponownie.",
+                            "806": "Płytka SEC nie ma komunikacji ModBus od co najmniej 10 sekund lub zapytanie nie powiodło się 10 razy z rzędu. Reset automatyczny.",
+                            "807": "Wszystkie możliwe usterki komunikacji ModBus z komponentami urządzenia występują jednocześnie od co najmniej 10 sekund. Reset automatyczny.",
+                            "768": "5-krotnie z rzędu zbyt mały przepływ przed rozmrażaniem.",
+                            "769": "Brak prawidłowego sygnału przepływu z pompy obiegowej. Reset automatyczny."
                         }
                     },
                     "remedy": {
-                        "name": "Rozwi\u0105zanie",
+                        "name": "Rozwiązanie",
                         "state": {
-                            "701": "Sprawd\u017a pomp\u0119 ciep\u0142a pod k\u0105tem nieszczelno\u015bci, punkt prze\u0142\u0105czania presostatu, rozmra\u017canie i minimaln\u0105 temperatur\u0119 powietrza.",
-                            "702": "Sprawd\u017a pomp\u0119 ciep\u0142a pod k\u0105tem nieszczelno\u015bci, punkt prze\u0142\u0105czania presostatu, rozmra\u017canie i minimaln\u0105 temperatur\u0119 powietrza.",
-                            "703": "Sprawd\u017a wydajno\u015b\u0107 pompy ciep\u0142a, zaw\u00f3r rozmra\u017caj\u0105cy i instalacj\u0119 grzewcz\u0105.",
-                            "704": "Sprawd\u017a ilo\u015b\u0107 czynnika ch\u0142odniczego, parowanie, przegrzanie, zasilanie, powr\u00f3t i minimaln\u0105 temperatur\u0119 \u017ar\u00f3d\u0142a ciep\u0142a.",
-                            "705": "Sprawd\u017a wentylator.",
-                            "706": "Sprawd\u017a ustawione warto\u015bci, spr\u0119\u017cark\u0119, BOSUP.",
-                            "707": "Sprawd\u017a rezystor koduj\u0105cy w pompie ciep\u0142a, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "708": "Sprawd\u017a czujnik powrotu, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "709": "Sprawd\u017a czujnik zasilania, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "710": "Sprawd\u017a czujnik gor\u0105cego gazu, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "711": "Sprawd\u017a czujnik temperatury zewn\u0119trznej, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "712": "Sprawd\u017a czujnik ciep\u0142ej wody, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "713": "Sprawd\u017a czujnik \u017ar\u00f3d\u0142a ciep\u0142a, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "714": "Sprawd\u017a przep\u0142yw ciep\u0142ej wody, wymiennik ciep\u0142a, temperatur\u0119 ciep\u0142ej wody i pomp\u0119 obiegow\u0105 ciep\u0142ej wody.",
-                            "715": "Sprawd\u017a przep\u0142yw wody grzewczej, przep\u0142yw nadmiarowy, temperatur\u0119 i kondensacj\u0119.",
-                            "716": "Sprawd\u017a przep\u0142yw wody grzewczej, przep\u0142yw nadmiarowy, temperatur\u0119 i kondensacj\u0119.",
-                            "717": "Sprawd\u017a przep\u0142yw, punkt prze\u0142\u0105czania DFS, filtr, odpowietrzenie.",
-                            "718": "Sprawd\u017a temperatur\u0119 zewn\u0119trzn\u0105 i ustawion\u0105 warto\u015b\u0107.",
-                            "719": "Sprawd\u017a temperatur\u0119 zewn\u0119trzn\u0105 i ustawion\u0105 warto\u015b\u0107.",
-                            "720": "Sprawd\u017a przep\u0142yw, filtr, odpowietrzenie, temperatur\u0119.",
-                            "721": "Sprawd\u017a punkt prze\u0142\u0105czania presostatu, przep\u0142yw po stronie \u017ar\u00f3d\u0142a ciep\u0142a.",
-                            "722": "Sprawd\u017a dzia\u0142anie i umiejscowienie czujnik\u00f3w zasilania i powrotu.",
-                            "723": "Sprawd\u017a dzia\u0142anie i umiejscowienie czujnik\u00f3w zasilania i powrotu.",
-                            "724": "Sprawd\u017a dzia\u0142anie i umiejscowienie czujnik\u00f3w zasilania i powrotu, wydajno\u015b\u0107 HUP, przep\u0142yw nadmiarowy i obiegi grzewcze.",
-                            "725": "Sprawd\u017a pomp\u0119 obiegow\u0105 CWU, nape\u0142nienie zasobnika, zawory odcinaj\u0105ce i zaw\u00f3r tr\u00f3jdro\u017cny. Odpowietrz wod\u0119 grzewcz\u0105 i CWU.",
-                            "726": "Sprawd\u017a czujnik obiegu mieszaj\u0105cego, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "727": "Sprawd\u017a ci\u015bnienie solanki i presostat ci\u015bnienia solanki.",
-                            "728": "Sprawd\u017a czujnik \u017ar\u00f3d\u0142a ciep\u0142a, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "729": "Sprawd\u017a pole wiruj\u0105ce i spr\u0119\u017cark\u0119.",
-                            "730": "Sprawd\u017a zapotrzebowanie mocy podczas wygrzewania jastrychu.",
-                            "732": "Sprawd\u017a mieszacz i pomp\u0119 obiegow\u0105 ogrzewania.",
-                            "733": "Sprawd\u017a przew\u00f3d po\u0142\u0105czeniowy anody i potencjostat. Nape\u0142nij zasobnik CWU.",
-                            "734": "Tymczasowo potwierd\u017a b\u0142\u0105d, aby przywr\u00f3ci\u0107 przygotowywanie ciep\u0142ej wody. Napraw b\u0142\u0105d 733.",
-                            "735": "Sprawd\u017a czujnik zewn\u0119trznego \u017ar\u00f3d\u0142a energii, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "736": "Sprawd\u017a czujnik kolektora s\u0142onecznego, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "737": "Sprawd\u017a czujnik zasobnika solarnego, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "738": "Sprawd\u017a czujnik obiegu mieszaj\u0105cego 2, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "750": "Sprawd\u017a zewn\u0119trzny czujnik powrotu, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "751": "Sprawd\u017a pole wiruj\u0105ce i przeka\u017anik kolejno\u015bci faz.",
-                            "752": "Patrz b\u0142\u0105d nr 751 i nr 717.",
-                            "755": "Sprawd\u017a po\u0142\u0105czenie sieciowe, prze\u0142\u0105cznik i adresy IP. W razie potrzeby ponownie uruchom wyszukiwanie pompy ciep\u0142a.",
-                            "756": "Sprawd\u017a po\u0142\u0105czenie sieciowe, prze\u0142\u0105cznik i adresy IP. W razie potrzeby ponownie uruchom wyszukiwanie pompy ciep\u0142a.",
-                            "757": "Przy 3-krotnym wyst\u0105pieniu tej usterki urz\u0105dzenie mo\u017ce odblokowa\u0107 wy\u0142\u0105cznie autoryzowany serwis!",
-                            "758": "Sprawd\u017a przep\u0142yw i czujnik zasilania.",
-                            "759": "Sprawd\u017a ustawienia drugiego \u017ar\u00f3d\u0142a ciep\u0142a i ogranicznik temperatury bezpiecze\u0144stwa.",
-                            "760": "Chro\u0144 wentylator i parownik przed silnym wiatrem.",
-                            "761": "Sprawd\u017a kabel/styk.",
-                            "762": "Sprawd\u017a czujnik, ewentualnie wymie\u0144.",
-                            "763": "Sprawd\u017a czujnik, ewentualnie wymie\u0144.",
-                            "764": "Sprawd\u017a czujnik, ewentualnie wymie\u0144.",
-                            "765": "Przy pierwszym uruchomieniu: sprawd\u017a pole wiruj\u0105ce, w przeciwnym razie zadzwo\u0144 do serwisu.",
-                            "766": "Sprawd\u017a pole wiruj\u0105ce.",
-                            "767": "Sprawd\u017a grza\u0142k\u0119 i ponownie wci\u015bnij bezpiecznik.",
-                            "770": "Sprawd\u017a czujnik temperatury, czujnik ci\u015bnienia i zaw\u00f3r rozpr\u0119\u017cny.",
-                            "771": "Sprawd\u017a czujnik temperatury, czujnik ci\u015bnienia, nape\u0142nienie i zaw\u00f3r rozpr\u0119\u017cny.",
-                            "776": "Sprawd\u017a termodynamik\u0119.",
-                            "777": "Sprawd\u017a zaw\u00f3r rozpr\u0119\u017cny, kabel po\u0142\u0105czeniowy i ewentualnie p\u0142yt\u0119 SEC.",
-                            "778": "Sprawd\u017a czujnik, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "779": "Sprawd\u017a czujnik, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "780": "Sprawd\u017a czujnik, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "781": "Sprawd\u017a czujnik, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "782": "Sprawd\u017a czujnik, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "783": "Sprawd\u017a kabel po\u0142\u0105czeniowy, kondensatory przeciwzak\u0142\u00f3ceniowe i okablowanie.",
-                            "784": "Wy\u0142\u0105cz ca\u0142\u0105 instalacj\u0119 na 2 minuty z zasilania. Przy powtarzaj\u0105cym si\u0119 b\u0142\u0119dzie sprawd\u017a falownik i spr\u0119\u017cark\u0119.",
-                            "785": "Wymie\u0144 p\u0142yt\u0119 SEC.",
-                            "786": "Sprawd\u017a okablowanie HZ/IO - p\u0142ytka SEC.",
-                            "787": "Potwierd\u017a usterk\u0119. Je\u015bli b\u0142\u0105d wyst\u0119puje wielokrotnie, wezwij autoryzowany serwis.",
-                            "788": "Sprawd\u017a falownik.",
-                            "789": "Sprawd\u017a kabel po\u0142\u0105czeniowy LIN/rezystor koduj\u0105cy.",
-                            "790": "Sprawd\u017a okablowanie, falownik i spr\u0119\u017cark\u0119.",
-                            "791": "Je\u015bli dotyczy konfiguracji SEC, sprawd\u017a kabel ModBus mi\u0119dzy HZIO a p\u0142yt\u0105 SEC. Sprawd\u017a r\u00f3wnie\u017c p\u0142yt\u0119 SEC, czy wszystko miga prawid\u0142owo. Je\u015bli to NIE jest konfiguracja z p\u0142yt\u0105 SEC (np. urz\u0105dzenie P184), sprawd\u017a rezystor koduj\u0105cy HZIO.",
-                            "792": "Sprawd\u017a wtyczk\u0119 koduj\u0105c\u0105 na p\u0142ycie LIN.",
-                            "793": "B\u0142\u0105d usuwa si\u0119 samoczynnie.",
-                            "739": "Sprawd\u017a czujnik \u201eobwodu mieszaj\u0105cego 3\u201d, wtyczk\u0119 i przew\u00f3d po\u0142\u0105czeniowy.",
-                            "794": "Sprawd\u017a zasilanie falownika.",
-                            "795": "Sprawd\u017a zasilanie falownika.",
-                            "796": "Przypadek 1: sprawd\u017a falownik. Usu\u0144 usterk\u0119. Przypadek 2: sprawd\u017a przep\u0142yw wody grzewczej, przelewy, czujnik temperatury zasilania i czujnik wysokiego ci\u015bnienia. Usu\u0144 usterk\u0119. Przypadek 3: nale\u017cy r\u0119cznie wy\u0142\u0105czy\u0107 i ponownie zabezpieczy\u0107.",
-                            "798": "Sprawd\u017a okablowanie ModBus wentylatora.",
-                            "799": "Sprawd\u017a okablowanie ModBus p\u0142ytki ASB.",
-                            "800": "Odbierz energi\u0119 z zasobnika desuperheatera. Urz\u0105dzenie mo\u017cna ponownie uruchomi\u0107, gdy tylko temperatura spadnie poni\u017cej 80\u00b0C.",
-                            "802": "Sprawd\u017a dzia\u0142anie wentylatora. Sprawd\u017a przew\u00f3d przy\u0142\u0105czeniowy. Sprawd\u017a czujnik. Sprawd\u017a otwory skrzynki rozdzielczej pod k\u0105tem zatkania.",
-                            "803": "Sprawd\u017a dzia\u0142anie wentylatora. Sprawd\u017a przew\u00f3d przy\u0142\u0105czeniowy. Sprawd\u017a czujnik. Sprawd\u017a otwory skrzynki rozdzielczej pod k\u0105tem zatkania.",
-                            "806": "Sprawd\u017a okablowanie ModBus p\u0142ytki SEC.",
-                            "807": "Sprawd\u017a interfejs ModBus na module steruj\u0105cym, przew\u00f3d po\u0142\u0105czeniowy do rozdzielacza ModBus oraz sam rozdzielacz ModBus. Sprawd\u017a okablowanie ModBus.",
-                            "768": "Sprawd\u017a przep\u0142yw wody grzewczej i przelewy. Usu\u0144 usterk\u0119.",
-                            "769": "Sprawd\u017a okablowanie obci\u0105\u017cenia i sterowanie pompy obiegowej. Usu\u0144 usterk\u0119."
+                            "701": "Sprawdź pompę ciepła pod kątem nieszczelności, punkt przełączania presostatu, rozmrażanie i minimalną temperaturę powietrza.",
+                            "702": "Sprawdź pompę ciepła pod kątem nieszczelności, punkt przełączania presostatu, rozmrażanie i minimalną temperaturę powietrza.",
+                            "703": "Sprawdź wydajność pompy ciepła, zawór rozmrażający i instalację grzewczą.",
+                            "704": "Sprawdź ilość czynnika chłodniczego, parowanie, przegrzanie, zasilanie, powrót i minimalną temperaturę źródła ciepła.",
+                            "705": "Sprawdź wentylator.",
+                            "706": "Sprawdź ustawione wartości, sprężarkę, BOSUP.",
+                            "707": "Sprawdź rezystor kodujący w pompie ciepła, wtyczkę i przewód połączeniowy.",
+                            "708": "Sprawdź czujnik powrotu, wtyczkę i przewód połączeniowy.",
+                            "709": "Sprawdź czujnik zasilania, wtyczkę i przewód połączeniowy.",
+                            "710": "Sprawdź czujnik gorącego gazu, wtyczkę i przewód połączeniowy.",
+                            "711": "Sprawdź czujnik temperatury zewnętrznej, wtyczkę i przewód połączeniowy.",
+                            "712": "Sprawdź czujnik ciepłej wody, wtyczkę i przewód połączeniowy.",
+                            "713": "Sprawdź czujnik źródła ciepła, wtyczkę i przewód połączeniowy.",
+                            "714": "Sprawdź przepływ ciepłej wody, wymiennik ciepła, temperaturę ciepłej wody i pompę obiegową ciepłej wody.",
+                            "715": "Sprawdź przepływ wody grzewczej, przepływ nadmiarowy, temperaturę i kondensację.",
+                            "716": "Sprawdź przepływ wody grzewczej, przepływ nadmiarowy, temperaturę i kondensację.",
+                            "717": "Sprawdź przepływ, punkt przełączania DFS, filtr, odpowietrzenie.",
+                            "718": "Sprawdź temperaturę zewnętrzną i ustawioną wartość.",
+                            "719": "Sprawdź temperaturę zewnętrzną i ustawioną wartość.",
+                            "720": "Sprawdź przepływ, filtr, odpowietrzenie, temperaturę.",
+                            "721": "Sprawdź punkt przełączania presostatu, przepływ po stronie źródła ciepła.",
+                            "722": "Sprawdź działanie i umiejscowienie czujników zasilania i powrotu.",
+                            "723": "Sprawdź działanie i umiejscowienie czujników zasilania i powrotu.",
+                            "724": "Sprawdź działanie i umiejscowienie czujników zasilania i powrotu, wydajność HUP, przepływ nadmiarowy i obiegi grzewcze.",
+                            "725": "Sprawdź pompę obiegową CWU, napełnienie zasobnika, zawory odcinające i zawór trójdrożny. Odpowietrz wodę grzewczą i CWU.",
+                            "726": "Sprawdź czujnik obiegu mieszającego, wtyczkę i przewód połączeniowy.",
+                            "727": "Sprawdź ciśnienie solanki i presostat ciśnienia solanki.",
+                            "728": "Sprawdź czujnik źródła ciepła, wtyczkę i przewód połączeniowy.",
+                            "729": "Sprawdź pole wirujące i sprężarkę.",
+                            "730": "Sprawdź zapotrzebowanie mocy podczas wygrzewania jastrychu.",
+                            "732": "Sprawdź mieszacz i pompę obiegową ogrzewania.",
+                            "733": "Sprawdź przewód połączeniowy anody i potencjostat. Napełnij zasobnik CWU.",
+                            "734": "Tymczasowo potwierdź błąd, aby przywrócić przygotowywanie ciepłej wody. Napraw błąd 733.",
+                            "735": "Sprawdź czujnik zewnętrznego źródła energii, wtyczkę i przewód połączeniowy.",
+                            "736": "Sprawdź czujnik kolektora słonecznego, wtyczkę i przewód połączeniowy.",
+                            "737": "Sprawdź czujnik zasobnika solarnego, wtyczkę i przewód połączeniowy.",
+                            "738": "Sprawdź czujnik obiegu mieszającego 2, wtyczkę i przewód połączeniowy.",
+                            "750": "Sprawdź zewnętrzny czujnik powrotu, wtyczkę i przewód połączeniowy.",
+                            "751": "Sprawdź pole wirujące i przekaźnik kolejności faz.",
+                            "752": "Patrz błąd nr 751 i nr 717.",
+                            "755": "Sprawdź połączenie sieciowe, przełącznik i adresy IP. W razie potrzeby ponownie uruchom wyszukiwanie pompy ciepła.",
+                            "756": "Sprawdź połączenie sieciowe, przełącznik i adresy IP. W razie potrzeby ponownie uruchom wyszukiwanie pompy ciepła.",
+                            "757": "Przy 3-krotnym wystąpieniu tej usterki urządzenie może odblokować wyłącznie autoryzowany serwis!",
+                            "758": "Sprawdź przepływ i czujnik zasilania.",
+                            "759": "Sprawdź ustawienia drugiego źródła ciepła i ogranicznik temperatury bezpieczeństwa.",
+                            "760": "Chroń wentylator i parownik przed silnym wiatrem.",
+                            "761": "Sprawdź kabel/styk.",
+                            "762": "Sprawdź czujnik, ewentualnie wymień.",
+                            "763": "Sprawdź czujnik, ewentualnie wymień.",
+                            "764": "Sprawdź czujnik, ewentualnie wymień.",
+                            "765": "Przy pierwszym uruchomieniu: sprawdź pole wirujące, w przeciwnym razie zadzwoń do serwisu.",
+                            "766": "Sprawdź pole wirujące.",
+                            "767": "Sprawdź grzałkę i ponownie wciśnij bezpiecznik.",
+                            "770": "Sprawdź czujnik temperatury, czujnik ciśnienia i zawór rozprężny.",
+                            "771": "Sprawdź czujnik temperatury, czujnik ciśnienia, napełnienie i zawór rozprężny.",
+                            "776": "Sprawdź termodynamikę.",
+                            "777": "Sprawdź zawór rozprężny, kabel połączeniowy i ewentualnie płytę SEC.",
+                            "778": "Sprawdź czujnik, wtyczkę i przewód połączeniowy.",
+                            "779": "Sprawdź czujnik, wtyczkę i przewód połączeniowy.",
+                            "780": "Sprawdź czujnik, wtyczkę i przewód połączeniowy.",
+                            "781": "Sprawdź czujnik, wtyczkę i przewód połączeniowy.",
+                            "782": "Sprawdź czujnik, wtyczkę i przewód połączeniowy.",
+                            "783": "Sprawdź kabel połączeniowy, kondensatory przeciwzakłóceniowe i okablowanie.",
+                            "784": "Wyłącz całą instalację na 2 minuty z zasilania. Przy powtarzającym się błędzie sprawdź falownik i sprężarkę.",
+                            "785": "Wymień płytę SEC.",
+                            "786": "Sprawdź okablowanie HZ/IO - płytka SEC.",
+                            "787": "Potwierdź usterkę. Jeśli błąd występuje wielokrotnie, wezwij autoryzowany serwis.",
+                            "788": "Sprawdź falownik.",
+                            "789": "Sprawdź kabel połączeniowy LIN/rezystor kodujący.",
+                            "790": "Sprawdź okablowanie, falownik i sprężarkę.",
+                            "791": "Jeśli dotyczy konfiguracji SEC, sprawdź kabel ModBus między HZIO a płytą SEC. Sprawdź również płytę SEC, czy wszystko miga prawidłowo. Jeśli to NIE jest konfiguracja z płytą SEC (np. urządzenie P184), sprawdź rezystor kodujący HZIO.",
+                            "792": "Sprawdź wtyczkę kodującą na płycie LIN.",
+                            "793": "Błąd usuwa się samoczynnie.",
+                            "739": "Sprawdź czujnik „obwodu mieszającego 3”, wtyczkę i przewód połączeniowy.",
+                            "794": "Sprawdź zasilanie falownika.",
+                            "795": "Sprawdź zasilanie falownika.",
+                            "796": "Przypadek 1: sprawdź falownik. Usuń usterkę. Przypadek 2: sprawdź przepływ wody grzewczej, przelewy, czujnik temperatury zasilania i czujnik wysokiego ciśnienia. Usuń usterkę. Przypadek 3: należy ręcznie wyłączyć i ponownie zabezpieczyć.",
+                            "798": "Sprawdź okablowanie ModBus wentylatora.",
+                            "799": "Sprawdź okablowanie ModBus płytki ASB.",
+                            "800": "Odbierz energię z zasobnika desuperheatera. Urządzenie można ponownie uruchomić, gdy tylko temperatura spadnie poniżej 80°C.",
+                            "802": "Sprawdź działanie wentylatora. Sprawdź przewód przyłączeniowy. Sprawdź czujnik. Sprawdź otwory skrzynki rozdzielczej pod kątem zatkania.",
+                            "803": "Sprawdź działanie wentylatora. Sprawdź przewód przyłączeniowy. Sprawdź czujnik. Sprawdź otwory skrzynki rozdzielczej pod kątem zatkania.",
+                            "806": "Sprawdź okablowanie ModBus płytki SEC.",
+                            "807": "Sprawdź interfejs ModBus na module sterującym, przewód połączeniowy do rozdzielacza ModBus oraz sam rozdzielacz ModBus. Sprawdź okablowanie ModBus.",
+                            "768": "Sprawdź przepływ wody grzewczej i przelewy. Usuń usterkę.",
+                            "769": "Sprawdź okablowanie obciążenia i sterowanie pompy obiegowej. Usuń usterkę."
                         }
                     }
                 }
             },
             "switchoff_reason": {
-                "name": "Pow\u00f3d wy\u0142\u0105czenia",
+                "name": "Powód wyłączenia",
                 "state": {
-                    "0": "Zak\u0142\u00f3cenie pompy ciep\u0142a",
-                    "1": "Zak\u0142\u00f3cenie instalacji",
-                    "2": "Tryb pracy drugiego generatora ciep\u0142a",
+                    "0": "Zakłócenie pompy ciepła",
+                    "1": "Zakłócenie instalacji",
+                    "2": "Tryb pracy drugiego generatora ciepła",
                     "3": "Blokada EVU",
                     "4": "",
                     "5": "Odszranianie powietrzem",
-                    "6": "Maksymalne ograniczenie temperatury u\u017cytkowania",
-                    "7": "Ograniczenie temperatury u\u017cytkowania minimalne",
-                    "8": "Ni\u017csze ograniczenie u\u017cytkowania",
+                    "6": "Maksymalne ograniczenie temperatury użytkowania",
+                    "7": "Ograniczenie temperatury użytkowania minimalne",
+                    "8": "Niższe ograniczenie użytkowania",
                     "9": "Brak zapotrzebowania",
-                    "10": "Zewn\u0119trzne \u017ar\u00f3d\u0142o energii",
-                    "11": "Przep\u0142yw",
-                    "12": "Pauza niskiego ci\u015bnienia",
+                    "10": "Zewnętrzne źródło energii",
+                    "11": "Przepływ",
+                    "12": "Pauza niskiego ciśnienia",
                     "13": "Pauza przegrzania",
                     "14": "Pauza falownika",
                     "15": "Pauza desuperheatera",
-                    "16": "Tryb pracy prze\u0142\u0105czania",
-                    "17": "Inne wy\u0142\u0105czenie",
-                    "18": "Minimalny przep\u0142yw ch\u0142odzenia",
+                    "16": "Tryb pracy przełączania",
+                    "17": "Inne wyłączenie",
+                    "18": "Minimalny przepływ chłodzenia",
                     "19": "PV max",
-                    "20": "Pauza gor\u0105cego gazu",
-                    "21": "Pauza przegrzania gor\u0105cego gazu",
+                    "20": "Pauza gorącego gazu",
+                    "21": "Pauza przegrzania gorącego gazu",
                     "22": "Brak zapotrzebowania",
-                    "23": "Minimalna temperatura wylotowa dolnego \u017ar\u00f3d\u0142a przy ch\u0142odzeniu",
+                    "23": "Minimalna temperatura wylotowa dolnego źródła przy chłodzeniu",
                     "24": "LPC",
                     "25": "Restart",
                     "27": "Maksymalna temperatura zasilania"
@@ -609,32 +609,32 @@
                         "name": "Czas"
                     },
                     "code_1": {
-                        "name": "Przedostatnie wy\u0142\u0105czenie",
+                        "name": "Przedostatnie wyłączenie",
                         "state": {
-                            "0": "Zak\u0142\u00f3cenie pompy ciep\u0142a",
-                            "1": "Zak\u0142\u00f3cenie instalacji",
-                            "2": "Tryb pracy drugiego generatora ciep\u0142a",
+                            "0": "Zakłócenie pompy ciepła",
+                            "1": "Zakłócenie instalacji",
+                            "2": "Tryb pracy drugiego generatora ciepła",
                             "3": "Blokada EVU",
                             "4": "",
                             "5": "Odszranianie powietrzem",
-                            "6": "Maksymalne ograniczenie temperatury u\u017cytkowania",
-                            "7": "Ograniczenie temperatury u\u017cytkowania minimalne",
-                            "8": "Ni\u017csze ograniczenie u\u017cytkowania",
+                            "6": "Maksymalne ograniczenie temperatury użytkowania",
+                            "7": "Ograniczenie temperatury użytkowania minimalne",
+                            "8": "Niższe ograniczenie użytkowania",
                             "9": "Brak zapotrzebowania",
-                            "10": "Zewn\u0119trzne \u017ar\u00f3d\u0142o energii",
-                            "11": "Przep\u0142yw",
-                            "12": "Pauza niskiego ci\u015bnienia",
+                            "10": "Zewnętrzne źródło energii",
+                            "11": "Przepływ",
+                            "12": "Pauza niskiego ciśnienia",
                             "13": "Pauza przegrzania",
                             "14": "Pauza falownika",
                             "15": "Pauza desuperheatera",
-                            "16": "Tryb pracy prze\u0142\u0105czania",
-                            "17": "Inne wy\u0142\u0105czenie",
-                            "18": "Minimalny przep\u0142yw ch\u0142odzenia",
+                            "16": "Tryb pracy przełączania",
+                            "17": "Inne wyłączenie",
+                            "18": "Minimalny przepływ chłodzenia",
                             "19": "PV max",
-                            "20": "Pauza gor\u0105cego gazu",
-                            "21": "Pauza przegrzania gor\u0105cego gazu",
+                            "20": "Pauza gorącego gazu",
+                            "21": "Pauza przegrzania gorącego gazu",
                             "22": "Brak zapotrzebowania",
-                            "23": "Minimalna temperatura wylotowa dolnego \u017ar\u00f3d\u0142a przy ch\u0142odzeniu",
+                            "23": "Minimalna temperatura wylotowa dolnego źródła przy chłodzeniu",
                             "24": "LPC",
                             "25": "Restart",
                             "27": "Maksymalna temperatura zasilania"
@@ -644,125 +644,125 @@
                         "name": "Przedostatni czas"
                     },
                     "code_2": {
-                        "name": "Trzecie od ko\u0144ca wy\u0142\u0105czenie",
+                        "name": "Trzecie od końca wyłączenie",
                         "state": {
-                            "0": "Zak\u0142\u00f3cenie pompy ciep\u0142a",
-                            "1": "Zak\u0142\u00f3cenie instalacji",
-                            "2": "Tryb pracy drugiego generatora ciep\u0142a",
+                            "0": "Zakłócenie pompy ciepła",
+                            "1": "Zakłócenie instalacji",
+                            "2": "Tryb pracy drugiego generatora ciepła",
                             "3": "Blokada EVU",
                             "4": "",
                             "5": "Odszranianie powietrzem",
-                            "6": "Maksymalne ograniczenie temperatury u\u017cytkowania",
-                            "7": "Ograniczenie temperatury u\u017cytkowania minimalne",
-                            "8": "Ni\u017csze ograniczenie u\u017cytkowania",
+                            "6": "Maksymalne ograniczenie temperatury użytkowania",
+                            "7": "Ograniczenie temperatury użytkowania minimalne",
+                            "8": "Niższe ograniczenie użytkowania",
                             "9": "Brak zapotrzebowania",
-                            "10": "Zewn\u0119trzne \u017ar\u00f3d\u0142o energii",
-                            "11": "Przep\u0142yw",
-                            "12": "Pauza niskiego ci\u015bnienia",
+                            "10": "Zewnętrzne źródło energii",
+                            "11": "Przepływ",
+                            "12": "Pauza niskiego ciśnienia",
                             "13": "Pauza przegrzania",
                             "14": "Pauza falownika",
                             "15": "Pauza desuperheatera",
-                            "16": "Tryb pracy prze\u0142\u0105czania",
-                            "17": "Inne wy\u0142\u0105czenie",
-                            "18": "Minimalny przep\u0142yw ch\u0142odzenia",
+                            "16": "Tryb pracy przełączania",
+                            "17": "Inne wyłączenie",
+                            "18": "Minimalny przepływ chłodzenia",
                             "19": "PV max",
-                            "20": "Pauza gor\u0105cego gazu",
-                            "21": "Pauza przegrzania gor\u0105cego gazu",
+                            "20": "Pauza gorącego gazu",
+                            "21": "Pauza przegrzania gorącego gazu",
                             "22": "Brak zapotrzebowania",
-                            "23": "Minimalna temperatura wylotowa dolnego \u017ar\u00f3d\u0142a przy ch\u0142odzeniu",
+                            "23": "Minimalna temperatura wylotowa dolnego źródła przy chłodzeniu",
                             "24": "LPC",
                             "25": "Restart",
                             "27": "Maksymalna temperatura zasilania"
                         }
                     },
                     "timestamp_2": {
-                        "name": "Trzeci od ko\u0144ca czas"
+                        "name": "Trzeci od końca czas"
                     },
                     "code_3": {
-                        "name": "Czwarte od ko\u0144ca wy\u0142\u0105czenie",
+                        "name": "Czwarte od końca wyłączenie",
                         "state": {
-                            "0": "Zak\u0142\u00f3cenie pompy ciep\u0142a",
-                            "1": "Zak\u0142\u00f3cenie instalacji",
-                            "2": "Tryb pracy drugiego generatora ciep\u0142a",
+                            "0": "Zakłócenie pompy ciepła",
+                            "1": "Zakłócenie instalacji",
+                            "2": "Tryb pracy drugiego generatora ciepła",
                             "3": "Blokada EVU",
                             "4": "",
                             "5": "Odszranianie powietrzem",
-                            "6": "Maksymalne ograniczenie temperatury u\u017cytkowania",
-                            "7": "Ograniczenie temperatury u\u017cytkowania minimalne",
-                            "8": "Ni\u017csze ograniczenie u\u017cytkowania",
+                            "6": "Maksymalne ograniczenie temperatury użytkowania",
+                            "7": "Ograniczenie temperatury użytkowania minimalne",
+                            "8": "Niższe ograniczenie użytkowania",
                             "9": "Brak zapotrzebowania",
-                            "10": "Zewn\u0119trzne \u017ar\u00f3d\u0142o energii",
-                            "11": "Przep\u0142yw",
-                            "12": "Pauza niskiego ci\u015bnienia",
+                            "10": "Zewnętrzne źródło energii",
+                            "11": "Przepływ",
+                            "12": "Pauza niskiego ciśnienia",
                             "13": "Pauza przegrzania",
                             "14": "Pauza falownika",
                             "15": "Pauza desuperheatera",
-                            "16": "Tryb pracy prze\u0142\u0105czania",
-                            "17": "Inne wy\u0142\u0105czenie",
-                            "18": "Minimalny przep\u0142yw ch\u0142odzenia",
+                            "16": "Tryb pracy przełączania",
+                            "17": "Inne wyłączenie",
+                            "18": "Minimalny przepływ chłodzenia",
                             "19": "PV max",
-                            "20": "Pauza gor\u0105cego gazu",
-                            "21": "Pauza przegrzania gor\u0105cego gazu",
+                            "20": "Pauza gorącego gazu",
+                            "21": "Pauza przegrzania gorącego gazu",
                             "22": "Brak zapotrzebowania",
-                            "23": "Minimalna temperatura wylotowa dolnego \u017ar\u00f3d\u0142a przy ch\u0142odzeniu",
+                            "23": "Minimalna temperatura wylotowa dolnego źródła przy chłodzeniu",
                             "24": "LPC",
                             "25": "Restart",
                             "27": "Maksymalna temperatura zasilania"
                         }
                     },
                     "timestamp_3": {
-                        "name": "Czwarty od ko\u0144ca czas"
+                        "name": "Czwarty od końca czas"
                     },
                     "code_4": {
-                        "name": "Pi\u0105te od ko\u0144ca wy\u0142\u0105czenie",
+                        "name": "Piąte od końca wyłączenie",
                         "state": {
-                            "0": "Zak\u0142\u00f3cenie pompy ciep\u0142a",
-                            "1": "Zak\u0142\u00f3cenie instalacji",
-                            "2": "Tryb pracy drugiego generatora ciep\u0142a",
+                            "0": "Zakłócenie pompy ciepła",
+                            "1": "Zakłócenie instalacji",
+                            "2": "Tryb pracy drugiego generatora ciepła",
                             "3": "Blokada EVU",
                             "4": "",
                             "5": "Odszranianie powietrzem",
-                            "6": "Maksymalne ograniczenie temperatury u\u017cytkowania",
-                            "7": "Ograniczenie temperatury u\u017cytkowania minimalne",
-                            "8": "Ni\u017csze ograniczenie u\u017cytkowania",
+                            "6": "Maksymalne ograniczenie temperatury użytkowania",
+                            "7": "Ograniczenie temperatury użytkowania minimalne",
+                            "8": "Niższe ograniczenie użytkowania",
                             "9": "Brak zapotrzebowania",
-                            "10": "Zewn\u0119trzne \u017ar\u00f3d\u0142o energii",
-                            "11": "Przep\u0142yw",
-                            "12": "Pauza niskiego ci\u015bnienia",
+                            "10": "Zewnętrzne źródło energii",
+                            "11": "Przepływ",
+                            "12": "Pauza niskiego ciśnienia",
                             "13": "Pauza przegrzania",
                             "14": "Pauza falownika",
                             "15": "Pauza desuperheatera",
-                            "16": "Tryb pracy prze\u0142\u0105czania",
-                            "17": "Inne wy\u0142\u0105czenie",
-                            "18": "Minimalny przep\u0142yw ch\u0142odzenia",
+                            "16": "Tryb pracy przełączania",
+                            "17": "Inne wyłączenie",
+                            "18": "Minimalny przepływ chłodzenia",
                             "19": "PV max",
-                            "20": "Pauza gor\u0105cego gazu",
-                            "21": "Pauza przegrzania gor\u0105cego gazu",
+                            "20": "Pauza gorącego gazu",
+                            "21": "Pauza przegrzania gorącego gazu",
                             "22": "Brak zapotrzebowania",
-                            "23": "Minimalna temperatura wylotowa dolnego \u017ar\u00f3d\u0142a przy ch\u0142odzeniu",
+                            "23": "Minimalna temperatura wylotowa dolnego źródła przy chłodzeniu",
                             "24": "LPC",
                             "25": "Restart",
                             "27": "Maksymalna temperatura zasilania"
                         }
                     },
                     "timestamp_4": {
-                        "name": "Pi\u0105ty od ko\u0144ca czas"
+                        "name": "Piąty od końca czas"
                     }
                 }
             },
             "status_line_1": {
                 "name": "Stan 1",
                 "state": {
-                    "heatpump_running": "Pompa ciep\u0142a jest aktywna",
-                    "heatpump_idle": "Pompa ciep\u0142a jest nieaktywna",
-                    "heatpump_coming": "Pompa ciep\u0142a jest uruchamiana",
-                    "heatpump_shutdown": "Pompa ciep\u0142a wy\u0142\u0105cza si\u0119",
-                    "errorcode_slot_0": "Kod b\u0142\u0119du pompy ciep\u0142a w gnie\u017adzie 0",
+                    "heatpump_running": "Pompa ciepła jest aktywna",
+                    "heatpump_idle": "Pompa ciepła jest nieaktywna",
+                    "heatpump_coming": "Pompa ciepła jest uruchamiana",
+                    "heatpump_shutdown": "Pompa ciepła wyłącza się",
+                    "errorcode_slot_0": "Kod błędu pompy ciepła w gnieździe 0",
                     "pump_forerun": "Rozbieg pompy",
-                    "defrost": "Rozmra\u017canie",
-                    "waiting_on_lin_connection": "Oczekiwanie na po\u0142\u0105czenie LIN",
-                    "compressor_heating_up": "Spr\u0119\u017carka nagrzewa si\u0119",
-                    "compressor_heater": "Grza\u0142ka spr\u0119\u017carki"
+                    "defrost": "Rozmrażanie",
+                    "waiting_on_lin_connection": "Oczekiwanie na połączenie LIN",
+                    "compressor_heating_up": "Sprężarka nagrzewa się",
+                    "compressor_heater": "Grzałka sprężarki"
                 }
             },
             "status_line_2": {
@@ -777,64 +777,64 @@
                 "name": "Stan 3",
                 "state": {
                     "heating": "ogrzewanie",
-                    "defrost": "rozmra\u017canie",
-                    "cooling": "ch\u0142odzenie",
+                    "defrost": "rozmrażanie",
+                    "cooling": "chłodzenie",
                     "pump_forerun": "rozbieg pompy",
                     "thermal_desinfection": "dezynfekcja termiczna",
                     "swimming_pool_solar": "basen/solar",
                     "no_request": "brak zapotrzebowania",
                     "cycle_lock": "blokada cyklu",
                     "lock_time": "czas blokady",
-                    "domestic_water": "ciep\u0142a woda",
-                    "flow_monitoring": "monitorowanie przep\u0142ywu",
-                    "grid_switch_on_delay": "op\u00f3\u017anienie w\u0142\u0105czenia sieci",
+                    "domestic_water": "ciepła woda",
+                    "flow_monitoring": "monitorowanie przepływu",
+                    "grid_switch_on_delay": "opóźnienie włączenia sieci",
                     "info_bake_out_program": "Informacje o programie pieczenia",
-                    "heating_external_energy_source": "ogrzewanie z zewn\u0119trznego \u017ar\u00f3d\u0142a energii",
-                    "domestic_water_external_energy_source": "Zewn\u0119trzne \u017ar\u00f3d\u0142o energii ciep\u0142ej wody",
-                    "second_heat_generator_1_active": "drugi generator ciep\u0142a 1 aktywny"
+                    "heating_external_energy_source": "ogrzewanie z zewnętrznego źródła energii",
+                    "domestic_water_external_energy_source": "Zewnętrzne źródło energii ciepłej wody",
+                    "second_heat_generator_1_active": "drugi generator ciepła 1 aktywny"
                 }
             },
             "heat_source_output": {
-                "name": "Do \u017ar\u00f3d\u0142a ciep\u0142a"
+                "name": "Do źródła ciepła"
             },
             "heat_source_input_temperature": {
-                "name": "Wej\u015bcie \u017ar\u00f3d\u0142a ciep\u0142a"
+                "name": "Wejście źródła ciepła"
             },
             "outdoor_temperature": {
-                "name": "Temperatura zewn\u0119trzna"
+                "name": "Temperatura zewnętrzna"
             },
             "status_time": {
                 "name": "Czas stanu"
             },
             "outdoor_temperature_average": {
-                "name": "\u015arednia temperatura zewn\u0119trzna"
+                "name": "Średnia temperatura zewnętrzna"
             },
             "compressor1_impulses": {
-                "name": "Impulsy spr\u0119\u017carki 1"
+                "name": "Impulsy sprężarki 1"
             },
             "compressor1_operation_hours": {
-                "name": "Godziny pracy spr\u0119\u017carki 1"
+                "name": "Godziny pracy sprężarki 1"
             },
             "compressor2_impulses": {
-                "name": "Impulsy spr\u0119\u017carki 2"
+                "name": "Impulsy sprężarki 2"
             },
             "compressor2_operation_hours": {
-                "name": "Godziny pracy spr\u0119\u017carki 2"
+                "name": "Godziny pracy sprężarki 2"
             },
             "operation_hours": {
                 "name": "Godziny pracy"
             },
             "heat_amount_counter": {
-                "name": "Licznik ilo\u015bci ciep\u0142a"
+                "name": "Licznik ilości ciepła"
             },
             "hot_gas_temperature": {
-                "name": "Temperatura gor\u0105cego gazu"
+                "name": "Temperatura gorącego gazu"
             },
             "suction_compressor_temperature": {
-                "name": "Temperatura spr\u0119\u017carki ss\u0105cej"
+                "name": "Temperatura sprężarki ssącej"
             },
             "suction_evaporator_temperature": {
-                "name": "Temperatura parownika ss\u0105cego"
+                "name": "Temperatura parownika ssącego"
             },
             "compressor_heating_temperature": {
                 "name": "Kompresor"
@@ -846,106 +846,106 @@
                 "name": "Cel przegrzania"
             },
             "high_pressure": {
-                "name": "Wysokie ci\u015bnienie"
+                "name": "Wysokie ciśnienie"
             },
             "low_pressure": {
-                "name": "Niskie ci\u015bnienie"
+                "name": "Niskie ciśnienie"
             },
             "additional_heat_generator_operation_hours": {
-                "name": "Godziny pracy dodatkowego \u017a\u00f3d\u0142a ciep\u0142a"
+                "name": "Godziny pracy dodatkowego źódła ciepła"
             },
             "additional_heat_generator2_operation_hours": {
-                "name": "Godziny pracy dodatkowego \u017a\u00f3d\u0142a ciep\u0142a"
+                "name": "Godziny pracy dodatkowego źódła ciepła"
             },
             "analog_out1": {
-                "name": "Wyj\u015bcie analogowe 1"
+                "name": "Wyjście analogowe 1"
             },
             "analog_out2": {
-                "name": "Wyj\u015bcie analogowe 2"
+                "name": "Wyjście analogowe 2"
             },
             "current_heat_output": {
                 "name": "Aktualna moc cieplna"
             },
             "additional_heat_generator_energy_p1059": {
-                "name": "Ilo\u015b\u0107 ciep\u0142a dodatkowego \u017ar\u00f3d\u0142a ciep\u0142a (firmware przed x.88)"
+                "name": "Ilość ciepła dodatkowego źródła ciepła (firmware przed x.88)"
             },
             "additional_heat_generator_energy": {
-                "name": "Ilo\u015b\u0107 ciep\u0142a dodatkowego \u017ar\u00f3d\u0142a ciep\u0142a"
+                "name": "Ilość ciepła dodatkowego źródła ciepła"
             },
             "heat_source_output_temperature": {
-                "name": "Moc \u017ar\u00f3d\u0142a ciep\u0142a"
+                "name": "Moc źródła ciepła"
             },
             "pump_frequency": {
-                "name": "Cz\u0119stotliwo\u015b\u0107 pompy"
+                "name": "Częstotliwość pompy"
             },
             "domestic_water": {
-                "name": "Ciep\u0142a woda"
+                "name": "Ciepła woda"
             },
             "dhw_temperature": {
-                "name": "Temperatura ciep\u0142ej wody"
+                "name": "Temperatura ciepłej wody"
             },
             "dhw_operation_hours": {
-                "name": "Godziny pracy ciep\u0142ej wody"
+                "name": "Godziny pracy ciepłej wody"
             },
             "dhw_heat_amount": {
-                "name": "Ilo\u015b\u0107 ciep\u0142a ciep\u0142ej wody"
+                "name": "Ilość ciepła ciepłej wody"
             },
             "dhw_energy_input": {
-                "name": "Pob\u00f3r energii ciep\u0142ej wody"
+                "name": "Pobór energii ciepłej wody"
             },
             "cop_dhw": {
                 "name": "COP"
             },
             "flow_in_temperature": {
-                "name": "Temperatura na wej\u015bciu"
+                "name": "Temperatura na wejściu"
             },
             "flow_in_circuit1_temperature": {
-                "name": "Obw\u00f3d temperatury wlotowej 1"
+                "name": "Obwód temperatury wlotowej 1"
             },
             "flow_in_circuit2_temperature": {
-                "name": "Obw\u00f3d temperatury wlotowej 2"
+                "name": "Obwód temperatury wlotowej 2"
             },
             "flow_in_circuit3_temperature": {
-                "name": "Obw\u00f3d temperatury wlotowej 3"
+                "name": "Obwód temperatury wlotowej 3"
             },
             "flow_in_circuit1_target_temperature": {
-                "name": "Obw\u00f3d docelowej temperatury na wlocie 1"
+                "name": "Obwód docelowej temperatury na wlocie 1"
             },
             "flow_in_circuit2_target_temperature": {
-                "name": "Obw\u00f3d docelowej temperatury na wlocie 2"
+                "name": "Obwód docelowej temperatury na wlocie 2"
             },
             "flow_in_circuit3_target_temperature": {
-                "name": "Obw\u00f3d docelowej temperatury na wlocie 3"
+                "name": "Obwód docelowej temperatury na wlocie 3"
             },
             "flow_out_temperature": {
-                "name": "Temperatura na wyj\u015bciu"
+                "name": "Temperatura na wyjściu"
             },
             "flow_out_temperature_target": {
-                "name": "Docelowa temperatura na wyj\u015bciu"
+                "name": "Docelowa temperatura na wyjściu"
             },
             "operation_hours_heating": {
                 "name": "Godziny pracy ogrzewania"
             },
             "heat_amount_heating": {
-                "name": "Ilo\u015b\u0107 ciep\u0142a grzewczego"
+                "name": "Ilość ciepła grzewczego"
             },
             "pool_heat_amount": {
                 "name": "Ilość ciepła basenu"
             },
             "heat_amount_flow_rate": {
-                "name": "Nat\u0119\u017cenie przep\u0142ywu ilo\u015bci ciep\u0142a grzewczego"
+                "name": "Natężenie przepływu ilości ciepła grzewczego"
             },
             "heat_source_flow_rate": {
-                "name": "Nat\u0119\u017cenie przep\u0142ywu \u017ar\u00f3d\u0142a ciep\u0142a grzewczego"
+                "name": "Natężenie przepływu źródła ciepła grzewczego"
             },
             "heat_energy_input": {
-                "name": "Ogrzewanie wej\u015bciowe energii"
+                "name": "Ogrzewanie wejściowe energii"
             },
             "cop_heating": {
                 "name": "COP"
             },
             "flow_out_temperature_external": {
-                "name": "Zewn\u0119trzna temperatura na wyj\u015bciu"
+                "name": "Zewnętrzna temperatura na wyjściu"
             },
             "solar_collector_temperature": {
                 "name": "Kolektor solarny"
@@ -957,7 +957,7 @@
                 "name": "Godziny pracy trybu solarnego"
             },
             "operation_hours_cooling": {
-                "name": "Godziny pracy ch\u0142odzenia"
+                "name": "Godziny pracy chłodzenia"
             },
             "room_thermostat_temperature": {
                 "name": "Temperatura termostatu pokojowego"
@@ -966,16 +966,16 @@
                 "name": "Temperatura docelowa termostatu pokojowego"
             },
             "cooling_energy_input": {
-                "name": "Energia zu\u017cyta na ch\u0142odzenie"
+                "name": "Energia zużyta na chłodzenie"
             },
             "pool_energy_input": {
                 "name": "Energia zużyta na basen"
             },
             "current_power_consumption": {
-                "name": "Pob\u00f3r mocy"
+                "name": "Pobór mocy"
             },
             "additional_heat_generator_energy_p1140": {
-                "name": "Ilo\u015b\u0107 ciep\u0142a dodatkowego \u017ar\u00f3d\u0142a ciep\u0142a (firmware x.88 i nowszy)"
+                "name": "Ilość ciepła dodatkowego źródła ciepła (firmware x.88 i nowszy)"
             },
             "circulation_pump_delta": {
                 "name": "Cyrkulacyjna pompdelta"
@@ -984,10 +984,10 @@
                 "name": "Cyrkulacyjna pompdelta docelowa"
             },
             "pump_flow_delta": {
-                "name": "Delta przep\u0142ywu pompy"
+                "name": "Delta przepływu pompy"
             },
             "pump_flow_delta_target": {
-                "name": "Delta docelowa przep\u0142ywu pompy"
+                "name": "Delta docelowa przepływu pompy"
             },
             "ventilation_supply_air_temperature": {
                 "name": "Temperatura powietrza nawiewanego"
@@ -1016,51 +1016,51 @@
         },
         "date": {
             "away_dhw_startdate": {
-                "name": "Data rozpocz\u0119cia trybu nieobecno\u015bci - ciep\u0142a woda"
+                "name": "Data rozpoczęcia trybu nieobecności - ciepła woda"
             },
             "away_dhw_enddate": {
-                "name": "Data zako\u0144czenia trybu nieobecno\u015bci - ciep\u0142a woda"
+                "name": "Data zakończenia trybu nieobecności - ciepła woda"
             },
             "away_heating_startdate": {
-                "name": "Data rozpocz\u0119cia trybu nieobecno\u015bci - ogrzewanie"
+                "name": "Data rozpoczęcia trybu nieobecności - ogrzewanie"
             },
             "away_heating_enddate": {
-                "name": "Data zako\u0144czenia trybu nieobecno\u015bci - ogrzewanie"
+                "name": "Data zakończenia trybu nieobecności - ogrzewanie"
             }
         },
         "text": {
             "timer_dhw_schedule_week": {
-                "name": "Harmonogram czasowy ciep\u0142ej wody (tydzie\u0144)"
+                "name": "Harmonogram czasowy ciepłej wody (tydzień)"
             },
             "timer_dhw_schedule_weekday": {
-                "name": "Harmonogram czasowy ciep\u0142ej wody (dni robocze)"
+                "name": "Harmonogram czasowy ciepłej wody (dni robocze)"
             },
             "timer_dhw_schedule_weekend": {
-                "name": "Harmonogram czasowy ciep\u0142ej wody (weekend)"
+                "name": "Harmonogram czasowy ciepłej wody (weekend)"
             },
             "timer_dhw_schedule_monday": {
-                "name": "Harmonogram czasowy ciep\u0142ej wody (poniedzia\u0142ek)"
+                "name": "Harmonogram czasowy ciepłej wody (poniedziałek)"
             },
             "timer_dhw_schedule_tuesday": {
-                "name": "Harmonogram czasowy ciep\u0142ej wody (wtorek)"
+                "name": "Harmonogram czasowy ciepłej wody (wtorek)"
             },
             "timer_dhw_schedule_wednesday": {
-                "name": "Harmonogram czasowy ciep\u0142ej wody (\u015broda)"
+                "name": "Harmonogram czasowy ciepłej wody (środa)"
             },
             "timer_dhw_schedule_thursday": {
-                "name": "Harmonogram czasowy ciep\u0142ej wody (czwartek)"
+                "name": "Harmonogram czasowy ciepłej wody (czwartek)"
             },
             "timer_dhw_schedule_friday": {
-                "name": "Harmonogram czasowy ciep\u0142ej wody (pi\u0105tek)"
+                "name": "Harmonogram czasowy ciepłej wody (piątek)"
             },
             "timer_dhw_schedule_saturday": {
-                "name": "Harmonogram czasowy ciep\u0142ej wody (sobota)"
+                "name": "Harmonogram czasowy ciepłej wody (sobota)"
             },
             "timer_dhw_schedule_sunday": {
-                "name": "Harmonogram czasowy ciep\u0142ej wody (niedziela)"
+                "name": "Harmonogram czasowy ciepłej wody (niedziela)"
             },
             "timer_heating_schedule_week": {
-                "name": "Harmonogram czasowy ogrzewania (tydzie\u0144)"
+                "name": "Harmonogram czasowy ogrzewania (tydzień)"
             },
             "timer_heating_schedule_weekday": {
                 "name": "Harmonogram czasowy ogrzewania (dni robocze)"
@@ -1069,19 +1069,19 @@
                 "name": "Harmonogram czasowy ogrzewania (weekend)"
             },
             "timer_heating_schedule_monday": {
-                "name": "Harmonogram czasowy ogrzewania (poniedzia\u0142ek)"
+                "name": "Harmonogram czasowy ogrzewania (poniedziałek)"
             },
             "timer_heating_schedule_tuesday": {
                 "name": "Harmonogram czasowy ogrzewania (wtorek)"
             },
             "timer_heating_schedule_wednesday": {
-                "name": "Harmonogram czasowy ogrzewania (\u015broda)"
+                "name": "Harmonogram czasowy ogrzewania (środa)"
             },
             "timer_heating_schedule_thursday": {
                 "name": "Harmonogram czasowy ogrzewania (czwartek)"
             },
             "timer_heating_schedule_friday": {
-                "name": "Harmonogram czasowy ogrzewania (pi\u0105tek)"
+                "name": "Harmonogram czasowy ogrzewania (piątek)"
             },
             "timer_heating_schedule_saturday": {
                 "name": "Harmonogram czasowy ogrzewania (sobota)"
@@ -1090,7 +1090,7 @@
                 "name": "Harmonogram czasowy ogrzewania (niedziela)"
             },
             "timer_ventilation_schedule_week": {
-                "name": "Harmonogram czasowy wentylacji (tydzie\u0144)"
+                "name": "Harmonogram czasowy wentylacji (tydzień)"
             },
             "timer_ventilation_schedule_weekday": {
                 "name": "Harmonogram czasowy wentylacji (dni robocze)"
@@ -1099,19 +1099,19 @@
                 "name": "Harmonogram czasowy wentylacji (weekend)"
             },
             "timer_ventilation_schedule_monday": {
-                "name": "Harmonogram czasowy wentylacji (poniedzia\u0142ek)"
+                "name": "Harmonogram czasowy wentylacji (poniedziałek)"
             },
             "timer_ventilation_schedule_tuesday": {
                 "name": "Harmonogram czasowy wentylacji (wtorek)"
             },
             "timer_ventilation_schedule_wednesday": {
-                "name": "Harmonogram czasowy wentylacji (\u015broda)"
+                "name": "Harmonogram czasowy wentylacji (środa)"
             },
             "timer_ventilation_schedule_thursday": {
                 "name": "Harmonogram czasowy wentylacji (czwartek)"
             },
             "timer_ventilation_schedule_friday": {
-                "name": "Harmonogram czasowy wentylacji (pi\u0105tek)"
+                "name": "Harmonogram czasowy wentylacji (piątek)"
             },
             "timer_ventilation_schedule_saturday": {
                 "name": "Harmonogram czasowy wentylacji (sobota)"
@@ -1122,25 +1122,25 @@
         },
         "select": {
             "thermal_desinfection_day": {
-                "name": "Dzie\u0144 dezynfekcji termicznej",
+                "name": "Dzień dezynfekcji termicznej",
                 "state": {
                     "none": "Brak",
-                    "monday": "Poniedzia\u0142ek",
+                    "monday": "Poniedziałek",
                     "tuesday": "Wtorek",
-                    "wednesday": "\u015aroda",
+                    "wednesday": "Środa",
                     "thursday": "Czwartek",
-                    "friday": "Pi\u0105tek",
+                    "friday": "Piątek",
                     "saturday": "Sobota",
                     "sunday": "Niedziela",
-                    "continuous": "Ci\u0105g\u0142y"
+                    "continuous": "Ciągły"
                 }
             },
             "heating_control_circuit_mode": {
                 "name": "Tryb sterowania obiegiem grzewczym",
                 "state": {
-                    "0": "Sterowanie krzyw\u0105 grzewcz\u0105 - wed\u0142ug temperatury zewn\u0119trznej",
-                    "1": "R\u0119cznie ustawiona temperatura",
-                    "2": "Wej\u015bcie analogowe"
+                    "0": "Sterowanie krzywą grzewczą - według temperatury zewnętrznej",
+                    "1": "Ręcznie ustawiona temperatura",
+                    "2": "Wejście analogowe"
                 }
             },
             "timer_dhw_program": {
@@ -1171,8 +1171,8 @@
                 "name": "Tryb PV",
                 "state": {
                     "automatic": "Automatyczny",
-                    "pv_off": "PV wy\u0142\u0105czony",
-                    "pool_off": "Basen wy\u0142\u0105czony",
+                    "pv_off": "PV wyłączony",
+                    "pool_off": "Basen wyłączony",
                     "pool_party": "Impreza basenowa",
                     "pool_holidays": "Wakacje basenowe"
                 }
@@ -1180,19 +1180,19 @@
             "heating_mode": {
                 "name": "Tryb ogrzewania",
                 "state": {
-                    "off": "Wy\u0142\u0105czony",
+                    "off": "Wyłączony",
                     "automatic": "Automatyczny",
-                    "second_heatsource": "Drugie \u017ar\u00f3d\u0142o ciep\u0142a",
+                    "second_heatsource": "Drugie źródło ciepła",
                     "party": "Tryb imprezowy",
                     "holidays": "Tryb wakacyjny"
                 }
             },
             "dhw_mode": {
-                "name": "Tryb ciep\u0142ej wody",
+                "name": "Tryb ciepłej wody",
                 "state": {
-                    "off": "Wy\u0142\u0105czony",
+                    "off": "Wyłączony",
                     "automatic": "Automatyczny",
-                    "second_heatsource": "Drugie \u017ar\u00f3d\u0142o ciep\u0142a",
+                    "second_heatsource": "Drugie źródło ciepła",
                     "party": "Tryb imprezowy",
                     "holidays": "Tryb wakacyjny"
                 }
@@ -1200,7 +1200,7 @@
             "heating_mode_mk1": {
                 "name": "Tryb ogrzewania MK1",
                 "state": {
-                    "off": "Wy\u0142\u0105czony",
+                    "off": "Wyłączony",
                     "automatic": "Automatyczny",
                     "party": "Tryb imprezowy",
                     "holidays": "Tryb wakacyjny"
@@ -1209,7 +1209,7 @@
             "heating_mode_mk2": {
                 "name": "Tryb ogrzewania MK2",
                 "state": {
-                    "off": "Wy\u0142\u0105czony",
+                    "off": "Wyłączony",
                     "automatic": "Automatyczny",
                     "party": "Tryb imprezowy",
                     "holidays": "Tryb wakacyjny"
@@ -1218,7 +1218,7 @@
             "heating_mode_mk3": {
                 "name": "Tryb ogrzewania MK3",
                 "state": {
-                    "off": "Wy\u0142\u0105czony",
+                    "off": "Wyłączony",
                     "automatic": "Automatyczny",
                     "party": "Tryb imprezowy",
                     "holidays": "Tryb wakacyjny"
@@ -1239,27 +1239,27 @@
                 "name": "Ogrzewanie"
             },
             "cooling_controller": {
-                "name": "Ch\u0142odzenie"
+                "name": "Chłodzenie"
             }
         },
         "water_heater": {
             "domestic_water": {
-                "name": "Ciep\u0142a woda"
+                "name": "Ciepła woda"
             }
         }
     },
     "device": {
         "heatpump": {
-            "name": "Pompa ciep\u0142a"
+            "name": "Pompa ciepła"
         },
         "heating": {
             "name": "Ogrzewanie"
         },
         "domestic_water": {
-            "name": "Ciep\u0142a woda"
+            "name": "Ciepła woda"
         },
         "cooling": {
-            "name": "Ch\u0142odzenie"
+            "name": "Chłodzenie"
         },
         "ventilation": {
             "name": "Wentylacja"
@@ -1267,30 +1267,30 @@
     },
     "config": {
         "abort": {
-            "cannot_connect": "Nie uda\u0142o si\u0119 po\u0142\u0105czy\u0107 z Luxtronik pod adresem {host}.\\nB\u0142\u0105d: {connect_error}",
-            "cannot_identify": "Po\u0142\u0105czono z urz\u0105dzeniem pod adresem {host}, ale nie uda\u0142o si\u0119 odczyta\u0107 jego numeru seryjnego w celu identyfikacji.\\nB\u0142\u0105d: {error}",
-            "already_configured": "To urz\u0105dzenie jest ju\u017c skonfigurowane.",
-            "already_configured_serial": "Pompa ciep\u0142a pod adresem {host} zg\u0142asza numer seryjny {serial}, kt\u00f3ry jest ju\u017c skonfigurowany jako {existing_title} ({existing_host}). Oba adresy prowadz\u0105 do tej samej pompy ciep\u0142a - je\u015bli spodziewano si\u0119 dw\u00f3ch osobnych urz\u0105dze\u0144, sprawd\u017a przekierowanie port\u00f3w pod k\u0105tem duplikat\u00f3w.",
-            "reconfigure_successful": "Konfiguracja zosta\u0142a pomy\u015blnie zaktualizowana.",
-            "unique_id_mismatch": "Urz\u0105dzenie pod nowym adresem ma inn\u0105 to\u017csamo\u015b\u0107 ni\u017c aktualnie skonfigurowane urz\u0105dzenie.",
-            "already_in_progress": "Proces konfiguracji jest ju\u017c w toku.",
-            "devices_configured": "Wszystkie wybrane urz\u0105dzenia s\u0105 ju\u017c skonfigurowane.",
-            "options_error": "Wyst\u0105pi\u0142 b\u0142\u0105d podczas \u0142adowania opcji.",
-            "no_devices_found": "Nie znaleziono \u017cadnych urz\u0105dze\u0144 w sieci.",
-            "single_instance_allowed": "Ju\u017c skonfigurowano. Dozwolona jest tylko jedna instancja.",
-            "unknown": "Nieznany b\u0142\u0105d."
+            "cannot_connect": "Nie udało się połączyć z Luxtronik pod adresem {host}.\\nBłąd: {connect_error}",
+            "cannot_identify": "Połączono z urządzeniem pod adresem {host}, ale nie udało się odczytać jego numeru seryjnego w celu identyfikacji.\\nBłąd: {error}",
+            "already_configured": "To urządzenie jest już skonfigurowane.",
+            "already_configured_serial": "Pompa ciepła pod adresem {host} zgłasza numer seryjny {serial}, który jest już skonfigurowany jako {existing_title} ({existing_host}). Oba adresy prowadzą do tej samej pompy ciepła - jeśli spodziewano się dwóch osobnych urządzeń, sprawdź przekierowanie portów pod kątem duplikatów.",
+            "reconfigure_successful": "Konfiguracja została pomyślnie zaktualizowana.",
+            "unique_id_mismatch": "Urządzenie pod nowym adresem ma inną tożsamość niż aktualnie skonfigurowane urządzenie.",
+            "already_in_progress": "Proces konfiguracji jest już w toku.",
+            "devices_configured": "Wszystkie wybrane urządzenia są już skonfigurowane.",
+            "options_error": "Wystąpił błąd podczas ładowania opcji.",
+            "no_devices_found": "Nie znaleziono żadnych urządzeń w sieci.",
+            "single_instance_allowed": "Już skonfigurowano. Dozwolona jest tylko jedna instancja.",
+            "unknown": "Nieznany błąd."
         },
         "error": {
-            "address": "Nieprawid\u0142owy adres zdalny. Adres musi by\u0107 adresem IP lub rozpoznawaln\u0105 nazw\u0105 hosta.",
-            "address_in_use": "Wybrany port jest ju\u017c u\u017cywany w tym systemie.",
-            "cannot_connect": "Po\u0142\u0105czenie nie powiod\u0142o si\u0119. Sprawd\u017a host i port.",
-            "cannot_identify": "Po\u0142\u0105czono z urz\u0105dzeniem, ale nie uda\u0142o si\u0119 odczyta\u0107 jego numeru seryjnego w celu identyfikacji.",
-            "unknown": "Nieoczekiwany b\u0142\u0105d"
+            "address": "Nieprawidłowy adres zdalny. Adres musi być adresem IP lub rozpoznawalną nazwą hosta.",
+            "address_in_use": "Wybrany port jest już używany w tym systemie.",
+            "cannot_connect": "Połączenie nie powiodło się. Sprawdź host i port.",
+            "cannot_identify": "Połączono z urządzeniem, ale nie udało się odczytać jego numeru seryjnego w celu identyfikacji.",
+            "unknown": "Nieoczekiwany błąd"
         },
         "step": {
             "user": {
-                "title": "Instalacja pompy ciep\u0142a Luxtronik",
-                "description": "Wykryte urz\u0105dzenia ju\u017c skonfigurowane: {configured}",
+                "title": "Instalacja pompy ciepła Luxtronik",
+                "description": "Wykryte urządzenia już skonfigurowane: {configured}",
                 "data": {
                     "host": "Host",
                     "port": "Network Port",
@@ -1300,35 +1300,35 @@
                 "data_description": {
                     "host": "Nazwa hosta lub adres IP",
                     "port": "Zwykle 8889 lub 8888",
-                    "timeout": "Je\u015bli sie\u0107 lub pompa ciep\u0142a dzia\u0142a wolno, mo\u017cna dostosowa\u0107 limit czasu.",
-                    "max_data_length": "Je\u015bli sie\u0107 lub pompa ciep\u0142a dzia\u0142a wolno, mo\u017cna dostosowa\u0107 d\u0142ugo\u015b\u0107 pakietu danych."
+                    "timeout": "Jeśli sieć lub pompa ciepła działa wolno, można dostosować limit czasu.",
+                    "max_data_length": "Jeśli sieć lub pompa ciepła działa wolno, można dostosować długość pakietu danych."
                 }
             },
             "manual_entry": {
-                "title": "R\u0119czna konfiguracja Luxtronik",
-                "description": "Nie znaleziono nowych urz\u0105dze\u0144 lub wszystkie wykryte urz\u0105dzenia s\u0105 ju\u017c skonfigurowane. Mo\u017cesz r\u0119cznie wprowadzi\u0107 hosta i port."
+                "title": "Ręczna konfiguracja Luxtronik",
+                "description": "Nie znaleziono nowych urządzeń lub wszystkie wykryte urządzenia są już skonfigurowane. Możesz ręcznie wprowadzić hosta i port."
             },
             "select_devices": {
-                "title": "Wybierz urz\u0105dzenia do skonfigurowania",
-                "description": "Wybierz jedno lub wi\u0119cej urz\u0105dze\u0144 do dodania. Ju\u017c skonfigurowane urz\u0105dzenia: {configured}",
+                "title": "Wybierz urządzenia do skonfigurowania",
+                "description": "Wybierz jedno lub więcej urządzeń do dodania. Już skonfigurowane urządzenia: {configured}",
                 "data": {
-                    "select_device_to_configure": "Wybierz urz\u0105dzenie, kt\u00f3re chcesz skonfigurowa\u0107"
+                    "select_device_to_configure": "Wybierz urządzenie, które chcesz skonfigurować"
                 }
             },
             "reconfigure": {
-                "title": "Rekonfiguracja po\u0142\u0105czenia Luxtronik",
-                "description": "Zaktualizuj ustawienia po\u0142\u0105czenia dla pompy ciep\u0142a Luxtronik.",
+                "title": "Rekonfiguracja połączenia Luxtronik",
+                "description": "Zaktualizuj ustawienia połączenia dla pompy ciepła Luxtronik.",
                 "data": {
                     "host": "Host",
                     "port": "Port sieciowy",
                     "timeout": "Limit czasu gniazda sieciowego (s)",
-                    "max_data_length": "Maksymalna d\u0142ugo\u015b\u0107 pakietu danych"
+                    "max_data_length": "Maksymalna długość pakietu danych"
                 },
                 "data_description": {
                     "host": "Nazwa hosta lub adres IP",
                     "port": "Zwykle 8889 lub 8888",
-                    "timeout": "Je\u015bli sie\u0107 lub pompa ciep\u0142a dzia\u0142a wolno, mo\u017cna dostosowa\u0107 limit czasu.",
-                    "max_data_length": "Je\u015bli sie\u0107 lub pompa ciep\u0142a dzia\u0142a wolno, mo\u017cna dostosowa\u0107 d\u0142ugo\u015b\u0107 pakietu danych."
+                    "timeout": "Jeśli sieć lub pompa ciepła działa wolno, można dostosować limit czasu.",
+                    "max_data_length": "Jeśli sieć lub pompa ciepła działa wolno, można dostosować długość pakietu danych."
                 }
             }
         }
@@ -1337,47 +1337,47 @@
         "step": {
             "user": {
                 "title": "Skonfiguruj opcje dla {name}",
-                "description": "Ustawienia dla pompy ciep\u0142a Luxtronik {name}.",
+                "description": "Ustawienia dla pompy ciepła Luxtronik {name}.",
                 "data": {
-                    "ha_sensor_indoor_temperature": "ID czujnika temperatury wewn\u0119trznej",
-                    "ha_sensor_current_power_consumption": "ID czujnika bie\u017c\u0105cego poboru mocy",
-                    "update_interval": "Interwa\u0142 aktualizacji"
+                    "ha_sensor_indoor_temperature": "ID czujnika temperatury wewnętrznej",
+                    "ha_sensor_current_power_consumption": "ID czujnika bieżącego poboru mocy",
+                    "update_interval": "Interwał aktualizacji"
                 },
                 "data_description": {
-                    "ha_sensor_indoor_temperature": "Termostat do sterowania ogrzewaniem jest tworzony w Home Assistant. Rzeczywista temperatura jest ustawiana przez czujnik Home Assistant.\nJe\u015bli Luxtronik jest pod\u0142\u0105czony do sprz\u0119towego termostatu pokojowego, pozostaw to pole puste.",
-                    "ha_sensor_current_power_consumption": "Je\u015bli wbudowany pomiar bie\u017c\u0105cego poboru mocy pompy ciep\u0142a jest niedok\u0142adny, do oblicze\u0144 COP (ogrzewanie/CWU) mo\u017cna zamiast tego u\u017cy\u0107 zewn\u0119trznego czujnika mocy Home Assistant (np. inteligentnego gniazdka). Nie zmienia to warto\u015bci wy\u015bwietlanej przez sam czujnik bie\u017c\u0105cego poboru mocy.\nPozostaw puste, aby u\u017cywa\u0107 wbudowanego pomiaru pompy ciep\u0142a.",
-                    "update_interval": "Jak cz\u0119sto odpytywa\u0107 pomp\u0119 ciep\u0142a o nowe dane."
+                    "ha_sensor_indoor_temperature": "Termostat do sterowania ogrzewaniem jest tworzony w Home Assistant. Rzeczywista temperatura jest ustawiana przez czujnik Home Assistant.\nJeśli Luxtronik jest podłączony do sprzętowego termostatu pokojowego, pozostaw to pole puste.",
+                    "ha_sensor_current_power_consumption": "Jeśli wbudowany pomiar bieżącego poboru mocy pompy ciepła jest niedokładny, do obliczeń COP (ogrzewanie/CWU) można zamiast tego użyć zewnętrznego czujnika mocy Home Assistant (np. inteligentnego gniazdka). Nie zmienia to wartości wyświetlanej przez sam czujnik bieżącego poboru mocy.\nPozostaw puste, aby używać wbudowanego pomiaru pompy ciepła.",
+                    "update_interval": "Jak często odpytywać pompę ciepła o nowe dane."
                 }
             }
         }
     },
     "exceptions": {
         "invalid_parameter_name": {
-            "message": "Nieprawid\u0142owa nazwa parametru: {parameter}"
+            "message": "Nieprawidłowa nazwa parametru: {parameter}"
         },
         "parameter_not_writable": {
-            "message": "Parametr {parameter} odrzucony \u2014 tylko parametry z prefiksami {prefixes} s\u0105 zapisywalne"
+            "message": "Parametr {parameter} odrzucony — tylko parametry z prefiksami {prefixes} są zapisywalne"
         },
         "ambiguous_write_target": {
-            "message": "Skonfigurowano wi\u0119cej ni\u017c jedn\u0105 pomp\u0119 ciep\u0142a Luxtronik ({count} za\u0142adowanych) \u2014 podaj device_id lub config_entry_id, aby wybra\u0107 cel zapisu"
+            "message": "Skonfigurowano więcej niż jedną pompę ciepła Luxtronik ({count} załadowanych) — podaj device_id lub config_entry_id, aby wybrać cel zapisu"
         },
         "invalid_write_target": {
-            "message": "Nie uda\u0142o si\u0119 znale\u017a\u0107 za\u0142adowanej pompy ciep\u0142a Luxtronik dla celu {target}"
+            "message": "Nie udało się znaleźć załadowanej pompy ciepła Luxtronik dla celu {target}"
         },
         "invalid_timer_schedule": {
-            "message": "Nieprawid\u0142owy harmonogram czasowy \"{value}\": oczekiwane s\u0105 wpisy \"HH:MM-HH:MM\" oddzielone znakiem \"/\", maksymalnie {max_rows} wpis\u00f3w"
+            "message": "Nieprawidłowy harmonogram czasowy \"{value}\": oczekiwane są wpisy \"HH:MM-HH:MM\" oddzielone znakiem \"/\", maksymalnie {max_rows} wpisów"
         },
         "write_confirmation_mismatch": {
-            "message": "Pompa ciep\u0142a Luxtronik nie potwierdzi\u0142a zapisanych warto\u015bci: {details}"
+            "message": "Pompa ciepła Luxtronik nie potwierdziła zapisanych wartości: {details}"
         },
         "write_confirmation_unavailable": {
-            "message": "Zapisano {parameters} do pompy ciep\u0142a Luxtronik, ale od\u015bwie\u017cenie potwierdzaj\u0105ce nie powiod\u0142o si\u0119 \u2014 wyniku nie uda\u0142o si\u0119 potwierdzi\u0107"
+            "message": "Zapisano {parameters} do pompy ciepła Luxtronik, ale odświeżenie potwierdzające nie powiodło się — wyniku nie udało się potwierdzić"
         }
     },
     "issues": {
         "connection_failed": {
-            "title": "Nie mo\u017cna po\u0142\u0105czy\u0107 si\u0119 z pomp\u0105 ciep\u0142a Luxtronik",
-            "description": "Integracja nie mog\u0142a po\u0142\u0105czy\u0107 si\u0119 z pomp\u0105 ciep\u0142a Luxtronik pod adresem **{host}:{port}**.\n\nB\u0142\u0105d: `{error}`\n\nSprawd\u017a, czy pompa ciep\u0142a jest w\u0142\u0105czona, po\u0142\u0105czenie sieciowe dzia\u0142a, a host/port s\u0105 poprawne. Mo\u017cesz zaktualizowa\u0107 ustawienia po\u0142\u0105czenia za pomoc\u0105 opcji **Rekonfiguruj** w menu integracji."
+            "title": "Nie można połączyć się z pompą ciepła Luxtronik",
+            "description": "Integracja nie mogła połączyć się z pompą ciepła Luxtronik pod adresem **{host}:{port}**.\n\nBłąd: `{error}`\n\nSprawdź, czy pompa ciepła jest włączona, połączenie sieciowe działa, a host/port są poprawne. Możesz zaktualizować ustawienia połączenia za pomocą opcji **Rekonfiguruj** w menu integracji."
         }
     }
 }

--- a/tests/test_translation_coverage.py
+++ b/tests/test_translation_coverage.py
@@ -58,6 +58,23 @@ def test_state_and_state_attribute_codes_match_across_locales() -> None:
     assert not problems, "\n" + "\n".join(problems)
 
 
+def test_translation_files_use_literal_utf8() -> None:
+    """No language file may spell non-ASCII characters as \\uXXXX escapes.
+
+    Home Assistant's hand-authored translation source (core's strings.json) is
+    plain UTF-8; core's escaped translations/*.json are Lokalise build output.
+    These files are hand-authored - this integration has no strings.json - so
+    they follow the authored-source convention.
+
+    Both spellings parse to the same string, so nothing catches the drift at
+    runtime: it creeps in whenever a string is pasted from a tool defaulting to
+    `json.dump(..., ensure_ascii=True)`, and then a reviewer cannot read the
+    diff and the next full rewrite churns every line in the file.
+    """
+    problems = check_translation_coverage.find_ascii_escaped_files()
+    assert not problems, "\n" + "\n".join(problems)
+
+
 def test_device_names_are_translated_at_top_level() -> None:
     """Every DeviceKey must have a `device.<key>.name` translation at the top level
     of every language file, not nested under `entity.device`.


### PR DESCRIPTION
## 🎨 What

Every `\uXXXX` escape in `custom_components/luxtronik2/translations/*.json` is replaced by the character it denotes — 3087 in `cs`, 1709 in `pl`, 635 in `de`, 46 in `nl`, 3 in `en` — plus the single one left in Python source (`const.py`, the net input delay timer label).

The rewrite is purely textual: indentation, key order, line endings and trailing newlines are byte-for-byte unchanged, every file parses to exactly the object it did before, and the `\n` sequences in `cannot_connect` / `cannot_identify` are untouched. **No behaviour change** — both spellings parse to the same string.

## 🤔 Why

Home Assistant's *hand-authored* translation source, core's `strings.json`, is plain UTF-8; the escaped `translations/*.json` shipped with core are Lokalise build output. This integration has no `strings.json`, so these files **are** the authored source and should follow the authored-source convention.

The practical reason is reviewability: `"Wärmemenge"` says what it is in a diff and `"Wärmemenge"` does not. Until now new strings were arriving in one spelling while the files were written in the other, which is what surfaced this ([#756 review](https://github.com/BenPru/luxtronik/pull/756)).

## ✅ Guard against drift

`find_ascii_escaped_files()` in `.github/scripts/check_translation_coverage.py`, wired into its `__main__` so the existing `translation-coverage.yml` workflow runs it on every PR, plus a pytest wrapper so a plain `pytest` catches it too. The drift is invisible at runtime — both spellings parse identically — so only a check on the file *text* can hold the convention.

The pattern anchors the whole run of backslashes rather than looking behind a single one, so `\u0041` (an escaped backslash followed by literal `u0041`) is not reported while a genuine escape after one is. Verified against seven backslash-run cases and by reintroducing an escape into a copy of `de.json`, which the check reports with file, count and line number.

## 🕵️ Blame

The JSON rewrite is its own commit and its SHA is listed in a new `.git-blame-ignore-revs`, which GitHub honours automatically, so it doesn't bury the authorship of 1604 translation lines. Locally: `git config blame.ignoreRevsFile .git-blame-ignore-revs`.

## 🧪 Verification

- Losslessness checked independently of the script that did the rewrite: decoded `HEAD` text vs. working tree is character-for-character identical for all five files, escape counts (`\`, `\"`, others) unchanged, no BOM, no line-ending flips, no invisible/ambiguous codepoints introduced
- `pytest --cov=custom_components.luxtronik2` → **1018 passed**, 99% coverage (the single miss is pre-existing in `text.py`)
- `ruff check` clean, `ruff format --check` clean, `codespell` clean, `basedpyright` → 0 errors
- `python .github/scripts/check_translation_coverage.py` → "All translation files have complete coverage!"
