### PR TITLE
feat(number): ✨ expose smart grid temperature offsets

### DIFF
--- a/ADVANCED_FEATURES.md
+++ b/ADVANCED_FEATURES.md
@@ -152,6 +152,8 @@ The **PV Mode** select entity (disabled by default) controls how the heat pump r
 ## Smart Grid & Power Limitation
 
 - **Smart Grid** (switch, config category): enables/disables the heat pump's SG-ready integration as a whole. When on, the **Smart Grid Status** sensor (see [EVU / Grid-Lock Status](#evu--grid-lock-status)) becomes available.
+- **Smart Grid heating reduction** / **Smart Grid heating increase** / **Smart Grid hot water increase** (numbers, config category): the setpoint offsets the controller applies in the SG operating states — the heating setpoint is lowered by the reduction in state 2 (both EVU contacts open) and raised by the increase in state 4 (both closed), where the DHW setpoint is raised too. Ranges follow the controller's own limits: −0.5 to −25 K, 0.5 to 5 K and 0.5 to 10 K respectively, all in 0.5 K steps, defaulting to −2 / +2 / +2 K.
+  These three exist **only while the Smart Grid switch above is on** — the controller hides them in its own service menu otherwise. Turning Smart Grid on makes them appear after the integration is reloaded (Settings → Devices & Services → Luxtronik → Reload) or Home Assistant restarts, not immediately. They are also absent on controllers whose firmware does not report these registers at all.
 - **Power limitation** / **Max. thermal power** (switches, disabled by default): turn on enforcement of the numeric power-limit entities below them (electrical power limit value; thermal power limits for heating/water/cooling) — the switches gate whether the limits are enforced at all, the number entities set the actual limit values.
 
 Like the heating-curve parameters mentioned in README §3.2, these are typically set once during commissioning; avoid toggling them frequently via automations.

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -131,6 +131,9 @@ WRITABLE_PARAMETER_PREFIXES: Final = (
     "THERMAL_POWER_LIMIT_HEATING",
     "THERMAL_POWER_LIMIT_WATER",
     "THERMAL_POWER_LIMIT_COOLING",
+    "SMART_GRID_HEATING_REDUCTION",
+    "SMART_GRID_HEATING_INCREASE",
+    "SMART_GRID_DHW_INCREASE",
 )
 # endregion Conf
 
@@ -527,6 +530,12 @@ class LuxParameter(StrEnum):
     P1119_LAST_DEFROST_TIMESTAMP = (
         "parameters.Unknown_Parameter_1119"  # 1685073431 -> 26.5.23 05:57
     )
+    # Smart Grid offsets, only reachable on the controller while P1030 is on
+    # (HMD2 manual 83055600 rev d, p.43). Kelvin deltas in tenths - see
+    # lux_overrides.parameters_to_add_update for the evidence. #765
+    P1120_SMART_GRID_HEATING_REDUCTION = "parameters.SMART_GRID_HEATING_REDUCTION"
+    P1121_SMART_GRID_HEATING_INCREASE = "parameters.SMART_GRID_HEATING_INCREASE"
+    P1122_SMART_GRID_DHW_INCREASE = "parameters.SMART_GRID_DHW_INCREASE"
     P1135_COOLING_HEAT_AMOUNT = "parameters.COOLING_HEAT_AMOUNT"
     P1136_HEAT_ENERGY_INPUT = "parameters.HEAT_ENERGY_INPUT"
     P1137_DHW_ENERGY_INPUT = "parameters.DHW_ENERGY_INPUT"
@@ -961,6 +970,9 @@ class SensorKey(StrEnum):
     COOLING_TARGET_TEMPERATURE_MK3 = "cooling_target_temperature_mk3"
     COOLING_MIN_FLOW_OUT_TEMPERATURE = "cooling_min_flow_out_temperature"
     SMART_GRID_SWITCH = "smartgrid"
