### PR TITLE
docs(readme,timer_schedules): 📝 document ventilation, the new timer circuits, and the pool counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ It takes a lot of time and effort to keep up with changes (Home Assistant and Lu
 
 Big thanks to [all community members](https://github.com/BenPru/luxtronik/graphs/contributors) who have contributed to this project. 
 
+## 📖 Contents
+
+- [⚠️ Warning](#️-warning) — what you can break, and how the integration limits that
+- [🔧 Compatibility](#-compatibility) — supported controllers and brands
+- [1. Installation](#1-installation) — add the HACS repository, install, add your heat pump, configure options
+- [2. Using Luxtronik](#2-using-luxtronik) — the devices and their entities
+  - [2.1 Heatpump](#21-heatpump) · [2.2 Heating](#22-heating) · [2.3 Cooling](#23-cooling) · [2.4 DHW](#24-dhw-domestic-hot-water) (incl. [2.4.1 DHW Timer Schedule](#241-dhw-timer-schedule-blocking-times)) · [2.5 Ventilation](#25-ventilation)
+- [3. Automations & Advanced Usage](#3-automations--advanced-usage)
+  - [3.1 Common Automations](#31-common-automations) (incl. [3.1.1 Automating Cooling](#311-automating-cooling) and [3.1.2 Automating DHW](#312-automating-dhw)) · [3.2 Advanced Entities](#32-advanced-entities-configuration) · [3.3 Energy Use](#33-energy-use)
+- [4. Troubleshooting](#4-troubleshooting) — first steps when something doesn't work
+
+**Other documents in this repository:**
+
+- **[ADVANCED_FEATURES.md](ADVANCED_FEATURES.md)** — integration options, COP and the external power sensor, EVU/Smart Grid, diagnostics downloads, holiday scheduling, solar thermal, and the other entities that only appear on some hardware.
+- **[TIMER_SCHEDULES.md](TIMER_SCHEDULES.md)** — the editable weekly schedules for DHW, heating, and ventilation: entity list, time format, and what a window means on each circuit.
+- **[REPORTING_ISSUES.md](REPORTING_ISSUES.md)** — how to file a bug report that can be diagnosed on the first pass.
+
 ## ⚠️ Warning
 Some settings exposed by this integration can impact the performance of your heat pump. Misconfigurations may cause the controller to go into an error state, requiring a local manual reset. 
 
@@ -69,9 +86,9 @@ After setup, **Settings → Devices & Services → Luxtronik → Configure** let
 
 ---
 
-## 2 Using Luxtronik
+## 2. Using Luxtronik
 
-Entities and actions are organized into four logical devices in Home Assistant to keep things structured. Here is an overview of what each device does and how to use the most common entities.
+Entities and actions are organized into up to five logical devices in Home Assistant to keep things structured. Here is an overview of what each device does and how to use the most common entities. *Cooling*, *DHW* and *Ventilation* only appear if the heat pump reports that capability; *Heatpump* and *Heating* are always present.
 
 > **ℹ️ Note:** Not every entity documented below will exist on every installation. Each one is only created if your specific heat pump reports the corresponding feature as present (e.g. a solar collector, a second heat generator, cooling capability) or its firmware version meets that entity's minimum requirement. This means **updating your heat pump's firmware can make additional sensors and controls appear** in Home Assistant that weren't there before — if you're missing an entity mentioned here, check whether a firmware update is available (see [Advanced Features: Firmware Update Entity](ADVANCED_FEATURES.md#firmware-update-entity)) before assuming it's unsupported.
 >
@@ -99,6 +116,7 @@ This device controls the space heating functionality (e.g., underfloor heating o
 - **Target Temperature Correction:** Quickly bump the heating target up or down by a few degrees without altering the main heating curve.
 - **Away/Holiday Start & End Date:** Pre-schedule a future Holiday period — the heat pump switches into Holiday mode on the start date and back to Automatic on the end date automatically — see [Advanced Features: Away / Holiday Scheduling](ADVANCED_FEATURES.md#away--holiday-scheduling).
 - **Heating Circuit Control Mode** *(disabled by default)*: switches the heat pump between its normal outside-temperature heating curve and a fixed manual flow/return target temperature — useful if you don't have a room thermostat and want to build your own control logic. See [Advanced Features: Heating Circuit Control Mode](ADVANCED_FEATURES.md#heating-circuit-control-mode-bypassing-the-heating-curve).
+- **Heating Timer Program & Heating Timer Schedule:** The controller's weekly schedule of **raise times** — windows in which the heating circuit runs in day mode, with night setback applying outside them — editable as Text entities, with a Select choosing the schedule shape (whole week / weekdays + weekend / per day). Note this is the opposite polarity from the DHW schedule's blocking times. See **[TIMER_SCHEDULES.md](TIMER_SCHEDULES.md)**.
 
 ### 2.3 Cooling
 If your heat pump supports active or passive cooling, this device manages it.
@@ -123,6 +141,114 @@ Advanced entities:
 > **⚠️ Important:** If the cooling target temperature is set too low, condensation can form on floor tiles, pipes, and inside the heat pump. A brine heat pump should generally not use a target temperature below 18°C to avoid damage. Consult your manual for details.
 
 > **ℹ️ Note:** The Energy input may not work as expected. This is a limitation of the Luxtronik firmware.
+
+The amount of cooling can be controlled with the Cooling climate entity's *Target Temperature* when the heatpump is configured to cool based on fixed temperature ([page 17](https://mw.ait-group.net/files/docs/EN/A0220/83055400.pdf)) — remember its meaning depends on your room control unit, per the note above.
+
+**Automating cooling** has its own section further down: [§3.1.1 Automating Cooling](#311-automating-cooling).
+
+### 2.4 DHW (Domestic Hot Water)
+This device controls the boiler/tank for your tap water.
+
+Basic entities:
+| Name | Entity Type | Units | Description |
+| :--- | :--- | :--- | :--- |
+| **Domestic Water** | Water Heater | °C | The water heater entity combines several of the entities below into a combined water heater entity. It shows the *Domestic Hot Water* temperature and allows setting the *Target* temperature. It has 4 operating modes (Automatic / Party / Holiday / Off). The away mode sets the operating *Mode* to Holiday or the last known state. |
+| **Mode** | Select | - | Sets the operating *Mode*: Automatic / Party / Holiday / Off. Automatic is for standard operation. Party is for increased hot water. Holiday and Off suspend operations. |
+| **Mode Automatic** | Switch | on/off | Sets the operating mode to Off or last known state. |
+| **DHW Target Temperature** | Number | °C | Set the DHW target temperature. |
+| **DHW Current Temperature** | Sensor | °C | The current DHW temperature. |
+
+Advanced entities:
+| Name | Entity Type | Units | Description |
+| :--- | :--- | :--- | :--- |
+| **Hysteresis** | Number | °C | The difference between the *DHW Current Temperature* and *DHW Target Temperature* before the water is heated up gain to the *DHW Target Temperature*. |
+| **Thermal Desinfection Target Temperature** | Number | °C | Target temperature for Thermal Disinfection cycle. |
+| **Thermal Desinfection Day** | Select | Day | The day on which the thermal disinfection cycle is performed, or `continuous` to make every DHW heating cycle eligible (see the on-demand trick below). The heat pump runs the cycle at its own fixed nightly time on that day — this integration cannot change *when* it runs, only *which day(s)*. |
+| **DHW Manual Frequency** | Number | Hz | Forces the compressor to a fixed frequency during DHW heating instead of the heat pump's own automatic choice (`0` = Automatic). Useful for solar self-consumption — see [Advanced Features: DHW Manual Frequency](ADVANCED_FEATURES.md#dhw-manual-frequency-matching-compressor-power-to-solar-surplus). |
+| **Away/Holiday Start & End Date** | Date | - | Pre-schedule a future DHW Holiday period (auto start and return), independent of the Heating device's own dates — see [Advanced Features: Away / Holiday Scheduling](ADVANCED_FEATURES.md#away--holiday-scheduling). |
+| **Hot water timer program** | Select | - | Which blocking-time schedule shape the controller uses: *Whole week*, *Weekdays + weekend*, or *Per day*. Switching it swaps which schedule entities are present — see [TIMER_SCHEDULES.md](TIMER_SCHEDULES.md). |
+
+> **ℹ️ Note:** It is not possible to trigger a thermal disinfection cycle on demand, or move it off its fixed nightly time, using the *Thermal Desinfection Day* select alone. It can be emulated at a time of your choosing by temporarily setting *Thermal Desinfection Day* to `continuous` and raising the *DHW Target Temperature* to the *Thermal Desinfection Target Temperature* value — this makes the heat pump's normal (immediate) heating logic reach disinfection temperature right away, instead of waiting for its own nightly schedule. See the *Legionella prevention using solar power* example below. The **Thermal Desinfection Target Temperature** entity also exposes a `last_thermal_desinfection` timestamp attribute (last time the DHW temperature rose above that target), handy for gating an automation like the example to "at most once a week".
+
+If your system has an integrated **solar thermal collector** feeding the DHW tank, extra temperature/pump entities appear automatically — see [Advanced Features: Solar Thermal Collector](ADVANCED_FEATURES.md#solar-thermal-collector).
+
+#### 2.4.1 DHW Timer Schedule (Blocking Times)
+
+DHW also supports an editable weekly schedule of **blocking times** — windows during which automatic DHW heating is switched off, exposed as a set of Text entities. The controller offers three schedule shapes (whole week, weekdays + weekend, per day) selected by the *Hot water timer program* entity; only the selected shape's schedule entities are present, the others are disabled. See **[TIMER_SCHEDULES.md](TIMER_SCHEDULES.md)** for the entity list, the `HH:MM-HH:MM/...` format, and an important note on how DHW's blocking-time semantics differ from the heating schedule.
+
+**Automating DHW** has its own section further down: [§3.1.2 Automating DHW](#312-automating-dhw).
+
+### 2.5 Ventilation
+
+Some units have an integrated ventilation module (controlled ventilation with heat recovery). If yours does, a fifth device appears with the module's own sensors and controls.
+
+Basic entities:
+| Name | Entity Type | Units | Description |
+| :--- | :--- | :--- | :--- |
+| **Ventilation mode** | Select | - | The module's operating mode: *Automatic* / *Party* / *Holidays* / *Off*. As on the heating circuit, the programmed timer schedule is expected to apply only in *Automatic* — see the note below. |
+| **Supply air temperature** | Sensor | °C | Temperature of the air being supplied to the rooms. |
+| **Exhaust air temperature** | Sensor | °C | Temperature of the air being extracted from the rooms. |
+| **Supply fan setpoint** / **Exhaust fan setpoint** | Sensor | % | How hard each fan is currently being driven, as a percentage of its full analog output. These are modulating outputs, so the value tracks the active stage rather than just on/off. |
+
+Advanced entities (diagnostic, read-only):
+| Name | Entity Type | Units | Description |
+| :--- | :--- | :--- | :--- |
+| **Humidity protection stage** / **Reduced stage** / **Nominal stage** / **Intensive stage** | Sensor | m³/h | The four airflow rates configured on the controller for the DIN 1946-6 ventilation stages. They show how the module is commissioned, and let you interpret a fan setpoint: on a 400 m³/h unit, a *Nominal stage* of 250 m³/h corresponds to a 62.5 % fan setpoint. |
+
+The module also has an editable weekly schedule (*Ventilation timer program* select + *Ventilation Timer Schedule* text entities) — see **[TIMER_SCHEDULES.md](TIMER_SCHEDULES.md)**, including which parts of its behaviour are still unconfirmed.
+
+> **ℹ️ Note:** The stage entities are deliberately read-only sensors rather than writable Number entities: their scale (m³/h with no conversion) is established from a single system, and a wrong unit on a display is a cosmetic problem while a wrong unit on a write is not. Set the stages on the controller itself.
+
+> **ℹ️ Note:** Whether this device exists is decided from the module's own air temperature readings, not from the controller's ventilation visibility flag — that flag reads 0 on units with a perfectly functional module, which would hide the device. The device is created when the integration starts, so after retrofitting a module, **reload the integration** (Settings → Devices & Services → Luxtronik → ⋮ → Reload) to make the device appear.
+
+---
+
+## 3. Automations & Advanced Usage
+
+### 3.1 Common Automations
+
+Here are a few practical examples of how to automate your Luxtronik heat pump:
+
+**1. Boost hot water before taking a bath:**
+Put the DHW circuit into *Party* mode when you need extra hot water quickly. There are two equivalent ways to do it, and in practice this is usually a **manual action in the UI** rather than an automation: either set the *Domestic water* water heater card to **Performance**, or set the *DHW mode* select to **Party**. Both write the same operating mode to the heat pump — use whichever entity is already on your dashboard.
+
+It can of course be automated if you want it on a schedule or a trigger:
+```yaml
+# via the water heater entity
+action: water_heater.set_operation_mode
+target:
+  entity_id: water_heater.luxtronik_domestic_water
+data:
+  operation_mode: performance
+
+# ...or via the mode select
+action: select.select_option
+target:
+  entity_id: select.luxtronik_dhw_mode
+data:
+  option: party
+```
+Remember to switch back to *Automatic* (water heater: **Heat pump**) afterwards — *Party* stays on until it is changed, and it overrides any [DHW blocking-time schedule](#241-dhw-timer-schedule-blocking-times) you have programmed.
+
+**2. Reduce heating target while away:**
+Use the target correction entity to temporarily lower the heating curve by 2 degrees when nobody is home.
+```yaml
+action: number.set_value
+target:
+  entity_id: number.luxtronik_heating_target_correction
+data:
+  value: -2.0
+```
+
+**3. Solar PV optimization (Simple):**
+If your solar panels are producing excess energy, increase the DHW target temperature so the heat pump acts as a thermal battery.
+```yaml
+action: water_heater.set_temperature
+target:
+  entity_id: water_heater.luxtronik_dhw
+data:
+  temperature: 55
+```
 
 #### 3.1.1 Automating Cooling
 It's important to understand your setup and configurations in order to correctly automate cooling using Home Assistant. A properly configured heatpump can work well on it's own and requires little intervention. 
@@ -156,38 +282,6 @@ action:
           entity_id: switch.luxtronik_cooling
 ```
 </details>
-
-The amount of cooling can be controlled with the Cooling climate entity's *Target Temperature* when the heatpump is configured to cool based on fixed temperature ([page 17](https://mw.ait-group.net/files/docs/EN/A0220/83055400.pdf)) — remember its meaning depends on your room control unit, per the note above.
-
-### 2.4 DHW (Domestic Hot Water)
-This device controls the boiler/tank for your tap water.
-
-Basic entities:
-| Name | Entity Type | Units | Description |
-| :--- | :--- | :--- | :--- |
-| **Domestic Water** | Water Heater | °C | The water heater entity combines several of the entities below into a combined water heater entity. It shows the *Domestic Hot Water* temperature and allows setting the *Target* temperature. It has 4 operating modes (Automatic / Party / Holiday / Off). The away mode sets the operating *Mode* to Holiday or the last known state. |
-| **Mode** | Select | - | Sets the operating *Mode*: Automatic / Party / Holiday / Off. Automatic is for standard operation. Party is for increased hot water. Holiday and Off suspend operations. |
-| **Mode Automatic** | Switch | on/off | Sets the operating mode to Off or last known state. |
-| **DHW Target Temperature** | Number | °C | Set the DHW target temperature. |
-| **DHW Current Temperature** | Sensor | °C | The current DHW temperature. |
-
-Advanced entities:
-| Name | Entity Type | Units | Description |
-| :--- | :--- | :--- | :--- |
-| **Hysteresis** | Number | °C | The difference between the *DHW Current Temperature* and *DHW Target Temperature* before the water is heated up gain to the *DHW Target Temperature*. |
-| **Thermal Desinfection Target Temperature** | Number | °C | Target temperature for Thermal Disinfection cycle. |
-| **Thermal Desinfection Day** | Select | Day | The day on which the thermal disinfection cycle is performed, or `continuous` to make every DHW heating cycle eligible (see the on-demand trick below). The heat pump runs the cycle at its own fixed nightly time on that day — this integration cannot change *when* it runs, only *which day(s)*. |
-| **DHW Manual Frequency** | Number | Hz | Forces the compressor to a fixed frequency during DHW heating instead of the heat pump's own automatic choice (`0` = Automatic). Useful for solar self-consumption — see [Advanced Features: DHW Manual Frequency](ADVANCED_FEATURES.md#dhw-manual-frequency-matching-compressor-power-to-solar-surplus). |
-| **Away/Holiday Start & End Date** | Date | - | Pre-schedule a future DHW Holiday period (auto start and return), independent of the Heating device's own dates — see [Advanced Features: Away / Holiday Scheduling](ADVANCED_FEATURES.md#away--holiday-scheduling). |
-| **DHW Timer Program** | Select | - | Which blocking-time schedule shape the controller uses: *Whole week*, *Weekdays + weekend*, or *Per day*. Switching it swaps which schedule entities are present — see [TIMER_SCHEDULES.md](TIMER_SCHEDULES.md). |
-
-> **ℹ️ Note:** It is not possible to trigger a thermal disinfection cycle on demand, or move it off its fixed nightly time, using the *Thermal Desinfection Day* select alone. It can be emulated at a time of your choosing by temporarily setting *Thermal Desinfection Day* to `continuous` and raising the *DHW Target Temperature* to the *Thermal Desinfection Target Temperature* value — this makes the heat pump's normal (immediate) heating logic reach disinfection temperature right away, instead of waiting for its own nightly schedule. See the *Legionella prevention using solar power* example below. The **Thermal Desinfection Target Temperature** entity also exposes a `last_thermal_desinfection` timestamp attribute (last time the DHW temperature rose above that target), handy for gating an automation like the example to "at most once a week".
-
-If your system has an integrated **solar thermal collector** feeding the DHW tank, extra temperature/pump entities appear automatically — see [Advanced Features: Solar Thermal Collector](ADVANCED_FEATURES.md#solar-thermal-collector).
-
-#### DHW Timer Schedule (Blocking Times)
-
-DHW also supports an editable weekly schedule of **blocking times** — windows during which automatic DHW heating is switched off, exposed as a set of Text entities. The controller offers three schedule shapes (whole week, weekdays + weekend, per day) selected by the *DHW Timer Program* entity; only the selected shape's schedule entities are present, the others are disabled. See **[TIMER_SCHEDULES.md](TIMER_SCHEDULES.md)** for the entity list, the `HH:MM-HH:MM/...` format, and an important note on how DHW's blocking-time semantics differ from the heating schedule.
 
 #### 3.1.2 Automating DHW
 Automations for DHW typically use the water heater entity or the Party/Boost mode. Common scenarios include pre-heating before showers, using excess solar energy to heat the tank.
@@ -286,38 +380,6 @@ action:
 
 </details>
 
----
-
-## 3. Automations & Advanced Usage
-
-### 3.1 Common Automations
-
-Here are a few practical examples of how to automate your Luxtronik heat pump:
-
-**1. Boost hot water before taking a bath:**
-Trigger the "Party" mode on the DHW device when you need extra hot water quickly.
-
-
-**2. Reduce heating target while away:**
-Use the target correction entity to temporarily lower the heating curve by 2 degrees when nobody is home.
-```yaml
-action: number.set_value
-target:
-  entity_id: number.luxtronik_heating_target_correction
-data:
-  value: -2.0
-```
-
-**3. Solar PV optimization (Simple):**
-If your solar panels are producing excess energy, increase the DHW target temperature so the heat pump acts as a thermal battery.
-```yaml
-action: water_heater.set_temperature
-target:
-  entity_id: water_heater.luxtronik_dhw
-data:
-  temperature: 55
-```
-
 ### 3.2 Advanced Entities (Configuration)
 
 To protect your system from accidental misconfiguration, several advanced configuration parameters are **disabled by default**. They can be enabled manually from the Home Assistant entity registry if you need them.
@@ -337,6 +399,8 @@ Not all heat pumps have built-in electrical energy metering. Some only show the 
 If you want to accurately measure the SCOP (Seasonal Coefficient of Performance) of your device, consider adding an external energy meter. Devices like Shelly offer a [16A power plug](https://www.shelly.com/en-nl/products/product-overview/1xplug) or [in-line/clamp energy meters](https://www.shelly.com/en-nl/products/energy-metering-energy-efficiency) that integrate perfectly with Home Assistant.
 
 The **Heating COP** and **DHW COP** sensors report an instantaneous efficiency ratio, and can use such an external meter directly as their power-consumption input instead of the heat pump's own reading — see [Advanced Features: COP Calculation and the External Power Sensor](ADVANCED_FEATURES.md#cop-calculation-and-the-external-power-sensor).
+
+**Pool heating** has its own pair of lifetime counters on the *Heatpump* device (diagnostic category): **Pool heat amount** — the thermal energy delivered to the pool — and **Pool energy input**, the electricity the heat pump consumed producing it. Both are total-increasing energy sensors in kWh, so Home Assistant keeps long-term statistics for them, and dividing one by the other over a period gives the pool circuit's seasonal efficiency. They are only created once their register reads something other than zero, because a unit without a pool reports 0.0 forever — so on a newly commissioned pool, reload the integration once it has run (see the note at the top of [§2 Using Luxtronik](#2-using-luxtronik)).
 
 > **⚠️ Series-2 controllers (firmware V2.x): the Additional heat generator energy sensors now read ten times lower.**
 > On a series-2 controller these counters step in 0.01 kWh, not the 0.1 kWh the integration previously assumed, so a unit that reported 14714 kWh now correctly reports 1471.4 kWh. Because they are total-increasing energy sensors, Home Assistant reads that one-off drop as a meter reset and books the first reading after the update as fresh consumption — a spurious spike of roughly the sensor's whole lifetime total in the energy dashboard.

--- a/TIMER_SCHEDULES.md
+++ b/TIMER_SCHEDULES.md
@@ -2,55 +2,114 @@
 
 Several circuits on the heat pump controller can be programmed with a weekly schedule directly on the controller (or its firmware's built-in web interface). This integration exposes those schedules as editable Home Assistant entities so they can be read and changed without touching the physical controller.
 
-Only the **DHW (Bw)** circuit is wired up so far. The other five timer-program circuits — heating (Hkr), mixing circuits 1/2 (Mk1/Mk2), circulation pump (ZIP), and pool (Swb) — are intentionally deferred until the DHW implementation has been validated in the field; see [Extending to other circuits](#extending-to-other-circuits) below.
+Three circuits are wired up: **DHW (Bw)**, **heating (Hkr)**, and the **ventilation module (Luf)**. The remaining timer-program circuits — mixing circuits 1/2/3 (Mk1/Mk2/Mk3), circulation pump (ZIP), pool (Swb), and the combined "all circuits" block — are still deferred; see [Extending to other circuits](#extending-to-other-circuits) below.
+
+**A schedule window does not mean the same thing on every circuit.** On DHW it *blocks* heating; on the heating circuit it *raises* the circuit into day mode. Read your circuit's section below before programming it.
+
+## How a schedule is programmed
+
+Every circuit works the same way, and each has two kinds of entity:
+
+- One **timer program** select, which picks the schedule *shape*. The controller supports three mutually-exclusive shapes:
+  - **Whole week** – one schedule applies to every day.
+  - **Weekdays + weekend** ("5+2") – one schedule for Monday-Friday, a separate one for Saturday-Sunday.
+  - **Per day** – an independent schedule for each individual day of the week.
+- A set of **schedule** text entities, one per day or day-group of the active shape.
+
+Each schedule entity holds that day's time windows as a single string of `HH:MM-HH:MM` pairs separated by `/`, for example:
+
+```
+12:00-13:00/22:00-23:30
+```
+
+Set the value to an empty string to clear all windows for that entity. How many windows fit per day differs per circuit (5 for DHW, 3 for heating and ventilation), and times are always whole minutes — the controller cannot set seconds.
+
+The timer program can be switched from Home Assistant as well as on the physical controller (or its web interface), and both directions are picked up automatically.
+
+### Only the active shape's entities are present
+
+Only the schedule entities of the shape currently selected in that circuit's *timer program* exist as usable entities. The other shapes' entities are **disabled** rather than left permanently unavailable, so the device page collapses them behind a *"+N disabled entities"* button instead of listing them as broken. Each circuit is tracked independently — DHW being on *Per day* while heating is on *Whole week* is perfectly normal.
+
+Changing a timer program — from Home Assistant or on the controller itself — swaps the entity set automatically within one polling interval; no restart or integration reload is needed. Because the entities are disabled rather than deleted, everything you attached to them survives the switch: a renamed entity ID, friendly name, icon, area, labels, and their recorder history all come back unchanged when that shape becomes active again.
+
+> **ℹ️ Note:** Home Assistant reloads an integration ~30 seconds after any of its entities is re-enabled, so switching a timer program is followed by a brief reload of the Luxtronik integration. The new shape's schedule entities themselves appear immediately — the reload happens afterwards and needs no action from you.
+
+Entities of an inactive shape keep a stale `unavailable` state in the state machine (Home Assistant's normal behaviour for a registered entity that no integration is currently providing). Nothing surfaces this in the UI, but a dashboard card that references such an entity by ID directly will show it as unavailable while its shape is inactive.
 
 ## DHW Timer Schedule (Blocking Times)
 
-The heat pump controller can be programmed with a weekly schedule of **blocking times** for DHW. Unlike a heating schedule (which defines when heating is *raised*), a DHW schedule window is a **"do not heat" window**: during a configured time span, automatic DHW heating is switched off; outside those spans it runs normally according to the *Mode* setting (see [README § 2.4 DHW](README.md#24-dhw-domestic-hot-water)). If you need hot water during an active blocking window, switch *Mode* to *Party* to override it temporarily (see the README's [Automating DHW](README.md#312-automating-dhw) section, *Boost hot water* example).
+**On the DHW device.** Up to **5 windows per day**, and each window is a **"do not heat" window**: during a configured time span, automatic DHW heating is switched off; outside those spans it runs normally according to the *Mode* setting (see [README § 2.4 DHW](README.md#24-dhw-domestic-hot-water)). This is the opposite polarity from the heating circuit below — the controller calls these windows *Sperrzeiten*, blocking times.
 
-The controller supports three mutually-exclusive schedule shapes for DHW, up to 5 blocking windows per day each:
-- **Week** – one schedule applies to every day.
-- **Weekday / Weekend** ("5+2") – one schedule for Monday-Friday, a separate one for Saturday-Sunday.
-- **Per day** – an independent schedule for each individual day of the week.
-
-Only one shape is active at a time. Which shape is active is exposed as the **DHW Timer Program** select entity, so it can be switched from Home Assistant as well as on the physical controller (or its web interface).
+If you need hot water during an active blocking window, switch *Mode* to *Party* to override it temporarily (see the README's [Common Automations](README.md#31-common-automations) section, *Boost hot water* example).
 
 | Name | Entity Type | Description |
 | :--- | :--- | :--- |
-| **DHW Timer Program** | Select | Which schedule shape the controller uses: *Whole week*, *Weekdays + weekend*, or *Per day*. |
+| **Hot water timer program** | Select | Which schedule shape the controller uses: *Whole week*, *Weekdays + weekend*, or *Per day*. |
 | **DHW Timer Schedule (Week)** | Text | Exists while the *Week* shape is active. |
 | **DHW Timer Schedule (Weekdays)** | Text | Exists while *Weekday/Weekend* is active; covers Monday-Friday. |
 | **DHW Timer Schedule (Weekend)** | Text | Exists while *Weekday/Weekend* is active; covers Saturday-Sunday. |
 | **DHW Timer Schedule (Monday)** … **(Sunday)** | Text | One entity per day of the week, present while *Per day* is active. |
 
-Each entity holds up to 5 blocking windows as a single string of `HH:MM-HH:MM` pairs separated by `/`, for example:
-```
-12:00-13:00/22:00-23:30
-```
-This blocks DHW heating over lunch (12:00-13:00) and in the evening (22:00-23:30). Set the value to an empty string to clear all blocking windows for that entity.
+The example above (`12:00-13:00/22:00-23:30`) blocks DHW heating over lunch and late in the evening.
 
-### Only the active shape's entities are present
+## Heating Timer Schedule (Raise / Setback Times)
 
-Only the schedule entities of the shape currently selected in *DHW Timer Program* exist as usable entities. The other shapes' entities are **disabled** rather than left permanently unavailable, so the device page collapses them behind a *"+N disabled entities"* button instead of listing them as broken.
+**On the Heating device.** Up to **3 windows per day**, and a window means the **opposite** of DHW's: inside a window the heating circuit is *raised* (day mode); outside every window it is *lowered* (night setback, by the amount set in the **Heating curve night reduction** number entity). Clearing a schedule therefore does not "disable" it — it leaves the circuit in night setback around the clock.
 
-Changing the timer program — from Home Assistant or on the controller itself — swaps the entity set automatically within one polling interval; no restart or integration reload is needed. Because the entities are disabled rather than deleted, everything you attached to them survives the switch: a renamed entity ID, friendly name, icon, area, labels, and their recorder history all come back unchanged when that shape becomes active again.
+| Name | Entity Type | Description |
+| :--- | :--- | :--- |
+| **Heating timer program** | Select | Which schedule shape the controller uses: *Whole week*, *Weekdays + weekend*, or *Per day*. |
+| **Heating Timer Schedule (Week)** | Text | Exists while the *Week* shape is active. |
+| **Heating Timer Schedule (Weekdays)** | Text | Exists while *Weekday/Weekend* is active; covers Monday-Friday. |
+| **Heating Timer Schedule (Weekend)** | Text | Exists while *Weekday/Weekend* is active; covers Saturday-Sunday. |
+| **Heating Timer Schedule (Monday)** … **(Sunday)** | Text | One entity per day of the week, present while *Per day* is active. |
 
-> **ℹ️ Note:** Home Assistant reloads an integration ~30 seconds after any of its entities is re-enabled, so switching the timer program is followed by a brief reload of the Luxtronik integration. The new shape's schedule entities themselves appear immediately — the reload happens afterwards and needs no action from you.
+So `06:00-12:00/13:00-22:00` runs the heating raised in the morning and again from the afternoon into the evening, and in setback overnight and over lunch.
 
-Entities of an inactive shape keep a stale `unavailable` state in the state machine (Home Assistant's normal behaviour for a registered entity that no integration is currently providing). Nothing surfaces this in the UI, but a dashboard card that references such an entity by ID directly will show it as unavailable while its shape is inactive.
+> **⚠️ A window of `00:00-00:00` does not mean "all day".** The controller reads it as *permanently lowered*: the circuit then runs in night mode only. This is firmware behaviour, documented in the controller's own manual (*Betriebsanleitung Heizungs- und Wärmepumpenregler 2.0/2.1*, document 83055200bDE, section "Einstellen der Schaltzeiten des Heizkreises"), not something this integration imposes.
+
+The schedule only has an effect while the heating *Mode* is **Automatic** — *Party* holds day mode and *Holidays* holds setback regardless of the programmed times.
+
+## Ventilation Timer Schedule
+
+**On the Ventilation device**, so these entities only exist if your unit has an integrated ventilation module (see [README § 2.5 Ventilation](README.md#25-ventilation)). Up to **3 windows per day**. The module is *expected* to follow the heating circuit's raise/setback pattern rather than DHW's blocking one — a window raising the stage rather than suppressing ventilation — but see the note below: that has not been confirmed against a physical unit.
+
+| Name | Entity Type | Description |
+| :--- | :--- | :--- |
+| **Ventilation timer program** | Select | Which schedule shape the controller uses: *Whole week*, *Weekdays + weekend*, or *Per day*. |
+| **Ventilation Timer Schedule (Week)** | Text | Exists while the *Week* shape is active. |
+| **Ventilation Timer Schedule (Weekdays)** | Text | Exists while *Weekday/Weekend* is active; covers Monday-Friday. |
+| **Ventilation Timer Schedule (Weekend)** | Text | Exists while *Weekday/Weekend* is active; covers Saturday-Sunday. |
+| **Ventilation Timer Schedule (Monday)** … **(Sunday)** | Text | One entity per day of the week, present while *Per day* is active. |
+
+> **ℹ️ No unit with a ventilation module has been sampled yet, so four things here are inferred rather than confirmed:**
+>
+> 1. That a window *raises* the ventilation stage, rather than blocking it the way a DHW window does.
+> 2. That the schedule applies only while *Ventilation mode* is *Automatic*.
+> 3. That the program selector uses the same *week / 5+2 / per day* codes as the other circuits.
+> 4. That the leading index in its parameter names distinguishes start time from end time.
+>
+> Items 3 and 4 are inferred from the firmware's parameter naming (and are marked as such in the code); items 1 and 2 are inferred from how the other circuits behave. If the shape you select doesn't match what the controller shows, if start and end times look swapped, or if the module behaves the opposite way round from what is described here, please open an issue with a [diagnostics download](ADVANCED_FEATURES.md#diagnostics-download) attached — that is exactly the evidence needed to settle all four.
 
 ## Extending to other circuits
 
-The remaining five timer-program circuits share the same underlying shape (mode selector + Week/5+2/Per-day time blocks), just with different parameter-name prefixes and row counts:
+The remaining timer-program circuits share the same underlying shape (mode selector + Week/5+2/Per-day time blocks), just with different parameter-name prefixes and row counts:
 
-| Circuit | Mode selector | Rows/day |
-| :--- | :--- | :--- |
-| Heating (Hkr) | `ID_Einst_SuHkr_akt` | 3 |
-| Mixing circuit 1 (Mk1) | `ID_Einst_SuMk1_akt` | 3 |
-| Mixing circuit 2 (Mk2) | `ID_Einst_SuMk2_akt` | 3 |
-| Circulation pump (ZIP) | `ID_Einst_SuZIP_akt` | 5 |
-| Pool (Swb) | `ID_Einst_SuSwb_akt` | 3 |
+| Circuit | Mode selector | Prefixes (week / 5+2 / per day) | Rows/day |
+| :--- | :--- | :--- | :--- |
+| Mixing circuit 1 (Mk1) | `ID_Einst_SuMk1_akt` (283) | `SuMk1W0` / `SuMk125` / `SuMk1TG` | 3 |
+| Mixing circuit 2 (Mk2) | `ID_Einst_SuMk2_akt2` (344) | `SuMk2Wo` / `SuMk225` / `SuMk2Tg` | 3 |
+| Mixing circuit 3 (Mk3) | `ID_Einst_SuMk3_akt2` (788) | `SuMk3Wo` / `SuMk325` / `SuMk3Tg` | 3 |
+| Circulation pump (ZIP) | `ID_Einst_SuZIP_akt` (506) | `SuZIPWo` / `SuZIP25` / `SuZIPTg` | 5 |
+| Pool (Swb) | `ID_Einst_SuSwb_akt` (607) | `SuSwbWo` / `SuSwb25` / `SuSwbTg` | 3 |
+| All circuits combined (All) | `ID_Einst_SuAll_akt2` (161) | `SuAllWo` / `SuAll25` / `SuAllTg` | 3 |
 
-Adding one is additive: define a `_TimerCircuit` in `timer_schedule_entities_predefined.py` (mirroring `_DHW_CIRCUIT`) with that circuit's selector name, row count, and `WO`/`25`/`TG` parameter prefixes, then call `_build_circuit_entities` with a matching set of `SensorKey` entries and translations. No changes to `text.py` itself should be needed — its logic, including the active-shape sync that enables and disables entities as the program changes, is already generic per `LuxtronikTimerScheduleTextDescription`. A select entity for the new circuit's own mode selector is one description in `select_entities_predefined.py`, reusing `raw_option_map` to map the HA option names onto the raw `week` / `5+2` / `days` values.
+> **⚠️ Several circuits expose *two* plausible selector parameters, an `_akt` and an `_akt2`, and the one that works is not always the first.** DHW's live selector is `ID_Einst_SUBW_akt2` (405), not `ID_Einst_SUBW_akt` (19); Mk2 and Mk3 and the combined block are the same way. The reliable rule in the library's parameter table is that a circuit's selector sits **immediately before its own time block** — 405 precedes the DHW block at 406, 222 precedes heating's 223, 895 precedes ventilation's 896. The selectors above were picked by that rule; confirm against a diagnostics dump before wiring one up.
 
-Unlike DHW, the heating/mixing/pool circuit schedules define when the circuit is *raised* (comfort setback), not blocking times — the semantics are the opposite of DHW's "Sperrzeiten". Confirm the correct direction for each circuit against the controller manual before writing its documentation, rather than assuming DHW's polarity applies uniformly.
+Adding one is additive: define a `_TimerCircuit` in `timer_schedule_entities_predefined.py` (mirroring `_HEATING_CIRCUIT`) with that circuit's selector name, row count, `WO`/`25`/`TG` parameter prefixes and name builder, then call `_build_circuit_entities` with a matching set of `SensorKey` entries and translations. No changes to `text.py` itself should be needed — its logic, including the per-circuit active-shape sync that enables and disables entities as a program changes, is already generic per `LuxtronikTimerScheduleTextDescription`. A select entity for the new circuit's own mode selector is one description in `select_entities_predefined.py`, reusing `raw_option_map` to map the HA option names onto the raw `week` / `5+2` / `days` values.
+
+Three things do *not* generalise, and cost a bug each time they are assumed:
+
+- **The parameter-name spelling is per circuit and must be copied verbatim from the library**, never derived: DHW uses `WO`/`TG`, heating uses `W0` (with a digit zero) and `TG`, ventilation uses `Wo`/`Tg`.
+- **The naming layout differs too.** DHW and heating name their parameters `<prefix>_zeit_<row>_<slot>`, with the start/end distinction in the trailing slot; ventilation puts it first, as `<prefix>_zeit_<0|1>_<row>_<2*col>`. That is why `_TimerCircuit` takes a `name_builder`. Check which layout a new circuit uses against a real diagnostics dump before wiring it up.
+- **The direction of a window is per circuit.** DHW blocks, heating raises; neither polarity can be assumed to carry over to the pool or the circulation pump. Confirm each new circuit against the controller manual before documenting it.


### PR DESCRIPTION
## 📝 What

Brings the user-facing documentation back in line with what has actually shipped over the last ~25 merged PRs. Documentation only — no code changes.

## 🎯 Why

Several merged features never reached the docs, and one document had become actively wrong:

- **TIMER_SCHEDULES.md** stated that DHW was the only wired-up timer circuit and listed heating as deferred — but #747 shipped heating *and* ventilation, so users were being told entities they can see don't exist.
- The **ventilation device** (#731, #745, #746) was undocumented everywhere, including the README's "four logical devices" overview.
- The **pool heat/energy counters** (#754) were not described anywhere.

## 🔄 Changes

### `TIMER_SCHEDULES.md` (rewritten)

- Restructured into a shared *"How a schedule is programmed"* section (shapes, `HH:MM-HH:MM/…` format, active-shape enable/disable behaviour — now correctly described as per-circuit) followed by one section per circuit.
- **Heating polarity is now stated rather than deferred.** The old text flagged this as an open question; it is settled from the manufacturer's manual (83055200bDE, *"Einstellen der Schaltzeiten des Heizkreises"*): a window **raises** the circuit into day mode, night setback applies outside it, and `00:00-00:00` means *permanently lowered* — a genuine trap, since it reads like "all day".
- **The ventilation section hedges instead of asserting.** No unit with a ventilation module has been sampled, so all four soft claims are listed explicitly (window polarity, Automatic-only, selector codes, start/end index ordering), split into "inferred from parameter naming" vs "inferred from other circuits", with a request for a diagnostics dump.
- **Corrected the extension guide's selector table.** A circuit's live selector is the one *immediately preceding its own time block* — which for DHW, Mk2, Mk3 and the combined block is the `_akt2` variant, not `_akt` (DHW's really is `ID_Einst_SUBW_akt2` at 405). The previous table's Mk2 and All entries were wrong, Mk3 was missing entirely, and the per-circuit prefix spellings (`WO`/`W0`/`Wo`) are now listed.

### `README.md`

- New **§2.5 Ventilation**: mode select, air temperatures, fan setpoints (documented as % of the full analog output, per the #729 evidence), and the four DIN 1946-6 stage sensors in m³/h — plus why they are read-only sensors, and why the device is detected from air temperatures rather than the `ID_Visi_Lueftung` flag (which reads 0 on working modules).
- **Pool heat amount / Pool energy input** added to §3.3 Energy Use, including the "only appears once non-zero" caveat.
- **Table of contents** at the top, plus pointers to the sibling documents.
- **Heading numbering fixed**: `3.1.1 Automating Cooling` and `3.1.2 Automating DHW` physically sat inside §2.3/§2.4 — they were *moved* rather than renumbered, so every existing anchor still resolves. The DHW timer subsection is now `2.4.1`.
- Fixed the entity name **`DHW Timer Program` → `Hot water timer program`** (matches `en.json`), and filled in the missing YAML for the "boost hot water" example — noting that in practice this is a UI action, and that the water heater takes `performance` where the select takes `party`.

## ✅ Verification

- Every factual claim (entity names, units, device classes, entity categories, `device_key`, gating logic, rows-per-day, parameter prefixes) checked against `translations/en.json`, the `*_entities_predefined.py` tables, and `coordinator.py`.
- All internal links and `#anchors` across README / ADVANCED_FEATURES / TIMER_SCHEDULES / REPORTING_ISSUES validated with a GitHub-compatible slug checker: **0 broken**.
- `codespell` clean; full test suite green (1037 passed, coverage unchanged at 99%) — docs-only, but run per the repo's pre-commit checklist.
- Reviewed by a code-review subagent; all Important findings addressed (the `DHW Timer Program` name, and hedging the ventilation polarity claims).

## 📌 Note for reviewers

The heating `00:00-00:00` behaviour and the raise/setback polarity come from the manufacturer's manual, not from the code — worth a sanity check by anyone with a controller in front of them. The ventilation claims are explicitly marked unverified in the document itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
