### PR TITLE
fix(lux_helper,coordinator): 🐛 always flush the write queue, even when the write fails

### DIFF
--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -225,6 +225,15 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         """
         try:
             async with self._lock:
+                # This batch owns the queue. `_write` empties it on every exit
+                # path, but a failure before `_write` is entered - a
+                # `connect()` timeout while the controller reboots, or a
+                # `parameters.set` that raises partway through the loop below -
+                # leaves the previous batch's entries behind. Starting clean
+                # means a stale entry can never ride along on an unrelated
+                # write, whatever went wrong last time. Cleared in place: the
+                # library's `set` mutates whichever dict `queue` refers to.
+                self.client.parameters.queue.clear()
                 for parameter, value in pairs:
                     await self.hass.async_add_executor_job(
                         self.client.parameters.set, parameter, value

--- a/custom_components/luxtronik2/lux_helper.py
+++ b/custom_components/luxtronik2/lux_helper.py
@@ -332,9 +332,26 @@ class Luxtronik:
         )
 
     def _write(self):
+        """Flush the queued parameter writes to the heat pump.
+
+        The queue is always emptied, whether the flush succeeds or raises.
+        Nothing retries a failed `write()` - the coordinator raises to the
+        caller and the entity re-syncs to the device's value - so an entry
+        left behind is never a pending retry. It would instead be re-sent by
+        the *next* write of any other parameter, silently applying a value the
+        user was already told had been reverted, and re-applying entries the
+        controller had already acknowledged.
+        """
+        try:
+            self._flush_queue()
+        finally:
+            self.parameters.queue = {}
+
+    def _flush_queue(self):
+        """Send each queued parameter as a 3002 write and await its ack."""
         if self._socket is None:
             raise OSError("Cannot write: socket is not connected")
-        for index, value in self.parameters.queue.items():
+        for index, value in list(self.parameters.queue.items()):
             if isinstance(value, float):
                 value = int(value)
 
@@ -372,8 +389,6 @@ class Luxtronik:
                     echoed_index,
                     cmd,
                 )
-        # Flush queue after writing all values
-        self.parameters.queue = {}
 
     def _read_exact(self, count: int) -> bytes:
         """Receive exactly ``count`` bytes from the socket.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1049,6 +1049,89 @@ class TestAsyncWrite:
 
 class TestAsyncWriteMany:
     @pytest.mark.asyncio
+    async def test_batch_does_not_inherit_entries_left_by_an_earlier_failure(self):
+        """A batch owns the queue: whatever an earlier failed write left
+        behind must not ride along on this one.
+
+        `_write`'s own `finally` cannot cover every case - a `connect()`
+        failure (the common one when the controller is rebooting) raises
+        before `_write` is ever entered, so the previous batch's entries are
+        still queued when this one starts.
+        """
+        coord = _make_coordinator_direct()
+
+        queue: dict[Any, Any] = {"stale_param": 500}
+        coord.client.parameters.queue = queue
+        coord.client.parameters.set = lambda target, value: queue.__setitem__(
+            target, value
+        )
+        written_batches: list[dict[Any, Any]] = []
+        coord.client.write = lambda: written_batches.append(dict(queue))
+
+        async def run(fn, *args):
+            return fn(*args)
+
+        coord.hass.async_add_executor_job = AsyncMock(side_effect=run)
+
+        async def fake_refresh():
+            coord.data = LuxtronikCoordinatorData(
+                parameters={"p1": (0, "06:00")},
+                calculations={},
+                visibilities={},
+            )
+
+        coord.async_refresh = fake_refresh
+
+        await coord.async_write_many([("p1", "06:00")])
+
+        assert written_batches == [{"p1": "06:00"}]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_batches_do_not_clear_each_other(self):
+        """An automation touching several entities fires several overlapping
+        writes. Clearing the queue at the start of a batch must never discard
+        a *different* batch's pending parameters - the clear, the queueing and
+        the flush are one critical section under `self._lock`.
+        """
+        coord = _make_coordinator_direct()
+
+        queue: dict[Any, Any] = {}
+        coord.client.parameters.queue = queue
+        coord.client.parameters.set = lambda target, value: queue.__setitem__(
+            target, value
+        )
+        written_batches: list[dict[Any, Any]] = []
+        coord.client.write = lambda: written_batches.append(dict(queue))
+
+        async def run(fn, *args):
+            # Yield control so the two batches genuinely interleave; without
+            # the lock this is where one would clear the other's queue.
+            await asyncio.sleep(0)
+            return fn(*args)
+
+        coord.hass.async_add_executor_job = AsyncMock(side_effect=run)
+
+        async def fake_refresh():
+            coord.data = LuxtronikCoordinatorData(
+                parameters={"p1": (0, "06:00"), "p2": (0, "22:00")},
+                calculations={},
+                visibilities={},
+            )
+
+        coord.async_refresh = fake_refresh
+
+        await asyncio.gather(
+            coord.async_write_many([("p1", "06:00")]),
+            coord.async_write_many([("p2", "22:00")]),
+        )
+
+        # Each batch flushed exactly its own parameter, and neither was lost.
+        assert sorted(written_batches, key=lambda batch: sorted(batch)) == [
+            {"p1": "06:00"},
+            {"p2": "22:00"},
+        ]
+
+    @pytest.mark.asyncio
     async def test_queues_all_pairs_before_single_write_call(self):
         coord = _make_coordinator_direct()
         coord.hass.async_add_executor_job = AsyncMock()