+    SMART_GRID_HEATING_REDUCTION = "smart_grid_heating_reduction"
+    SMART_GRID_HEATING_INCREASE = "smart_grid_heating_increase"
+    SMART_GRID_DHW_INCREASE = "smart_grid_dhw_increase"
     SWITCHOFF_REASON = "switchoff_reason"
     PUMP_VENT_HUP = "pump_vent_hup"
     PUMP_VENT_TIMER_H = "pump_vent_timer_h"

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt as dt_util
 from packaging.version import InvalidVersion, Version
 
-from .common import get_sensor_data, normalize_sensor_value
+from .common import get_sensor_data, normalize_sensor_value, smart_grid_enabled
 from .const import (
     CONF_CALCULATIONS,
     CONF_MAX_DATA_LENGTH,
@@ -683,6 +683,24 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
 
         if not self.device_key_active(description.device_key):
             return False
+        if description.visibility == LP.P1030_SMART_GRID_SWITCH:
+            # The Smart Grid offsets do not exist in the controller's own menu
+            # while Smart Grid is off (HMD2 manual 83055600 rev d, p.30), so
+            # they should not exist here either - 25 of the 29 pumps in the
+            # diagnostics corpus are in that state and would otherwise carry
+            # three permanently-unused entities. P1030 holds a mode rather
+            # than a flag, hence the helper instead of a truthiness test. #765
+            if not smart_grid_enabled(self.data):
+                return False
+            # `key_exists` cannot stand in for a presence check here: its
+            # `_register_returned` only infers absence above
+            # UPSTREAM_MAX_DEFINED_INDEX (1125), and these three sit below it.
+            # One corpus unit returns P1030 but ends its parameter block
+            # before 1120, and would get three unwritable entities stuck on
+            # unknown. Reading None cannot mean "present but undecodable" for
+            # a Kelvin register, so it means the controller never sent it.
+            if self.get_value(description.luxtronik_key) is None:
+                return False
         if description.entity_active_formula is not None:
             active_value = self.get_value(description.luxtronik_key)
             if active_value is None:

--- a/custom_components/luxtronik2/lux_overrides.py
+++ b/custom_components/luxtronik2/lux_overrides.py
@@ -178,6 +178,22 @@ parameters_to_add_update = {
     993: Celsius("ID_Einst_min_VL_Kuehl", True),
     979: Celsius("ID_Einst_Minimale_Ruecklaufsolltemperatur", True),
     1045: FrequencyAutomatic("ID_Einst_P155_DHW_Freq", True),
+    # Smart Grid temperature offsets, #765. Upstream leaves all three as
+    # Unknown_Parameter_112x / Unknown and marks them non-writeable; the
+    # controller writes them from its own service menu, so that flag is
+    # overridden here deliberately.
+    #
+    # They are Kelvin deltas stored in tenths, established three ways: the
+    # reporter's A/B test on an LWC407 (V1.86.2) moved the controller from
+    # -2.0/+2.0/+2.0 K to -1.5/+2.5/+5.0 K and the registers followed
+    # (-20/20/20 -> -15/25/50); the HMD2 manual (83055600 rev d, p.43) lists
+    # the same three settings under "Smart Grid" with those defaults and
+    # ranges; and across 29 pumps in the diagnostics corpus every unit at
+    # factory default reads -20/20/20, while all four deviating units are
+    # exactly the four with Smart Grid switched on at P1030.
+    1120: Kelvin("SMART_GRID_HEATING_REDUCTION", True),
+    1121: Kelvin("SMART_GRID_HEATING_INCREASE", True),
+    1122: Kelvin("SMART_GRID_DHW_INCREASE", True),
     1146: Celsius("Extra_DHW_target_temp", True),
     1147: SecondsToHours("Extra_DHW_duration", True),
     1148: Celsius("HEATING_TARGET_TEMP_ROOM_THERMOSTAT", True),

--- a/custom_components/luxtronik2/number_entities_predefined.py
+++ b/custom_components/luxtronik2/number_entities_predefined.py
@@ -481,6 +481,37 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         entity_registry_enabled_default=False,
         factor=1,
     ),
+    # Smart Grid setpoint offsets. Ranges and 0.5 K step come from the HMD2
+    # manual (83055600 rev d, p.43); zero is deliberately outside them, since
+    # the controller's own smallest offset is 0.5 K. `visibility` makes
+    # `entity_active` drop these entirely while Smart Grid is off - they are
+    # not reachable in the controller's menu then either. #765
+    LuxtronikNumberDescription(
+        key=SensorKey.SMART_GRID_HEATING_REDUCTION,
+        luxtronik_key=LP.P1120_SMART_GRID_HEATING_REDUCTION,
+        device_key=DeviceKey.heating,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.KELVIN,
+        native_min_value=-25.0,
+        native_max_value=-0.5,
+        native_step=0.5,
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        visibility=LP.P1030_SMART_GRID_SWITCH,
+    ),
+    LuxtronikNumberDescription(
+        key=SensorKey.SMART_GRID_HEATING_INCREASE,
+        luxtronik_key=LP.P1121_SMART_GRID_HEATING_INCREASE,
+        device_key=DeviceKey.heating,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.KELVIN,
+        native_min_value=0.5,
+        native_max_value=5.0,
+        native_step=0.5,
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        visibility=LP.P1030_SMART_GRID_SWITCH,
+    ),
     # endregion Heating
     # region Domestic water
     LuxtronikNumberDescription(
@@ -573,6 +604,19 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         native_step=1,
         entity_category=EntityCategory.CONFIG,
         mode=NumberMode.BOX,
+    ),
+    LuxtronikNumberDescription(
+        key=SensorKey.SMART_GRID_DHW_INCREASE,
+        luxtronik_key=LP.P1122_SMART_GRID_DHW_INCREASE,
+        device_key=DeviceKey.domestic_water,
+        device_class=NumberDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.KELVIN,
+        native_min_value=0.5,
+        native_max_value=10.0,
+        native_step=0.5,
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+        visibility=LP.P1030_SMART_GRID_SWITCH,
     ),
     # region Solar
     LuxtronikNumberDescription(

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -264,6 +264,15 @@
             },
             "pump_optimization_time": {
                 "name": "Doba trvání optimalizace čerpadla"
+            },
+            "smart_grid_heating_reduction": {
+                "name": "Smart Grid snížení vytápění"
+            },
+            "smart_grid_heating_increase": {
+                "name": "Smart Grid zvýšení vytápění"
+            },
+            "smart_grid_dhw_increase": {
+                "name": "Smart Grid zvýšení teplé vody"
             }
         },
         "sensor": {

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -264,6 +264,15 @@
             },
             "pump_optimization_time": {
                 "name": "Pumpenoptimierung Laufzeit"
+            },
+            "smart_grid_heating_reduction": {
+                "name": "Smart Grid Absenkung Heizen"
+            },
+            "smart_grid_heating_increase": {
+                "name": "Smart Grid Erhöhung Heizen"
+            },
+            "smart_grid_dhw_increase": {
+                "name": "Smart Grid Erhöhung Warmwasser"
             }
         },
         "sensor": {

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -264,6 +264,15 @@
             },
             "pump_optimization_time": {
                 "name": "Pump optimization time"
+            },
+            "smart_grid_heating_reduction": {
+                "name": "Smart Grid heating reduction"
+            },
+            "smart_grid_heating_increase": {
+                "name": "Smart Grid heating increase"
+            },
+            "smart_grid_dhw_increase": {
+                "name": "Smart Grid hot water increase"
             }
         },
         "sensor": {

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -264,6 +264,15 @@
             },
             "heat_source_input_temperature_min": {
                 "name": "Warmtebron invoer minimum temperatuur"
+            },
+            "smart_grid_heating_reduction": {
+                "name": "Smart Grid verlaging verwarmen"
+            },
+            "smart_grid_heating_increase": {
+                "name": "Smart Grid verhoging verwarmen"
+            },
+            "smart_grid_dhw_increase": {
+                "name": "Smart Grid verhoging tapwater"
             }
         },
         "sensor": {

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -264,6 +264,15 @@
             },
             "cooling_threshold_temperature": {
                 "name": "Temperatura progu chłodzenia"
+            },
+            "smart_grid_heating_reduction": {
+                "name": "Smart Grid obniżenie ogrzewania"
+            },
+            "smart_grid_heating_increase": {
+                "name": "Smart Grid podwyższenie ogrzewania"
+            },
+            "smart_grid_dhw_increase": {
+                "name": "Smart Grid podwyższenie CWU"
             }
         },
         "sensor": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -764,6 +764,136 @@ class TestEntityActive:
         desc.device_key = DeviceKey.heatpump
         assert coord.entity_active(desc) is False
 
