### PR TITLE
fix(lux_helper): 🐛 wait only briefly for a write acknowledgement

### DIFF
--- a/custom_components/luxtronik2/lux_helper.py
+++ b/custom_components/luxtronik2/lux_helper.py
@@ -46,6 +46,16 @@ LUXTRONIK_PARAMETERS_READ = 3003
 LUXTRONIK_CALCULATIONS_READ = 3004
 LUXTRONIK_VISIBILITIES_READ = 3005
 
+# A write acknowledgement is eight bytes and a healthy controller returns it
+# immediately: measured at 3 ms and 4 ms on an MSW4-16 / V3.92.1 over a wired
+# LAN, where reading ~1900 values on the same socket takes about 0.1 s. The
+# connection timeout (60 s by default) is therefore wildly out of proportion
+# here, and a controller that reboots on a write and never acks at all (issue
+# #761) stalls the write for that whole minute, which is long enough to block
+# Home Assistant's startup. 5 s leaves three orders of magnitude of headroom
+# over the measurement while capping the damage from a silent controller.
+LUXTRONIK_WRITE_ACK_TIMEOUT = 5.0
+
 
 def discover(
     broadcast_addresses: list[str] | None = None,
@@ -349,8 +359,10 @@ class Luxtronik:
 
     def _flush_queue(self):
         """Send each queued parameter as a 3002 write and await its ack."""
-        if self._socket is None:
+        sock = self._socket
+        if sock is None:
             raise OSError("Cannot write: socket is not connected")
+        ack_timeout = min(LUXTRONIK_WRITE_ACK_TIMEOUT, self._socket_timeout)
         for index, value in list(self.parameters.queue.items()):
             if isinstance(value, float):
                 value = int(value)
@@ -359,7 +371,7 @@ class Luxtronik:
                 LOGGER.warning("Parameter id '%s' or value '%s' invalid!", index, value)
                 continue
             data = struct.pack(">iii", LUXTRONIK_PARAMETERS_WRITE, index, value)
-            self._socket.sendall(data)
+            sock.sendall(data)
             # The controller acknowledges a 3002 write with two ints: the
             # echoed command (3002) and the echoed *parameter index* - NOT the
             # value it stored. Verified on an Alpha Innotec MSW4-16: writing
@@ -369,8 +381,32 @@ class Luxtronik:
             # the value was accepted, clamped or rejected - confirming a write
             # requires reading the parameter back (see the WRITE_CONFIRM_*
             # retry loop in coordinator.async_write_many).
-            cmd = self._read_int()
-            echoed_index = self._read_int()
+            #
+            # Only the ack runs on the short timeout; the connection timeout
+            # is restored immediately afterwards so the polling reads that
+            # share this socket keep their full budget. A timeout here
+            # propagates to `_read_write` - the only production caller - which
+            # disconnects, so a late ack can never be left in the stream to
+            # misalign the next read. That also means a stalled ack aborts the
+            # whole flush: a multi-parameter batch costs one ack timeout, not
+            # one per parameter.
+            sock.settimeout(ack_timeout)
+            try:
+                cmd = self._read_int()
+                echoed_index = self._read_int()
+            except TimeoutError as err:
+                # Re-raised with attribution rather than logged: `_read_write`
+                # logs nothing by design, so a bare "timed out" here is
+                # indistinguishable from a poll or connect timeout. This
+                # threshold is ours rather than the user's, so it has to name
+                # itself in the report. Still a TimeoutError, hence still an
+                # OSError, so the disconnect above still happens.
+                raise TimeoutError(
+                    f"No write acknowledgement for parameter {index} "
+                    f"within {ack_timeout:.1f}s"
+                ) from err
+            finally:
+                sock.settimeout(self._socket_timeout)
             LOGGER.debug(
                 "Parameter '%d' set to '%s' (ack cmd=%s echoed_index=%s)",
                 index,

--- a/tests/test_lux_helper.py
+++ b/tests/test_lux_helper.py
@@ -12,6 +12,7 @@ from custom_components.luxtronik2.const import DEFAULT_MAX_DATA_LENGTH, DEFAULT_
 from custom_components.luxtronik2.lux_helper import (
     LUXTRONIK_DISCOVERY_MAGIC_PACKET,
     LUXTRONIK_DISCOVERY_RESPONSE_PREFIX,
+    LUXTRONIK_WRITE_ACK_TIMEOUT,
     Luxtronik,
     _is_socket_closed,
     discover,
@@ -534,6 +535,132 @@ class TestLuxtronikReadWrite:
         client = Luxtronik("192.168.1.100", DEFAULT_PORT, 10.0, DEFAULT_MAX_DATA_LENGTH)
         client._socket = None
         with pytest.raises(OSError, match="Cannot write"):
+            client._write()
+
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_write_reads_the_ack_under_a_short_timeout(self, mock_socket_class):
+        """The ack is 8 bytes, so it must not inherit the connection timeout.
+
+        A controller that reboots on a write (issue #761) never sends the ack
+        at all. Waiting out the full connection timeout for those 8 bytes
+        stalls the write for a minute and blocks Home Assistant's startup,
+        where a few seconds is already far more than a healthy controller
+        needs.
+        """
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+
+        effective: list[float | None] = [60.0]
+        timeouts_while_reading_the_ack: list[float | None] = []
+        mock_sock.settimeout.side_effect = lambda value: effective.__setitem__(0, value)
+
+        def recv(_size):
+            timeouts_while_reading_the_ack.append(effective[0])
+            return struct.pack(
+                ">i", 3002 if len(timeouts_while_reading_the_ack) == 1 else 1
+            )
+
+        mock_sock.recv.side_effect = recv
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 60.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        client.parameters.queue = {1: 42}
+
+        client._write()
+
+        assert timeouts_while_reading_the_ack == [
+            LUXTRONIK_WRITE_ACK_TIMEOUT,
+            LUXTRONIK_WRITE_ACK_TIMEOUT,
+        ]
+
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_write_restores_the_connection_timeout_after_the_ack(
+        self, mock_socket_class
+    ):
+        """The short timeout covers the ack only.
+
+        The polling reads share this socket and move ~1900 values, so leaving
+        the ack's few seconds in place would make every later read far more
+        fragile than the user's configured timeout allows.
+        """
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+        mock_sock.recv.side_effect = [
+            struct.pack(">i", 3002),
+            struct.pack(">i", 1),
+        ]
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 60.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        client.parameters.queue = {1: 42}
+
+        client._write()
+
+        assert [call[0][0] for call in mock_sock.settimeout.call_args_list] == [
+            LUXTRONIK_WRITE_ACK_TIMEOUT,
+            60.0,
+        ]
+
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_write_never_waits_longer_for_the_ack_than_configured(
+        self, mock_socket_class
+    ):
+        """The ack timeout is a ceiling, not a floor.
+
+        The connection timeout is user-configurable, and someone who lowered
+        it below the ack timeout asked for a shorter wait, not a longer one.
+        """
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+
+        # Seeded with a sentinel, not the expected value: seeding 2.0 would
+        # let an implementation that never calls settimeout at all pass.
+        effective: list[float | None] = [None]
+        timeouts_while_reading_the_ack: list[float | None] = []
+        mock_sock.settimeout.side_effect = lambda value: effective.__setitem__(0, value)
+
+        def recv(_size):
+            timeouts_while_reading_the_ack.append(effective[0])
+            return struct.pack(
+                ">i", 3002 if len(timeouts_while_reading_the_ack) == 1 else 1
+            )
+
+        mock_sock.recv.side_effect = recv
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 2.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        client.parameters.queue = {1: 42}
+
+        client._write()
+
+        assert timeouts_while_reading_the_ack == [2.0, 2.0]
+
+    @patch("custom_components.luxtronik2.lux_helper.socket.socket")
+    def test_write_names_the_ack_timeout_when_no_ack_arrives(self, mock_socket_class):
+        """A hard-coded threshold must say when it is the one that fired.
+
+        `_read_write` deliberately does not log, so without this the failure
+        reaches the user as a bare "timed out" - indistinguishable from a poll
+        or connect timeout. Since 5 s is our choice rather than the user's
+        configured value, a controller that acks more slowly than we assumed
+        would otherwise produce an undiagnosable regression report.
+        """
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = -1
+        mock_socket_class.return_value = mock_sock
+        mock_sock.recv.side_effect = TimeoutError("timed out")
+
+        client = Luxtronik("192.168.1.100", DEFAULT_PORT, 60.0, DEFAULT_MAX_DATA_LENGTH)
+        client._socket = mock_sock
+        client.parameters.queue = {1: 42}
+
+        with pytest.raises(
+            TimeoutError,
+            match=r"No write acknowledgement for parameter 1 within 5\.0s",
+        ):
             client._write()
 
     @patch("custom_components.luxtronik2.lux_helper.socket.socket")


### PR DESCRIPTION
## 🐛 Problem

A write to the heat pump waited for its acknowledgement under the **connection** timeout — 60 seconds by default. The acknowledgement is eight bytes.

On the Novelan WZS81H / V1.90.0 in #761 the controller crashes and reboots on receiving a write, stores the value, and never acknowledges it. The integration then sat waiting out the full minute, which was long enough to block Home Assistant's startup, and the controller stayed unreachable for a further ~2 minutes afterwards.

The evidence is a diagnostics dump with an embedded debug log:

| Time | Event |
|---|---|
| 15:26:41.693 | write command sent |
| 15:27:41.725 | connection dropped — **exactly 60.03 s later** |
| 15:27:45.320 | `Write error: timed out` |
| 15:29:45.383 | back online, poll completes in **0.12 s** |

The acknowledgement debug line is absent between those points, which pins the block to the 8-byte ack read rather than anywhere else in the write path.

## ✅ Change

- **A dedicated 5 s ack timeout**, restored to the connection timeout immediately afterwards so the polling reads that share the socket keep their full budget.
- **Capped at the configured connection timeout** — a user who lowered it below 5 s asked for a shorter wait, not a longer one.
- **An attributable error message.** `_read_write` logs nothing by design, so a bare `timed out` was indistinguishable from a poll or connect timeout. Since this threshold is ours rather than the user's, it now names itself: `No write acknowledgement for parameter 105 within 5.0s`.

## 📏 Why 5 seconds

Measured, not guessed. Two writes on an MSW4-16 / V3.92.1 over a wired LAN, with debug logging on:

```
23:43:25,306  Done: self.client.parameters.set (1 parameter(s))
23:43:25,309  Parameter '105' set to '560' (ack cmd=3002 echoed_index=105)   →  3 ms
23:43:41,029  Done: self.client.parameters.set (1 parameter(s))
23:43:41,033  Parameter '105' set to '570' (ack cmd=3002 echoed_index=105)   →  4 ms
```

Reading ~1900 values on that same socket takes about 0.1 s. So 5 s leaves roughly three orders of magnitude of headroom over the measurement, while capping the damage from a controller that answers with silence.

## 🔒 Why this cannot corrupt the stream

The obvious objection is that a late acknowledgement would leave 8 stale bytes in the socket and misalign every following read. It cannot happen: `TimeoutError` subclasses `OSError`, so the timeout propagates to `_read_write`, which calls `_disconnect()` before re-raising. The socket is destroyed, not reused — visible in the #761 log as the `Disconnected` line immediately following the timeout.

## 🧪 Tests

Three new tests, each written before the code and watched failing first:

| Test | Verifies |
|---|---|
| `test_write_reads_the_ack_under_a_short_timeout` | the ack is read at 5 s, not 60 s |
| `test_write_restores_the_connection_timeout_after_the_ack` | the sequence is exactly `[5.0, 60.0]` |
| `test_write_never_waits_longer_for_the_ack_than_configured` | a 2 s connection timeout yields a 2 s ack wait |
| `test_write_names_the_ack_timeout_when_no_ack_arrives` | the error names the parameter and the threshold |

They assert the timeout **in force at the moment `recv` is called**, not merely that `settimeout` was called, so they would catch a restore placed before the read. Both strengthened assertions were mutation-tested: removing `sock.settimeout(ack_timeout)` makes them fail.

`1065 passed`, coverage unchanged at 99%, `ruff check` / `ruff format --check` clean, `basedpyright` 0 errors, `codespell` clean.

## ⚠️ Scope

This does **not** fix the controller's reboot — that is firmware behaviour and belongs with the manufacturer. It fixes the blast radius on our side: a brief error instead of a minute-long stall that takes the integration down with it.

Two related items are deliberately left out of this PR:

- **The confirm loop's horizon.** `WRITE_CONFIRM_MAX_ATTEMPTS = 6` with backoff gives ~2.5 s, which is hopeless against a ~2 minute reboot — so a write that actually landed is still reported as failed. It succeeds on the first attempt on a healthy pump, so this is specific to #761 and needs its own design decision.
- **The connect timeout during a reboot.** The reconnect after the failed write still runs at the full 60 s against a host that is mid-restart.

Refs #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)
