### PR TITLE
feat(sensor,const,lux_overrides): ✨ expose the cooling heat quantity counter

### DIFF
--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -115,9 +115,15 @@ WRITABLE_PARAMETER_PREFIXES: Final = (
     "Unknown_Parameter_",
     "HEATING_TARGET_TEMP_ROOM_THERMOSTAT",
     "ELECTRICAL_POWER_LIMIT_VALUE",
+    # 1146/1147, writable and entity-backed, but missing here since they were
+    # invented - the number entities set them through the coordinator, so only
+    # the write service was refusing them.
+    "Extra_DHW_target_temp",
+    "Extra_DHW_duration",
     "HEAT_ENERGY_INPUT",
     "DHW_ENERGY_INPUT",
     "COOLING_ENERGY_INPUT",
+    "COOLING_HEAT_AMOUNT",
     "POOL_ENERGY_INPUT",
     "SECOND_HEAT_GENERATOR_AMOUNT_COUNTER",
     "POWER_LIMIT_SWITCH",
@@ -521,6 +527,7 @@ class LuxParameter(StrEnum):
     P1119_LAST_DEFROST_TIMESTAMP = (
         "parameters.Unknown_Parameter_1119"  # 1685073431 -> 26.5.23 05:57
     )
+    P1135_COOLING_HEAT_AMOUNT = "parameters.COOLING_HEAT_AMOUNT"
     P1136_HEAT_ENERGY_INPUT = "parameters.HEAT_ENERGY_INPUT"
     P1137_DHW_ENERGY_INPUT = "parameters.DHW_ENERGY_INPUT"
     P1138_POOL_ENERGY_INPUT = "parameters.POOL_ENERGY_INPUT"
@@ -838,6 +845,7 @@ class SensorKey(StrEnum):
     HEAT_ENERGY_INPUT = "heat_energy_input"
     DHW_ENERGY_INPUT = "dhw_energy_input"
     COOLING_ENERGY_INPUT = "cooling_energy_input"
+    COOLING_HEAT_AMOUNT = "cooling_heat_amount"
     POOL_HEAT_AMOUNT = "pool_heat_amount"
     POOL_ENERGY_INPUT = "pool_energy_input"
     COP_HEATING = "cop_heating"

--- a/custom_components/luxtronik2/lux_overrides.py
+++ b/custom_components/luxtronik2/lux_overrides.py
@@ -190,8 +190,8 @@ parameters_to_add_update = {
     # totals put the same upper bound under 2 at /10 on six further units.
     # Upstream's "kWh/10" note claims /10 for these and is simply wrong here;
     # it also sits on 1059 and calculations 151/152/154, which need /10.
-    # 1139 has read 0.0 on every unit seen so far, so it follows its three
-    # siblings by analogy rather than by measurement.
+    # 1139 read 0.0 on every unit seen in #734, so it followed its siblings by
+    # analogy until the readings below measured it.
     #
     # #752 confirmed the scale directly for the first time: on an LD9 whose
     # controller page was photographed at the moment of the dump, 1136 read
@@ -199,6 +199,12 @@ parameters_to_add_update = {
     # 2223.3 kWh. The same unit identified 1138 as the pool counter - 113191
     # against a displayed 1131.9 kWh - which had sat unregistered because a
     # unit without a pool reads 0.0 there.
+    #
+    # A second unit in that issue, an LD5 that cools, settled 1139 the same way
+    # - 83272 counts against a displayed 832.7 kWh - and identified 1135 as the
+    # cooling heat quantity, 410381 counts against a displayed 4103.8 kWh. 1135
+    # had sat unregistered because a unit that never cools reads 0 there.
+    1135: Energy2("COOLING_HEAT_AMOUNT", False),
     1136: Energy2("HEAT_ENERGY_INPUT", False),
     1137: Energy2("DHW_ENERGY_INPUT", False),
     1138: Energy2("POOL_ENERGY_INPUT", False),

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -895,7 +895,7 @@ SENSORS: list[descr] = [
         # reads 0 there.
         #
         # Having the cooling device is not enough to have these counters: of
-        # the 10 units in the diagnostics corpus with cooling operating hours,
+        # the 11 units in the diagnostics corpus with cooling operating hours,
         # 8 read exactly 0 in both 1135 and 1139, one of them after 10647
         # hours of cooling. Only units whose heat-source outlet sensor is
         # absent (TWA -50, so no passive-cooling circuit) were seen counting,

--- a/custom_components/luxtronik2/sensor_entities_predefined.py
+++ b/custom_components/luxtronik2/sensor_entities_predefined.py
@@ -865,8 +865,50 @@ SENSORS: list[descr] = [
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         native_precision=2,
         # 0.01 kWh raw unit, applied by the Energy2 datatype (see 1136 above).
-        # This one reads 0.0 on every unit examined in #734, so its scale
-        # follows its three siblings by analogy and is not itself measured.
+        # It read 0.0 on every unit examined in #734, so its scale rested on
+        # its three siblings until #752 measured it: 83272 counts against
+        # 832.7 kWh on the controller's own page.
+        #
+        # Gated for the same reason as 1135 below - the two move together, and
+        # on most cooling units neither one does.
+        entity_active_formula="!= 0.0",
+    ),
+    descr(
+        key=SensorKey.COOLING_HEAT_AMOUNT,
+        luxtronik_key=LP.P1135_COOLING_HEAT_AMOUNT,
+        device_key=DeviceKey.cooling,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        native_precision=2,
+        # The cooling half of the heat-quantity family, and the counterpart of
+        # 1139 above: the controller carries one on each of its Energie and
+        # Gebruikte energie pages. 0.01 kWh raw unit, applied by the Energy2
+        # datatype and measured on the #752 LD5, whose Energie page read
+        # 4103.8 kWh against 410381 counts at the moment of the dump. Two
+        # series-3 units in the diagnostics corpus put the same scale beyond a
+        # factor of ten - see test_implied_cooling_power_is_physical - which is
+        # why this register, unlike 1059, needs no per-series split.
+        #
+        # It sat as Unknown_Parameter_1135 because a unit that never cools
+        # reads 0 there.
+        #
+        # Having the cooling device is not enough to have these counters: of
+        # the 10 units in the diagnostics corpus with cooling operating hours,
+        # 8 read exactly 0 in both 1135 and 1139, one of them after 10647
+        # hours of cooling. Only units whose heat-source outlet sensor is
+        # absent (TWA -50, so no passive-cooling circuit) were seen counting,
+        # which fits the two registers measuring active cooling only - though
+        # the dumps cannot prove that mechanism, only the pattern. Without the
+        # formula most cooling installations gain two permanently-zero
+        # entities.
+        #
+        # The cost is that a unit which starts cooling later needs a reload
+        # before the entities appear, since entity_active is evaluated at
+        # setup. That is the same trade the pool counters make, and it buys
+        # the majority case.
+        entity_active_formula="!= 0.0",
     ),
     # endregion Cooling
     # region Pool

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -968,6 +968,9 @@
             "cooling_energy_input": {
                 "name": "Spotřebovaná energie pro chlazení"
             },
+            "cooling_heat_amount": {
+                "name": "Množství tepla pro chlazení"
+            },
             "pool_energy_input": {
                 "name": "Spotřebovaná energie pro bazén"
             },

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -983,6 +983,9 @@
             "cooling_energy_input": {
                 "name": "Eingesetzte Energie Kühlung"
             },
+            "cooling_heat_amount": {
+                "name": "Wärmemenge Kühlung"
+            },
             "pool_energy_input": {
                 "name": "Eingesetzte Energie Schwimmbad"
             },

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -968,6 +968,9 @@
             "cooling_energy_input": {
                 "name": "Energy input"
             },
+            "cooling_heat_amount": {
+                "name": "Heat amount"
+            },
             "pool_energy_input": {
                 "name": "Pool energy input"
             },

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -980,6 +980,9 @@
             "cooling_energy_input": {
                 "name": "Gebruikte energie koeling"
             },
+            "cooling_heat_amount": {
+                "name": "Hoeveelheid warmte koeling"
+            },
             "pool_energy_input": {
                 "name": "Gebruikte energie zwembad"
             },

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -968,6 +968,9 @@
             "cooling_energy_input": {
                 "name": "Energia zużyta na chłodzenie"
             },
+            "cooling_heat_amount": {
+                "name": "Ilość ciepła chłodzenia"
+            },
             "pool_energy_input": {
                 "name": "Energia zużyta na basen"
             },

--- a/tests/test_lux_overrides.py
+++ b/tests/test_lux_overrides.py
@@ -21,6 +21,7 @@ from custom_components.luxtronik2.const import (
     CONF_PARAMETERS,
     CONF_VISIBILITIES,
     PARSED_COUNT_ATTR,
+    WRITABLE_PARAMETER_PREFIXES,
     LuxSwitchoffReason,
 )
 from custom_components.luxtronik2.model import LuxtronikCoordinatorData
@@ -315,6 +316,30 @@ class TestRecordParsedBlockLengths:
         assert getattr(Parameters(), PARSED_COUNT_ATTR, None) is None
 
 
+class TestInventedParameterNames:
+    """Every name invented here has to be reachable by the write service."""
+
+    def test_every_invented_name_is_writable(self):
+        """const.py documents this as a rule to be kept by hand, so a new
+        override with a custom name silently loses the ability to be written
+        until someone remembers the second edit. The names that upstream
+        supplies all start with ID_ or Unknown_Parameter_ and are covered by
+        prefixes already; only the invented ones need checking.
+        """
+        invented = {
+            datatype.name
+            for datatype in lux_overrides.parameters_to_add_update.values()
+            if not datatype.name.startswith(("ID_", "Unknown_Parameter_"))
+        }
+        assert invented
+        unreachable = {
+            name
+            for name in invented
+            if not name.startswith(WRITABLE_PARAMETER_PREFIXES)
+        }
+        assert unreachable == set()
+
+
 class TestUpstreamMaxDefinedIndex:
     def test_pins_the_installed_library_range(self):
         """The absence rule only fires above this index, so an upstream bump must
@@ -345,7 +370,7 @@ class TestUpstreamMaxDefinedIndex:
         assert key_exists(data, f"parameters.{short.parameters[1125].name}") is True
 
     def test_every_override_only_parameter_sits_above_the_range(self):
-        """The 14 indices that exist only because of lux_overrides are exactly the
+        """The 15 indices that exist only because of lux_overrides are exactly the
         ones the absence rule must be able to reach."""
         upstream_max = lux_overrides.UPSTREAM_MAX_DEFINED_INDEX[CONF_PARAMETERS]
         override_only = {
@@ -354,6 +379,7 @@ class TestUpstreamMaxDefinedIndex:
             if index > upstream_max
         }
         assert override_only == {
+            1135,
             1136,
             1137,
             1138,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -859,9 +859,10 @@ class TestVentilationFanScaling:
 
 
 class TestEnergyInputScaling:
-    """Parameters 1136/1137/1139 count energy input in 0.01 kWh units, so the
-    Energy2 datatype they are registered with is the whole conversion and none
-    of the three descriptions carries a `factor`.
+    """The 0.01 kWh counter family - energy input on 1136/1137/1138/1139 and
+    cooling heat quantity on 1135 - is registered with the Energy2 datatype,
+    which is the whole conversion, so none of the descriptions carries a
+    `factor`.
 
     The scale was measured in #734, not read off upstream's "kWh/10" note
     (which claims /10 for these registers and is wrong): regressing the
@@ -891,6 +892,17 @@ class TestEnergyInputScaling:
 
     def test_cooling_energy_input_scaling(self):
         self._assert_raw_converts_to(SensorKey.COOLING_ENERGY_INPUT, 12345, 123.45)
+
+    def test_cooling_heat_amount_scaling(self):
+        """The reading that identified 1135: the #752 LD5 showed 410381 counts
+        against 4103.8 kWh on the controller's own Energie page, read alongside
+        the cooling energy input on the same unit. It had sat as
+        Unknown_Parameter_1135 because a unit that never cools reads 0 there.
+
+        The only display comparison for this register, but not the only
+        evidence - see test_implied_cooling_power_is_physical.
+        """
+        self._assert_raw_converts_to(SensorKey.COOLING_HEAT_AMOUNT, 410381, 4103.81)
 
     def test_pool_energy_input_scaling(self):
         """The only reading of 1138 there is: the #752 unit showed 113191
@@ -932,6 +944,55 @@ class TestEnergyInputScaling:
         ):
             cop = heat_kwh / self._converted_value(sensor_key, counts)
             assert 1.0 < cop < 8.0
+
+    def test_cooling_counters_are_gated_on_having_counted(self):
+        """Both cooling counters sit behind "!= 0.0" because most cooling
+        installations never move them. Of the 10 units in the diagnostics
+        corpus with cooling operating hours, 8 read exactly 0 in both
+        registers - one of them after 10647 hours of cooling - so without the
+        gate the majority of cooling-capable units gain two entities that can
+        only ever report zero.
+
+        The two are gated identically because they move together: no unit in
+        the corpus has one counting while the other stays at 0.
+        """
+        for key in (SensorKey.COOLING_HEAT_AMOUNT, SensorKey.COOLING_ENERGY_INPUT):
+            description = next(d for d in SENSORS if d.key == key)
+            assert description.entity_active_formula == "!= 0.0"
+
+    def test_implied_cooling_power_is_physical(self):
+        """1135's scale rests on a single display comparison (an LD5, series
+        2), so this pins it from the other direction on the two units in the
+        diagnostics corpus whose cooling counters have moved - both series 3,
+        which is what rules out the per-series split that 1059 turned out to
+        need in this same issue.
+
+        Dividing the cooling heat quantity by the cooling operating hours
+        gives the average thermal power the unit sustained over its whole
+        cooling life, which cannot approach its rated capacity - no machine
+        runs flat out every hour it is enabled. At 0.01 kWh per count the two
+        units give 1.5 kW and 4.0 kW, ordinary domestic figures. At 0.1 they
+        give 15.0 kW and 40.4 kW sustained averages, the second beyond the
+        rated output of anything in the corpus.
+
+        A plausibility bound rather than a proof - unlike the COP-below-1
+        argument above, a factor of ten is the only drift it can catch.
+        """
+        for counts, input_counts, cooling_seconds in (
+            # diagnostics/310304_024/2025-09-22.json, V3.92.0
+            (215339, 52526, 5159452),
+            # diagnostics/330715_0248/2024-07-11.json, V3.89.5
+            (37327, 6597, 332291),
+        ):
+            hours = cooling_seconds / 3600
+            heat_kwh = self._converted_value(SensorKey.COOLING_HEAT_AMOUNT, counts)
+            input_kwh = self._converted_value(
+                SensorKey.COOLING_ENERGY_INPUT, input_counts
+            )
+            assert 0.2 < heat_kwh / hours < 12.0
+            # Scale-invariant, so it says nothing about the factor - it is here
+            # to catch a pairing that stops being the same machine's counters.
+            assert 1.0 < heat_kwh / input_kwh < 10.0
 
 
 class TestAuxHeaterAmountScaling:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -947,7 +947,7 @@ class TestEnergyInputScaling:
 
     def test_cooling_counters_are_gated_on_having_counted(self):
         """Both cooling counters sit behind "!= 0.0" because most cooling
-        installations never move them. Of the 10 units in the diagnostics
+        installations never move them. Of the 11 units in the diagnostics
         corpus with cooling operating hours, 8 read exactly 0 in both
         registers - one of them after 10647 hours of cooling - so without the
         gate the majority of cooling-capable units gain two entities that can
@@ -961,18 +961,19 @@ class TestEnergyInputScaling:
             assert description.entity_active_formula == "!= 0.0"
 
     def test_implied_cooling_power_is_physical(self):
-        """1135's scale rests on a single display comparison (an LD5, series
-        2), so this pins it from the other direction on the two units in the
-        diagnostics corpus whose cooling counters have moved - both series 3,
-        which is what rules out the per-series split that 1059 turned out to
-        need in this same issue.
+        """1135's scale is measured against a controller display on one unit
+        only, so this pins it from the other direction across every unit in
+        the diagnostics corpus whose cooling counters have moved - the LD5
+        that carries the display reading plus two series-3 machines, which is
+        what rules out the per-series split that 1059 turned out to need in
+        this same issue.
 
         Dividing the cooling heat quantity by the cooling operating hours
         gives the average thermal power the unit sustained over its whole
         cooling life, which cannot approach its rated capacity - no machine
-        runs flat out every hour it is enabled. At 0.01 kWh per count the two
-        units give 1.5 kW and 4.0 kW, ordinary domestic figures. At 0.1 they
-        give 15.0 kW and 40.4 kW sustained averages, the second beyond the
+        runs flat out every hour it is enabled. At 0.01 kWh per count the
+        three units give 1.5, 5.6 and 4.0 kW, ordinary domestic figures. At
+        0.1 they give 15.0, 55.9 and 40.4 kW sustained averages, beyond the
         rated output of anything in the corpus.
 
         A plausibility bound rather than a proof - unlike the COP-below-1
@@ -981,6 +982,9 @@ class TestEnergyInputScaling:
         for counts, input_counts, cooling_seconds in (
             # diagnostics/310304_024/2025-09-22.json, V3.92.0
             (215339, 52526, 5159452),
+            # diagnostics/320503_0555/2026-08-19.json, V2.90.0 - the series-2
+            # unit whose controller page was read against this dump (#752).
+            (410381, 83272, 2642397),
             # diagnostics/330715_0248/2024-07-11.json, V3.89.5
             (37327, 6597, 332291),
         ):


### PR DESCRIPTION
## 📊 What

Adds **`cooling_heat_amount`** (parameter 1135), the cooling counterpart of the heating and DHW heat quantities. The controller shows it on its own *Energie* page next to *Verwarmen* and *Warmwater*, but the integration never exposed it — the register sat as `Unknown_Parameter_1135`, because a unit that never cools reads 0 there and no dump from a cooling unit had been examined.

Also gates the existing **cooling energy input (1139)** on having counted, and fixes a write-service gap found by a new invariant test.

## 🔍 Evidence

Identified from the diagnostics dump in #752, whose owner photographed the controller's own pages at the moment of the dump:

| register | diagnostics | controller display |
|---|---|---|
| 1135 cooling heat quantity | 410381 counts | 4103.8 kWh |
| 1139 cooling energy input | 83272 counts | 832.7 kWh |

0.01 kWh per count, the same unit as the rest of the family.

Because that unit is a **series-2** controller — and parameter 1059 turned out in this very issue to need a *per-series* scale — the scale is pinned from a second direction across every corpus unit whose cooling counters have moved, spanning both generations:

| unit | 1135 → kWh | cooling hours | average output |
|---|---|---|---|
| `320503_0555` (V2.90.0, the measured LD5) | 4103.8 | 734 h | **5.6 kW** |
| `310304_024` (V3.92.0) | 2153.4 | 1433 h | **1.5 kW** |
| `330715_0248` (V3.89.5) | 373.3 | 92 h | **4.0 kW** |

At 0.1 kWh per count those become 55.9, 15.0 and 40.4 kW *sustained lifetime averages*, beyond the rated output of anything in the corpus. Agreement across both controller generations is what rules out a per-series split here.

## 🚦 Why both cooling counters are now gated

Of the **11** corpus installations with cooling operating hours, **8 read exactly 0 in both 1135 and 1139** — one of them after **10,647 hours** of cooling. Without `entity_active_formula="!= 0.0"` the majority of cooling-capable units gain two entities that can only ever report zero.

The two counters always move together — no unit has one counting while the other stays at 0 — so they are gated alike.

Only units whose heat-source outlet sensor is absent (`TWA` = −50, i.e. no passive-cooling circuit) were seen counting, which fits these registers measuring active cooling only. The dumps show the pattern, not the mechanism, and the comment says so.

**Trade-off:** `entity_active` is evaluated at setup, so a unit that starts cooling later needs a reload before the entities appear. That's the same trade the pool counters make, and at 8-of-11 it buys the majority case.

## 🐛 Incidental fix — write service refused two parameters

A new test asserts that every invented (non-`ID_`) name in `parameters_to_add_update` is reachable by the write service — an invariant `const.py` documents but nothing enforced. It failed immediately on **`Extra_DHW_target_temp` and `Extra_DHW_duration`** (1146/1147): both are `writeable=True` and backed by number entities, but `luxtronik2.write` has been rejecting them by name since they were added. The entities themselves were unaffected, since they write through the coordinator. Two lines to fix, and now guarded.

## 🧹 Also

- Corrects the notes in `lux_overrides.py` and `sensor_entities_predefined.py` that called 1139's scale an unmeasured analogy — the same issue measured it.
- Updates the stale `TestEnergyInputScaling` docstring, which still named three registers for a family that now has five.

## ✅ Verification

- **1059 tests pass**, coverage 99% (no regression)
- `ruff check` clean · `ruff format --check` clean · `basedpyright` **0 errors** · `codespell` clean · translation coverage script clean
- The new scaling and physics tests were mutation-checked: flipping 1135 to the `Energy` datatype makes both fail.

## ⚠️ Note for release notes

Renaming 1135 removes `Unknown_Parameter_1135` as a `luxtronik2.write` target. Same precedent as 1138 in #754; realistically nobody writes to a counter.

Refs #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)