+    def test_smart_grid_offsets_inactive_when_switched_off(self):
+        """P1030 = 0 means the Smart Grid submenu does not exist on the
+        controller either, so its three offsets must not become entities
+        (#765). 25 of the 29 pumps in the diagnostics corpus are in this
+        state.
+        """
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_SoftStand": "V3.90.1",
+                "ID_WEB_Zaehler_BetrZeitHz": 100,
+            },
+            parameters={"ID_Einst_SmartGrid": 0},
+        )
+        desc = LuxtronikEntityDescription(
+            key="test",
+            luxtronik_key=LP.P1120_SMART_GRID_HEATING_REDUCTION,
+            device_key=DeviceKey.heating,
+            visibility=LP.P1030_SMART_GRID_SWITCH,
+        )
+        assert coord.entity_active(desc) is False
+
+    def test_smart_grid_offsets_active_when_switched_on(self):
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_SoftStand": "V3.90.1",
+                "ID_WEB_Zaehler_BetrZeitHz": 100,
+            },
+            parameters={
+                "ID_Einst_SmartGrid": 1,
+                "SMART_GRID_HEATING_REDUCTION": -2.0,
+            },
+        )
+        desc = LuxtronikEntityDescription(
+            key="test",
+            luxtronik_key=LP.P1120_SMART_GRID_HEATING_REDUCTION,
+            device_key=DeviceKey.heating,
+            visibility=LP.P1030_SMART_GRID_SWITCH,
+        )
+        assert coord.entity_active(desc) is True
+
+    def test_smart_grid_offsets_active_for_non_flag_mode_value(self):
+        """P1030 holds a mode, not a flag: the Luxtronik 2.0 unit in #669
+        reports 3 with Smart Grid on, and the WZS in the corpus does too.
+        An `== 1` gate would wrongly drop the entities there.
+        """
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_SoftStand": "V3.90.1",
+                "ID_WEB_Zaehler_BetrZeitHz": 100,
+            },
+            parameters={
+                "ID_Einst_SmartGrid": 3,
+                "SMART_GRID_HEATING_REDUCTION": -2.0,
+            },
+        )
+        desc = LuxtronikEntityDescription(
+            key="test",
+            luxtronik_key=LP.P1120_SMART_GRID_HEATING_REDUCTION,
+            device_key=DeviceKey.heating,
+            visibility=LP.P1030_SMART_GRID_SWITCH,
+        )
+        assert coord.entity_active(desc) is True
+
+    def test_smart_grid_offsets_need_the_register_to_be_returned(self):
+        """`key_exists` cannot gate these: `_register_returned` only infers
+        absence above UPSTREAM_MAX_DEFINED_INDEX, which is 1125, so 1120-1122
+        sit inside upstream's range and pass unconditionally.
+
+        The controller in diagnostics/200927_014f returns P1030 but stops its
+        parameter block before 1120. With Smart Grid on, such a unit would
+        otherwise get three permanently unknown, unwritable entities - the
+        same failure #738 fixed elsewhere.
+        """
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_SoftStand": "V3.90.1",
+                "ID_WEB_Zaehler_BetrZeitHz": 100,
+            },
+            parameters={"ID_Einst_SmartGrid": 1},
+        )
+        desc = LuxtronikEntityDescription(
+            key="test",
+            luxtronik_key=LP.P1120_SMART_GRID_HEATING_REDUCTION,
+            device_key=DeviceKey.heating,
+            visibility=LP.P1030_SMART_GRID_SWITCH,
+        )
+        assert coord.entity_active(desc) is False
+
+    def test_smart_grid_offsets_inactive_when_p1030_is_absent(self):
+        """A controller that never returns P1030 cannot be running Smart
+        Grid, so the gate must fall closed rather than open.
+        """
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_SoftStand": "V3.90.1",
+                "ID_WEB_Zaehler_BetrZeitHz": 100,
+            },
+            parameters={"SMART_GRID_HEATING_REDUCTION": -2.0},
+        )
+        desc = LuxtronikEntityDescription(
+            key="test",
+            luxtronik_key=LP.P1120_SMART_GRID_HEATING_REDUCTION,
+            device_key=DeviceKey.heating,
+            visibility=LP.P1030_SMART_GRID_SWITCH,
+        )
+        assert coord.entity_active(desc) is False
+
+    def test_smart_grid_dhw_offset_needs_a_dhw_circuit(self):
+        """The Smart Grid gate must not overrule the device gate: a unit
+        without domestic water has no DHW setpoint to raise.
+        """
+        coord = _make_coordinator(
+            calculations={
+                "ID_WEB_SoftStand": "V3.90.1",
+                "ID_WEB_Zaehler_BetrZeitHz": 100,
+                "ID_WEB_Zaehler_BetrZeitBW": 0,
+            },
+            parameters={
+                "ID_Einst_SmartGrid": 1,
+                "SMART_GRID_DHW_INCREASE": 2.0,
+            },
+        )
+        desc = LuxtronikEntityDescription(
+            key="test",
+            luxtronik_key=LP.P1122_SMART_GRID_DHW_INCREASE,
+            device_key=DeviceKey.domestic_water,
+            visibility=LP.P1030_SMART_GRID_SWITCH,
+        )
+        assert coord.entity_active(desc) is False
+
     def test_solar_visibility_active(self):
         coord = _make_coordinator_direct()
         coord._is_version_not_compatible = MagicMock(return_value=False)

