### PR TITLE
docs(timer-schedules): 📝 document what the schedule times mean

### DIFF
--- a/TIMER_SCHEDULES.md
+++ b/TIMER_SCHEDULES.md
@@ -24,6 +24,22 @@ Each schedule entity holds that day's time windows as a single string of `HH:MM-
 
 Set the value to an empty string to clear all windows for that entity. How many windows fit per day differs per circuit (5 for DHW, 3 for heating and ventilation), and times are always whole minutes — the controller cannot set seconds.
 
+### What the times mean
+
+**An end time of `00:00` means midnight**, not "unset". `18:00-00:00` is a window running from 18:00 until the end of the day, and it is how the controller itself writes such a window — `23:59` is not needed and leaves a one-minute hole. A start time of `00:00` is equally ordinary: `00:00-12:00` runs from midnight to noon.
+
+**A window counts as unused only when *both* halves are `00:00`.** That is why `00:00-00:00` has its own meaning per circuit (see the heating warning below), while `18:00-00:00` is a perfectly normal window.
+
+So to cover everything outside 12:00–18:00 on a five-window circuit like DHW, the value is:
+
+```
+00:00-12:00/18:00-00:00
+```
+
+> **ℹ️ Note:** the midnight reading of a trailing `00:00` is observed behaviour, not a documented one. The controller's manual (*Regelaar Deel 1*, document 83055200, revision iNL) covers `00:00-00:00` but says nothing about `HH:MM-00:00`. It is how real controllers store their schedules — including units whose active program uses such a window — so it is safe to rely on, but it is not quotable from the manual.
+
+**An empty schedule does not mean "no schedule".** What it does depends on the circuit's polarity, and the two are opposites: on DHW an empty schedule blocks nothing, so hot water follows the *Mode* setting alone; on heating it leaves the circuit lowered around the clock. Read your circuit's section below before clearing one.
+
 The timer program can be switched from Home Assistant as well as on the physical controller (or its web interface), and both directions are picked up automatically.
 
 ### Only the active shape's entities are present


### PR DESCRIPTION
## 📝 What

Documents the two conventions behind the `HH:MM` values in a timer schedule, in a new **What the times mean** subsection of `TIMER_SCHEDULES.md`.

## 🐛 Why

The integration's own pair pattern rejects `24:00`. That invites the inference that `00:00` as an *end* time is equally invalid, and that `23:59` is the safe way to say "until midnight". It is not — `23:59` leaves a one-minute hole, and real controllers store midnight as `00:00`.

This was got wrong in a user-facing draft before being caught against device data.

## 🔍 Evidence

- An **active** 5+2 DHW program on an Alpha Innotec MSW4-16 (V3.92.1) reads `00:00-04:00 / 05:30-13:00 / 17:00-00:00`, with the unused rows 4 and 5 at `00:00-00:00`
- The same shape occurs 30+ times across the local diagnostics corpus, in older dumps as raw seconds (`72000-0` = 20:00 → midnight)
- `text.py` treats a row as unused only when **both** halves are `00:00` (`if start in (None, _UNSET_TIME) and end in (None, _UNSET_TIME)`), so `18:00-00:00` round-trips intact

## ✅ Covered

- End time `00:00` is midnight, not "unset"; a start of `00:00` is equally ordinary
- A window is unused only when both halves are `00:00` — which is what leaves `00:00-00:00` free to carry its own per-circuit meaning
- A worked example for covering everything outside a wanted span, the case that reads backwards on a blocking circuit like DHW
- An empty schedule is not "no schedule", with both polarities side by side. Only the heating half was documented; the DHW half — an empty schedule blocks nothing — was left to be inferred

## ⚠️ Provenance

The midnight reading is marked in the text as **observed** rather than documented. Manual 83055200 (*Regelaar Deel 1*, revision iNL) covers `00:00-00:00` but says nothing about `HH:MM-00:00`. Safe to rely on, not quotable from the manual — and the note says so, so a later reader does not cite it as if it were.

## 🧪 Testing

Documentation only. No code, no entity, no behaviour change. `codespell` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
