### PR TITLE
docs(sensor): 📝 record what the V1.x dumps do and don't settle

### DIFF
--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -67,14 +67,23 @@ from .model import (
 #   series but not the minor: a change at x.88 rather than between generations
 #   would fit it equally well and would leave older series-2 firmware reading
 #   ten times low. Keyed on the series because a counter's scale is a property
-#   of the controller line, not of a register set; a pre-x.88 series-2 dump is
-#   the second thing to check for after a V1.x one (#752).
-# Series 1 - assumed to match series 2, never measured: there is no V1.x
-#   diagnostics dump in the corpus at all. A controller line that used 0.01 kWh
-#   on series 1, kept it on series 2 and changed to 0.1 on series 3 is a
-#   plausible history; one that used 0.1, switched to 0.01, then switched back
-#   is not. It also keeps series 1 inside the ID_Waermemenge_* family above.
-#   Still an assumption, and the one to revisit first - tracked in #752.
+#   of the controller line, not of a register set; a pre-x.88 series-2 dump
+#   is what to look for (#752).
+# Series 1 - assumed to match series 2, still not measured. Five V1.x units
+#   are in the corpus now (V1.73, V1.77, V1.88.3 x2, V1.90.0) and none of
+#   them settles it: 1059 reads 0 on every one that returns it, and V1.73
+#   does not return it at all - its parameter block stops at 1021. The WZS
+#   on V1.90.0 reads 0 against 3037 h of ZWE1 run time and a working heat
+#   meter, which points at series 1 never filling the counter rather than
+#   filling it in another unit. Those dumps do settle the family argument
+#   above: the ID_Waermemenge_* counters are 0.01 kWh on series 1 as well
+#   (P0854 6449260 against calculation 151 64492.6 on V1.73, same ratio on
+#   V1.88.3 and V1.90.0), so it now rests on a measurement rather than on
+#   symmetry. A controller line that used 0.01 kWh on series 1, kept it on
+#   series 2 and changed to 0.1 on series 3 is a plausible history; one that
+#   used 0.1, switched to 0.01, then switched back is not. Still an
+#   assumption, but it can only bite on a series-1 unit that populates 1059,
+#   and no such unit has been seen - tracked in #752.
 #
 # Listed exhaustively rather than as a single series-2 exception so that every
 # generation states its scale where it can be checked. A generation missing

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -384,9 +384,20 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         entity_active_formula="!= 0.0",
         # Shares 1059's scale, by analogy rather than by measurement: it is
-        # the same physical element on the same controller, and no series-2
-        # unit has been seen with 1140 counting yet. Giving it its own scale
-        # would make a unit's total jump at the handover between the two.
+        # the same physical element on the same controller. Giving it its own
+        # scale would make a unit's total jump at the handover between the
+        # two.
+        #
+        # The analogy is not worth chasing further: across the diagnostics
+        # corpus 1140 counts only on series 3 (six units, V3.88.0 through
+        # V3.92.3) and reads exactly 0 on every series-1 and series-2 unit,
+        # while the handover itself was watched happening on one MSW4-16
+        # during V3.92.1 (0 -> 330 -> 841). So the register starting to count
+        # looks like series-3 firmware behaviour rather than something the
+        # older lines have yet to do, and `entity_active_formula` keeps the
+        # entity from existing at all while it reads 0 - a wrong series-1 or
+        # series-2 factor here cannot reach a user unless a generation that
+        # has never counted starts to.
         factor_by_firmware_series=AUX_HEATER_ENERGY_FACTOR_BY_SERIES,
         native_precision=1,
         # Despite the name this is not the second heat generator (ZWE2) - it


### PR DESCRIPTION
## 📋 Summary

The comment above `AUX_HEATER_ENERGY_FACTOR_BY_SERIES` said there was no V1.x diagnostics dump in the corpus at all, and named finding one as the first thing to check for #752. There are five now (V1.73, V1.77, V1.88.3 ×2, V1.90.0). This updates the comment to what they actually show. **Comment only — no behaviour change, the factor mapping is untouched.**

## 🔍 What the V1.x dumps show

- **They do not settle the series-1 scale of parameter 1059.** It reads `0` on every V1 unit that returns it, and V1.73 does not return it at all — its parameter block stops at index 1021.
- **The likely reason is that series 1 never fills the counter**, rather than filling it in a different unit: the WZS on V1.90.0 reads 0 against 3037 h of ZWE1 run time *and* a working heat meter (P0852 = 17612276).
- **The `ID_Waermemenge_*` family is 0.01 kWh on series 1 too**, now measured rather than assumed by symmetry — P0854 6449260 against calculation 151 64492.6 on V1.73, and the same ratio on V1.88.3 and V1.90.0. That is the argument the assumed series-1 factor rests on, so it is on firmer ground than before even though the direct measurement is still missing.

## ♻️ Also

Drops the "check for a V1.x dump" pointer from the series-2 paragraph — that lead is spent. A pre-x.88 series-2 dump is what remains to look for.

## ✅ Verification

- `ruff check` / `ruff format --check` clean on the touched file
- `codespell` clean
- `pytest tests/test_sensor.py` — 58 passed (the series-factor tests pin the mapping, which is unchanged)

Refs #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## ➕ Second commit: parameter 1140

The scale note on 1140 read as an open lead — *"no series-2 unit has been seen with 1140 counting yet"*. The corpus answers it, so it is now stated as a finding:

- 1140 counts **only on series 3** (six units, V3.88.0 through V3.92.3) and reads exactly 0 on every series-1 and series-2 unit.
- The handover from 1059 was observed on one MSW4-16 during V3.92.1 (0 → 330 → 841), so a register starting to count looks like series-3 firmware behaviour rather than something the older lines have yet to do.
- `entity_active_formula="!= 0.0"` bounds the risk: while the register reads 0 the entity is not created at all, so a wrong series-1 or series-2 factor cannot reach a user unless a generation that has never counted starts to.

Still a comment-only change.