--- a/tests/test_entity_platforms.py
+++ b/tests/test_entity_platforms.py
@@ -383,6 +383,79 @@ class TestNumberAsyncSetupEntry:
         assert len(entities) > 0
 
 
+class TestSmartGridOffsetEntities:
+    """#765: the three Smart Grid offsets only exist while Smart Grid is on.
+
+    `_mock_coordinator` forces `entity_active` True, so these use a real
+    coordinator instead - the point is exactly what `entity_active` decides.
+    """
+
+    _KEYS = {
+        SK.SMART_GRID_HEATING_REDUCTION,
+        SK.SMART_GRID_HEATING_INCREASE,
+        SK.SMART_GRID_DHW_INCREASE,
+    }
+
+    @staticmethod
+    def _coordinator(smart_grid: int):
+        from custom_components.luxtronik2.coordinator import LuxtronikCoordinator
+
+        data = make_coordinator_data(
+            parameters={
+                "ID_Einst_SmartGrid": smart_grid,
+                # A firmware-V3.90 unit takes the DHW target from
+                # ID_Soll_BWS_akt, not ID_Einst_BWS_akt - it stands in here
+                # for "an ordinary number entity, unaffected by the gate".
+                "ID_Soll_BWS_akt": 50.0,
+                "SMART_GRID_HEATING_REDUCTION": -2.0,
+                "SMART_GRID_HEATING_INCREASE": 2.0,
+                "SMART_GRID_DHW_INCREASE": 2.0,
+            },
+            calculations={
+                "ID_WEB_SoftStand": "V3.90.1",
+                "ID_WEB_Zaehler_BetrZeitHz": 100,
+                "ID_WEB_Zaehler_BetrZeitBW": 100,
+            },
+        )
+        client = MagicMock()
+        client.parameters = data.parameters
+        client.calculations = data.calculations
+        client.visibilities = data.visibilities
+        with patch("homeassistant.helpers.frame.report_usage"):
+            coord = LuxtronikCoordinator(
+                hass=MagicMock(),
+                client=client,
+                config={CONF_HOST: "1.2.3.4", CONF_PORT: 8889},
+            )
+        coord.data = data
+        coord.last_update_success = True
+        coord.get_device = MagicMock(return_value=MagicMock())
+        return coord
+
+    async def _setup_keys(self, coord):
+        from custom_components.luxtronik2.number import async_setup_entry
+
+        entry = _mock_entry()
+        entry.runtime_data = coord
+        add = MagicMock()
+        with patch("homeassistant.helpers.frame.report_usage"):
+            await async_setup_entry(MagicMock(), entry, add)
+        return {e.entity_description.key for e in add.call_args[0][0]}
+
+    @pytest.mark.asyncio
+    async def test_created_when_smart_grid_is_on(self):
+        keys = await self._setup_keys(self._coordinator(1))
+        assert keys >= self._KEYS
+
+    @pytest.mark.asyncio
+    async def test_not_created_when_smart_grid_is_off(self):
+        keys = await self._setup_keys(self._coordinator(0))
+        assert not (self._KEYS & keys)
+        # Other numbers are unaffected - the gate is not tearing the platform
+        # down wholesale.
+        assert SK.DHW_TARGET_TEMPERATURE in keys
+
+
 # ===========================================================================
 # LuxtronikNumberEntity
 # ===========================================================================