--- a/tests/test_lux_helper.py
+++ b/tests/test_lux_helper.py
@@ -639,6 +639,107 @@ class TestLuxtronikReadWrite:
 
         mock_sock.sendall.assert_called_once()
 
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_write_clears_queue_when_the_ack_times_out(self, mock_socket_class):
+        """A write that fails must not stay queued.
+
+        Nothing retries `client.write()` - the coordinator raises to the
+        caller and the entity re-syncs to the device value - so an entry left
+        behind is never a pending retry, only a delayed replay.
+        """
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+        mock_sock.recv.side_effect = [
+            struct.pack(">i", 3002),
+            TimeoutError("timed out"),
+        ]
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        client.parameters.queue = {1: 42}
+
+        with pytest.raises(TimeoutError):
+            client._write()
+
+        assert client.parameters.queue == {}
+
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_failed_write_is_not_replayed_by_the_next_write(self, mock_socket_class):
+        """A parameter whose write failed must not ride along on a later,
+        unrelated write - the user was already told it was reverted."""
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+        mock_sock.recv.side_effect = [TimeoutError("timed out")]
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        client.parameters.queue = {2: 500}  # DHW target, write times out
+
+        with pytest.raises(TimeoutError):
+            client._write()
+
+        # Later, an unrelated parameter is written over a healthy socket.
+        # `parameters.set` mutates the existing queue dict rather than
+        # replacing it, so a stale entry would still be in there.
+        mock_sock.reset_mock()
+        mock_sock.recv.side_effect = [
+            struct.pack(">i", 3002),
+            struct.pack(">i", 2),
+            struct.pack(">i", 3002),
+            struct.pack(">i", 108),
+        ]
+        client.parameters.queue[108] = 1
+
+        client._write()
+
+        written = [
+            struct.unpack(">iii", call.args[0])[1]
+            for call in mock_sock.sendall.call_args_list
+        ]
+        assert written == [108]
+
+    def test_parameters_set_mutates_the_queue_in_place(self):
+        """Characterisation test pinning the pinned library's contract.
+
+        `test_failed_write_is_not_replayed_by_the_next_write` reproduces the
+        replay by mutating `queue` directly, which is only a faithful model of
+        `Parameters.set` while `set` writes into the existing dict rather than
+        rebinding it. If a future luxtronik release rebinds, that test would
+        stop reproducing anything and still pass - this one fails loudly
+        instead.
+        """
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        queue = client.parameters.queue
+
+        client.parameters.set(2, 50.0)  # ID_Einst_BWS_akt, Celsius -> tenths
+
+        assert client.parameters.queue is queue
+        assert queue == {2: 500}
+
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_write_clears_acked_entries_when_a_later_one_fails(self, mock_socket_class):
+        """Partial batch failure (e.g. a multi-row timer schedule): entries the
+        controller already acked must not be written a second time."""
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+        mock_sock.recv.side_effect = [
+            struct.pack(">i", 3002),
+            struct.pack(">i", 1),  # first parameter acked
+            TimeoutError("timed out"),  # second never acks
+        ]
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        client.parameters.queue = {1: 42, 2: 43}
+
+        with pytest.raises(TimeoutError):
+            client._write()
+
+        assert client.parameters.queue == {}
+
 
 def _fragmented_recv(payload: bytes, chunk_sizes: list[int]):
     """Build a recv() side effect that serves ``payload`` in short reads.


### PR DESCRIPTION
## 🐛 The bug

`Luxtronik._write()` iterates `parameters.queue` (a `{index: value}` dict that the library's `Parameters.set` mutates in place), sending each entry as a 3002 write and blocking on a two-integer acknowledgement after each one. The line clearing the queue sat **after** the loop:

```python
for index, value in self.parameters.queue.items():
    self._socket.sendall(data)
    cmd = self._read_int()            # ← blocks for the ack
    echoed_index = self._read_int()   # ← can raise
    ...
self.parameters.queue = {}            # ← only reached if the whole loop survives
```

Any exception while awaiting an ack (`TimeoutError` / `ConnectionError` / `struct.error`) propagates to `_read_write`, which disconnects and re-raises — so the clear never runs and the queue keeps **every** entry, including ones the controller had already acknowledged in that batch.

Nothing retries `client.write()`: `async_write_many` raises `LuxtronikWriteError` to the caller, and e.g. `number.py` logs the failure and reverts the entity to the device value. So a leftover entry is never a pending retry — it is a **delayed replay**.

### Why that matters

1. User sets the DHW target to 50 °C → `queue = {2: 500}`
2. The ack times out. The UI reports the failure and snaps the entity back. **As far as the user is concerned, that write is dead.**
3. An hour later an automation flips an unrelated switch → `queue = {2: 500, 108: 1}`
4. Both are sent. The pump receives a DHW target nobody asked for at that moment — silently overwriting anything changed on the controller's own display in between.

Only a *failed* write could trigger this, but the damage landed on the *next successful, unrelated* write.

## ✅ The fix

**Two layers, because one is not enough:**

- `_write()` wraps the loop in `try/finally`, so the queue is emptied on every exit path.
- `async_write_many()` clears the queue at the **start** of each batch, inside the existing lock. `_write`'s `finally` cannot cover a failure raised *before* `_write` is entered — `_read_write` calls `connect()` outside its try block, so a connect timeout while the controller reboots (the common real-world case) leaves the previous batch queued. A `parameters.set` that raises partway through a multi-row timer-schedule batch does the same.

Together the invariant becomes *"the queue cannot outlive its batch"* by construction, rather than by enumerating exit paths.

Also renamed the loop to `_flush_queue` and iterate a copy of the queue.

## 🧪 Tests

Five new tests. The four that pin the fix were each watched failing against the pre-fix code first:

| Test | Pre-fix failure |
|---|---|
| `test_write_clears_queue_when_the_ack_times_out` | `assert {1: 42} == {}` |
| `test_failed_write_is_not_replayed_by_the_next_write` | `assert [2, 108] == [108]` |
| `test_write_clears_acked_entries_when_a_later_one_fails` | `assert {1: 42, 2: 43} == {}` |
| `test_batch_does_not_inherit_entries_left_by_an_earlier_failure` | stale entry rode along in the flushed batch |

`test_concurrent_batches_do_not_clear_each_other` guards the obvious worry about a start-of-batch clear — an automation touching several entities at once. It passes as-is (the lock already serialises `clear`/`set`/`write`), so it is a regression guard rather than a driver; verified it has teeth by temporarily moving the clear outside the lock and confirming it fails.

`test_parameters_set_mutates_the_queue_in_place` is a characterisation test pinning the upstream contract the replay reproduction depends on — if a future `luxtronik` release rebinds `self.queue` inside `set` instead of mutating it, that test fails loudly instead of quietly reproducing nothing.

## 📋 Notes

- **Not a regression.** The clear has been positioned after the loop since the code was inherited from upstream, so this predates every recent change.
- **Not the cause of #761**, though it was found while analysing that report. It plausibly makes things worse there: on a pump where *every* write fails, the queue grows with each attempt, so each try sends a larger batch than the last.
- **Behaviour change worth naming:** on the near-unreachable `socket is None` path, `_write` now drops the batch where it previously survived. Correct given there is no retry consumer, but deliberate rather than accidental.

## ✔️ Checks

- `pytest`: **1061 passed**
- Coverage: `lux_helper.py` **100%**, `coordinator.py` **100%**, TOTAL 99% (no regression)
- `basedpyright`: 0 errors, 0 warnings, 0 notes
- `ruff check` / `ruff format --check`: clean
- `codespell`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)