@@ -460,6 +533,35 @@ class TestLuxtronikNumberEntity:
         # value / factor = 50.0 / 0.1 = 500
         call_args = coord.async_write.call_args
         assert call_args[0][1] == 500
+
+    @pytest.mark.asyncio
+    async def test_async_set_native_value_negative_passes_through(self):
+        """The Smart Grid heating reduction is the only negative value this
+        integration writes. It carries no `factor`, so the float must reach
+        `async_write` unconverted and the library's Kelvin datatype does the
+        x10 - a factor applied here would double-scale it. #765
+        """
+        from custom_components.luxtronik2.number import LuxtronikNumberEntity
+
+        data = make_coordinator_data(parameters={"SMART_GRID_HEATING_REDUCTION": -2.0})
+        coord = _mock_coordinator(data)
+        desc = LuxtronikNumberDescription(
+            key=SK.SMART_GRID_HEATING_REDUCTION,
+            luxtronik_key=LP.P1120_SMART_GRID_HEATING_REDUCTION,
+            device_key=DeviceKey.heating,
+        )
+        entry = _mock_entry()
+        with patch("homeassistant.helpers.frame.report_usage"):
+            entity = LuxtronikNumberEntity(
+                MagicMock(), entry, coord, desc, DeviceKey.heating
+            )
+        _patch_entity_hass(entity)
+
+        entity._pending_value = -1.5
+        await entity._async_set_native_value()
+
+        coord.async_write.assert_called_once()
+        assert coord.async_write.call_args[0][1] == -1.5
 
     @pytest.mark.asyncio
     async def test_async_set_native_value_no_pending(self):

--- a/tests/test_lux_overrides.py
+++ b/tests/test_lux_overrides.py
@@ -7,6 +7,7 @@ from luxtronik.datatypes import (
     BivalenceLevel,
     Celsius,
     HeatpumpCode,
+    Kelvin,
     SwitchoffFile,
     Unknown,
 )
@@ -338,6 +339,53 @@ class TestInventedParameterNames:
             if not name.startswith(WRITABLE_PARAMETER_PREFIXES)
         }
         assert unreachable == set()
+
+
+class TestSmartGridTemperatureOffsets:
+    """Parameters 1120-1122, the Smart Grid offsets of #765.
+
+    Upstream leaves all three as `Unknown_Parameter_112x` / `Unknown` and
+    marks them non-writeable; this integration renames them, types them as
+    Kelvin deltas and writes them, so the mapping is pinned here.
+
+    Evidence for the mapping: the reporter's A/B test on an LWC407 moved
+    -2.0/+2.0/+2.0 K to -1.5/+2.5/+5.0 K and the registers followed
+    (-20/20/20 -> -15/25/50); the HMD2 manual (83055600 rev d, p.43) lists
+    exactly these three settings with those defaults; and across 29 pumps in
+    the diagnostics corpus every unit at factory default reads -20/20/20
+    while every deviation sits on a unit with Smart Grid switched on.
+    """
+
+    def test_parameters_are_named_and_kelvin_typed(self):
+        lux_overrides.update_Luxtronik_Parameters()
+
+        for index, name in (
+            (1120, "SMART_GRID_HEATING_REDUCTION"),
+            (1121, "SMART_GRID_HEATING_INCREASE"),
+            (1122, "SMART_GRID_DHW_INCREASE"),
+        ):
+            assert Parameters.parameters[index].name == name
+            assert isinstance(Parameters.parameters[index], Kelvin)
+
+    def test_reduction_scales_a_negative_raw_value(self):
+        """The reduction is the only negative-valued parameter this
+        integration writes, and the manual's range reaches -25 K.
+        """
+        lux_overrides.update_Luxtronik_Parameters()
+        reduction = Parameters.parameters[1120]
+
+        assert reduction.from_heatpump(-20) == -2.0
+        assert reduction.from_heatpump(-250) == -25.0
+        assert reduction.to_heatpump(-25.0) == -250
+        assert reduction.to_heatpump(-0.5) == -5
+
+    def test_increases_scale_by_tenths(self):
+        lux_overrides.update_Luxtronik_Parameters()
+
+        assert Parameters.parameters[1121].from_heatpump(50) == 5.0
+        assert Parameters.parameters[1121].to_heatpump(5.0) == 50
+        assert Parameters.parameters[1122].from_heatpump(100) == 10.0
+        assert Parameters.parameters[1122].to_heatpump(10.0) == 100
 
 
 class TestUpstreamMaxDefinedIndex:

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -717,6 +717,37 @@ class TestTimerScheduleSync:
         ]
 
     @pytest.mark.asyncio
+    async def test_apply_without_coordinator_data_changes_nothing(self):
+        """A poll that produced no data at all concludes nothing.
+
+        `_active_schedule_descriptions` returns None only in that case, and
+        the entities already live must then survive untouched - removing or
+        disabling them on a failed read is exactly the churn the per-circuit
+        freeze elsewhere in this method exists to avoid.
+        """
+        from custom_components.luxtronik2.text import LuxtronikTimerScheduleText
+
+        sync, coord, added = self._make_sync("week")
+        registry = self._registry({})
+        with (
+            patch(
+                "custom_components.luxtronik2.text.er.async_get", return_value=registry
+            ),
+            patch("homeassistant.helpers.frame.report_usage"),
+        ):
+            await sync.async_setup()
+            live_before = list(added)
+            coord.data = None
+            with patch.object(
+                LuxtronikTimerScheduleText, "async_remove", new=AsyncMock()
+            ) as remove:
+                await sync.async_apply()
+
+        assert added == live_before
+        remove.assert_not_awaited()
+        registry.async_update_entity.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_overlapping_apply_calls_are_serialized(self):
         """Two overlapping `async_apply()` calls must not interleave.
 


### PR DESCRIPTION
## ✨ What

Exposes the three Smart Grid setpoint offsets from the controller's service menu as number entities, as requested in #765:

| Entity | Parameter | Range | Step | Default |
|---|---|---|---|---|
| Smart Grid heating reduction | 1120 | −25.0 … −0.5 K | 0.5 | −2.0 K |
| Smart Grid heating increase | 1121 | 0.5 … 5.0 K | 0.5 | +2.0 K |
| Smart Grid hot water increase | 1122 | 0.5 … 10.0 K | 0.5 | +2.0 K |

The heating setpoint is lowered by the reduction in SG state 2 (both EVU contacts open) and raised by the increase in state 4 (both closed), where the DHW setpoint is raised too.

## 🔍 Evidence for the mapping

Three independent lines, since upstream `python-luxtronik` leaves all three as `Unknown_Parameter_112x` / `type: Unknown`:

1. **The reporter's A/B test** (LWC407, V1.86.2): changing the controller from −2.0/+2.0/+2.0 K to −1.5/+2.5/+5.0 K moved the registers −20/20/20 → −15/25/50. Signed, in tenths of a Kelvin.
2. **The HMD2 manual** (83055600 rev d, p.43) lists exactly these three settings under the "Smart Grid" heading with those defaults, the ranges above and a 0.5 K step. The Dutch copy of the same manual agrees.
3. **The diagnostics corpus** (29 pumps, 77 dumps): every unit at factory default reads −20/20/20, and all four units that deviate are exactly the four with Smart Grid switched on at P1030. No unit has custom offsets with Smart Grid off, and none has Smart Grid on with untouched offsets.

## 🚦 Gating

The entities are **not created at all** while Smart Grid is off — the controller hides them in its own service menu then, and 25 of the 29 corpus pumps are in that state, so disabling-by-default would mean permanent clutter for them instead.

- `entity_active` gates on P1030 via the existing `smart_grid_enabled()` helper. P1030 holds a *mode*, not a flag — a Luxtronik 2.0 unit in #669 reports `3` — so a `== 1` test would be wrong.
- The gate sits **after** `device_key_active`, so the DHW offset still respects the domestic-water device.
- It also requires the register itself to have been returned. `key_exists` cannot do this job here: `_register_returned` only infers absence *above* `UPSTREAM_MAX_DEFINED_INDEX` (1125), and these three sit below it. One corpus unit returns P1030 but ends its parameter block before 1120, and would otherwise get three permanently-unknown, unwritable entities.

Consequence worth knowing: switching Smart Grid on makes the entities appear after an integration reload, not immediately. Documented in `ADVANCED_FEATURES.md`.

## 🔧 Changes

- `lux_overrides.py` — 1120/1121/1122 renamed and typed as `Kelvin` (the `/10` delta type), deliberately overriding upstream's `writeable: False`
- `const.py` — three `LuxParameter` + three `SensorKey` members; the invented names added to `WRITABLE_PARAMETER_PREFIXES` so the write service accepts them
- `coordinator.py` — the P1030 gate in `entity_active`
- `number_entities_predefined.py` — three descriptions, shaped like `HEATING_HYSTERESIS` (`device_class=TEMPERATURE` + `UnitOfTemperature.KELVIN`; HA only auto-converts when the native unit is °C/°F, so K passes through)
- `translations/{en,de,nl,cs,pl}.json` — German and Dutch use the manual's own wording
- `ADVANCED_FEATURES.md` — the three entities, their ranges, and the reload caveat

## ✅ Tests

- `entity_active`: gate off at P1030=0, on at 1, on at **3**, off when P1030 is absent, off when the register was not returned, and DHW still refused without a domestic-water circuit
- `lux_overrides`: naming, `Kelvin` typing, and the negative round-trip (−250 ↔ −25.0 K)
- Platform level: `number.async_setup_entry` creates the three entities with Smart Grid on and none with it off, while ordinary numbers are unaffected
- Write path: a negative value reaches `coordinator.async_write` unconverted (no `factor`; the library's datatype does the ×10)

```
1082 passed
coverage             100% (3590 statements, 0 missed)
ruff check           All checks passed!
ruff format --check  clean
basedpyright         0 errors, 0 warnings, 0 notes
codespell            clean
```

The second commit on this branch is unrelated to #765: it covers the no-data path in `text.py`'s schedule sync, which was the package's last uncovered line.

## ⚠️ Not verified on hardware

Deliberate: no maintainer pump in reach has Smart Grid enabled, and the manual warns against switching it on where the EVU lock is wired. The mapping rests on the three evidence lines above. @alpenfun — if you install this branch, confirmation that the three entities appear, read your current values, and write correctly would be welcome.

Resolves #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)
