### PR TITLE
fix(number): 🐛 gate DHW and cooling entities on the firmware minor

### DIFF
--- a/DHW_TARGET_REGISTERS.md
+++ b/DHW_TARGET_REGISTERS.md
@@ -101,14 +101,41 @@ target stays at P0002. P0105 acts as a ceiling, not as the setpoint.
 | `number_entities_predefined.py` | minor 90.0 / 90.1 | [PR #357](https://github.com/BenPru/luxtronik/pull/357), May 2025 |
 | `water_heater.py` | minor 88.2 / 88.3 | commit `fecdf38`, Jan 2026 |
 
-Both platforms were set to 90.0/90.1 by PR #357. Commit `fecdf38` later did two
-things at once — converted `water_heater` from the absolute firmware fields to
-the series-agnostic `*_minor` ones (correct) *and* lowered its threshold to
-88.3 (a separate judgement, based on the single 2.88.3 report above). It touched
-`common.py`, `coordinator.py`, `model.py`, `sensor.py` and `water_heater.py`;
-`number_entities_predefined.py` was simply not in the commit.
+Both platforms were set to 90.0/90.1 by PR #357. Commit `fecdf38` then rebuilt
+the minor-version mechanism and used it on one platform only:
+
+- `firmware_version_minor` changed from `int` to `Version`. Before it was
+  `int(re.sub("[^0-9]", "", ver.split(".")[1]))` — a whole number, so `88.3`
+  could not be expressed as a threshold at all. The 88.3 value was in that sense
+  a by-product of making it expressible.
+- `max_firmware_version_minor` was added; only the `min_` side had existed, so
+  no minor-gated *pair* was possible before.
+- `model.py` moved `min_firmware_version_minor` off the `FirmwareVersionMinor`
+  enum onto `Version`.
+- `water_heater.py` then moved to 88.2/88.3.
+- `common.py` and `sensor.py` changes in the same commit are unrelated
+  (`LC.UNSET` guards for SmartGrid log warnings).
+
+`number_entities_predefined.py` was not in the commit and stayed on the absolute
+fields, which kept working — so nothing failed, it just silently diverged.
 
 **The divergence is an oversight, not a decision.**
+
+### What it looks like on an affected unit
+
+For a unit with minor in `[88.3, 90.0]` — the reporter's 2.88.3 among them — the
+two platforms now read different registers for the same physical setpoint:
+
+| entity | register |
+|---|---|
+| `water_heater` target temperature | P0105 |
+| `number.<prefix>_dhw_target_temperature` | P0002 |
+
+With the V1.88.3 dump's values (P0002 = 43.0, P0105 = 46.0) the water heater
+card shows 46 while the number entity shows 43, and writes go to different
+registers depending on which control the user touches. Both water heater
+descriptions share one `SensorKey`, so this was a register swap on the existing
+entity, not a new one.
 
 A later change converted the `number` gates to the `*_minor` form too, which is
 why both platforms now use minor comparisons while still disagreeing on the

--- a/DHW_TARGET_REGISTERS.md
+++ b/DHW_TARGET_REGISTERS.md
@@ -1,0 +1,168 @@
+# The DHW target temperature registers
+
+Reference notes for maintainers on the two "hot water target" parameters, why
+the `number` and `water_heater` platforms gate them on different firmware
+versions, and what to ask for when the next report about a wrong DHW setpoint
+arrives.
+
+**Nothing here is a bug report or a plan.** The thresholds described below are
+deliberately left as they are — see [Why nothing was changed](#why-nothing-was-changed).
+
+## The two registers
+
+| | parameter | controller label | meaning |
+|---|---|---|---|
+| **P0002** | `ID_Einst_BWS_akt` | "Deckung WP" | the temperature reachable by the compressor alone. The controller **lowers this by itself** when the setpoint cannot be reached (documented in the AIT manual), so it is not a pure user setting. |
+| **P0105** | `ID_Soll_BWS_akt` | "Wunschwert" | the desired value, shown as the primary figure on the controller display. |
+| **C0018** | `ID_WEB_Einst_BWS_akt` | "Warmwasser-Soll" | read-only mirror of the *effective* target, including any Smart Grid offset. This is what the pump actually aims at. |
+
+C0018 is the useful one when analysing a dump: it tells you which of the two
+parameters the controller is currently deriving its target from.
+
+## Two separate firmware events, often conflated
+
+The single most common mistake in this area is treating "P0105 became correct"
+and "P0002 became broken" as one event. They are not.
+
+### Event 1 — writing P0105 starts propagating to P0002
+
+Somewhere in the interval `(minor 79, minor 88.3]`:
+
+- **FW 3.79** — writing P0105 from HA did *not* move P0002 (stayed 53), and the
+  pump heated to 53. P0105 was inert.
+  ([#280](https://github.com/BenPru/luxtronik/issues/280#issuecomment-2430134992))
+- **FW 2.88.3** — a reporter confirmed P0105 "sets the right value" on his unit.
+  ([#280](https://github.com/BenPru/luxtronik/issues/280#issuecomment-3690032168))
+- **FW 3.90.0** — writing P0105 changed P0002 identically and the pump heated to
+  it. ([#280](https://github.com/BenPru/luxtronik/issues/280#issuecomment-2428257354))
+
+### Event 2 — P0105 becomes a cap on the effective target
+
+At roughly minor 90.1. Below it the effective target is read from P0002 and
+P0105 does not participate; at and above it the effective target follows
+`min(P0002, P0105)`. This is why a P0002 stuck at the 75.0 sentinel stops
+mattering there, and it is the event [#280](https://github.com/BenPru/luxtronik/issues/280)
+and [#428](https://github.com/BenPru/luxtronik/issues/428) actually reported.
+
+Put plainly:
+
+> **Event 1 is where using P0002 became the wrong choice.
+> Event 2 is where that wrong choice started to hurt.**
+
+Before Event 2 the two registers usually track each other, so P0002 mostly
+worked and nobody complained.
+
+## The evidence
+
+From the local `diagnostics/` corpus. Dumps where `P0002 == P0105` carry no
+information and are omitted; every divergent case is listed.
+
+### Below minor 90.1 — effective target follows P0002
+
+| firmware | P0002 | P0105 | C0018 | note |
+|---|---|---|---|---|
+| V1.88.3 | 43.0 | 46.0 | 43.0 | |
+| V1.90.0 | 49.0 | 48.0 | 49.0 | `min()` would give 48.0 |
+| V1.90.0 | 49.0 | 48.0 | 54.0 | Smart Grid +5 K on top of P0002 |
+| V3.88.0 | 40.0 | 38.0 | 40.0 | `min()` would give 38.0 |
+| V3.88.0 | 48.5 | 47.5 | 48.5 | `min()` would give 47.5 |
+
+Three of these discriminate between "follows P0002" and "follows `min()`", and
+all three say P0002.
+
+### At and above minor 90.1 — effective target follows min(P0002, P0105)
+
+| firmware | P0002 | P0105 | C0018 |
+|---|---|---|---|
+| V3.92.0 | 54.7 | 45.0 | 45.0 |
+| V3.92.0 | 75.0 | 50.0 | 50.0 |
+| V3.92.0 | 75.0 | 52.0 | 52.0 |
+| V3.92.1 | 53.5 | 59.5 | 53.5 |
+| V3.92.1 | 56.5 | 60.0 | 56.5 |
+| V3.92.1 | 75.0 | 50.0 | 50.0 |
+| V3.92.1 | 75.0 | 53.0 | 53.0 |
+| V3.92.1 | 75.0 | 53.0 | 59.5 |
+| V3.92.1 | 75.0 | 56.5 | 56.5 |
+| V3.92.1 | 75.0 | 57.0 | 57.0 |
+| V3.92.3 | 49.5 | 47.5 | 47.5 |
+| V3.92.3 | 75.0 | 56.0 | 56.0 |
+| V3.92.3 | 75.0 | 58.0 | 58.0 |
+
+Twelve of thirteen fit `min(P0002, P0105)` exactly. The one exception
+(`75.0 / 53.0 / 59.5`) carries a Smart Grid offset.
+
+Note the two V3.92.1 rows where P0105 is the *higher* value: the effective
+target stays at P0002. P0105 acts as a ceiling, not as the setpoint.
+
+## Why the two platforms disagree
+
+| platform | threshold | set by |
+|---|---|---|
+| `number_entities_predefined.py` | minor 90.0 / 90.1 | [PR #357](https://github.com/BenPru/luxtronik/pull/357), May 2025 |
+| `water_heater.py` | minor 88.2 / 88.3 | commit `fecdf38`, Jan 2026 |
+
+Both platforms were set to 90.0/90.1 by PR #357. Commit `fecdf38` later did two
+things at once — converted `water_heater` from the absolute firmware fields to
+the series-agnostic `*_minor` ones (correct) *and* lowered its threshold to
+88.3 (a separate judgement, based on the single 2.88.3 report above). It touched
+`common.py`, `coordinator.py`, `model.py`, `sensor.py` and `water_heater.py`;
+`number_entities_predefined.py` was simply not in the commit.
+
+**The divergence is an oversight, not a decision.**
+
+A later change converted the `number` gates to the `*_minor` form too, which is
+why both platforms now use minor comparisons while still disagreeing on the
+value. That conversion fixed a real bug — the absolute form compares the
+firmware *major*, which is the controller series, so every V1.x and V2.x unit
+read as older than any "3.x" bound — but it deliberately preserved each
+platform's existing threshold.
+
+## Why nothing was changed
+
+Neither threshold is clearly right, because a single register cannot express
+both events:
+
+- **Writing** P0105 appears correct from Event 1 onward — which supports
+  `water_heater`'s 88.3.
+- **Reading** P0105 is wrong until Event 2 — the corpus shows a V1.88.3 unit
+  displaying 46 while the pump works toward 43 — which supports `number`'s 90.1.
+
+Both can be true at the same time, because the integration uses one register
+for both directions. Picking either threshold for both platforms fixes one
+direction and breaks the other, so the thresholds were left alone rather than
+churned on incomplete evidence. Nobody has reported a problem against the
+current state.
+
+Two dead ends worth not re-deriving:
+
+- **Register-existence detection does not work here.** Both P0002 and P0105
+  exist on both sides of both events. The discriminator is meaning, not
+  presence, so a firmware gate really is the only available lever.
+- **C0018 alone does not settle which register is authoritative.** It is the
+  P0002-lineage mirror below Event 2, so "C0018 equals P0002" is nearly
+  circular there. It only becomes informative because the *relationship*
+  changes at Event 2.
+
+## What to ask the next reporter
+
+The corpus is static snapshots, so it cannot show write propagation. One
+measurement closes the remaining gap. Ask for, on a unit below minor 90.1:
+
+1. The firmware version and a diagnostics dump.
+2. Write P0105 via the `luxtronik2.write` action to a clearly different value.
+3. After the next DHW cycle: what temperature did the water actually reach,
+   and what do P0002 and C0018 read now?
+
+If the water reaches the P0105 value, Event 1 has happened on that firmware.
+If it reaches P0002 instead, it has not — which is exactly the false positive
+that makes "P0105 sets the right value" untrustworthy on its own, since the
+displayed figure changes either way.
+
+Also worth knowing: the corpus contains **no V1.x or V2.x dump at minor ≥ 90.1**
+at all. If a report arrives from one, it is the first of its kind — capture it.
+
+## Related
+
+- [#280](https://github.com/BenPru/luxtronik/issues/280) — the original thread; contains the FW 3.79, 3.90.0 and 2.88.3 observations, and the Smart Grid explanation of C0018.
+- [#428](https://github.com/BenPru/luxtronik/issues/428) — V3.92.0, P0002 showing "Deckung WP" instead of the setpoint.
+- [#517](https://github.com/BenPru/luxtronik/issues/517) — unrelated to the thresholds: the `firmware_version_minor` crash on two-part versions introduced alongside `fecdf38`, since fixed.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Big thanks to [all community members](https://github.com/BenPru/luxtronik/graphs
 - **[ADVANCED_FEATURES.md](ADVANCED_FEATURES.md)** — integration options, COP and the external power sensor, EVU/Smart Grid, diagnostics downloads, holiday scheduling, solar thermal, and the other entities that only appear on some hardware.
 - **[TIMER_SCHEDULES.md](TIMER_SCHEDULES.md)** — the editable weekly schedules for DHW, heating, and ventilation: entity list, time format, and what a window means on each circuit.
 - **[REPORTING_ISSUES.md](REPORTING_ISSUES.md)** — how to file a bug report that can be diagnosed on the first pass.
+- **[DHW_TARGET_REGISTERS.md](DHW_TARGET_REGISTERS.md)** — maintainer reference: what is known about the two hot water setpoint parameters, why the firmware thresholds for them differ per platform, and what to measure if your hot water target reads wrong.
 
 ## ⚠️ Warning
 Some settings exposed by this integration can impact the performance of your heat pump. Misconfigurations may cause the controller to go into an error state, requiring a local manual reset. 

--- a/custom_components/luxtronik2/model.py
+++ b/custom_components/luxtronik2/model.py
@@ -94,6 +94,13 @@ class LuxtronikEntityDescription(EntityDescription, frozen_or_thawed=True):
     # present on both sides of a change whose *meaning* moves.
     min_firmware_version_minor: Version | None = None
     max_firmware_version_minor: Version | None = None
+    # Deprecated for descriptions: these compare the WHOLE version, whose
+    # major digit is the controller series rather than a threshold, so a
+    # V1.x or V2.x unit reads as older than any "3.x" bound no matter how
+    # current its firmware is. No predefined description may set them - see
+    # tests/test_predefined_entities.py. Kept because the coordinator still
+    # implements them; a genuinely per-generation difference belongs in code
+    # against `LuxtronikCoordinator.firmware_series`.
     min_firmware_version: Version | None = None
     max_firmware_version: Version | None = None
 

--- a/custom_components/luxtronik2/number_entities_predefined.py
+++ b/custom_components/luxtronik2/number_entities_predefined.py
@@ -524,7 +524,7 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         native_min_value=DEFAULT_DHW_MIN_TEMPERATURE,
         native_max_value=65.0,
         native_step=0.5,
-        max_firmware_version=Version("3.90.0"),
+        max_firmware_version_minor=Version("90.0"),
     ),
     # Bug #280 since firmware 3.90.1 different set point
     LuxtronikNumberDescription(
@@ -537,7 +537,7 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         native_min_value=DEFAULT_DHW_MIN_TEMPERATURE,
         native_max_value=65.0,
         native_step=0.5,
-        min_firmware_version=Version("3.90.1"),
+        min_firmware_version_minor=Version("90.1"),
     ),
     LuxtronikNumberDescription(
         key=SensorKey.DHW_HYSTERESIS,
@@ -686,7 +686,7 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         entity_category=EntityCategory.CONFIG,
         mode=NumberMode.BOX,
         visibility=LV.V0005_COOLING,
-        min_firmware_version=Version("3.92.1"),
+        min_firmware_version_minor=Version("92.1"),
     ),
     LuxtronikNumberDescription(
         key=SensorKey.COOLING_OUTDOOR_TEMP_THRESHOLD,
@@ -701,7 +701,7 @@ NUMBER_SENSORS: list[LuxtronikNumberDescription] = [
         entity_category=EntityCategory.CONFIG,
         mode=NumberMode.BOX,
         visibility=LV.V0005_COOLING,
-        max_firmware_version=Version("3.92.0"),
+        max_firmware_version_minor=Version("92.0"),
     ),
     LuxtronikNumberDescription(
         key=SensorKey.COOLING_START_DELAY_HOURS,

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -38,6 +38,7 @@ from custom_components.luxtronik2.model import (
     LuxtronikNumberDescription,
 )
 from custom_components.luxtronik2.number import LuxtronikNumberEntity
+from custom_components.luxtronik2.number_entities_predefined import NUMBER_SENSORS
 
 _ENTRY_DATA = {
     CONF_HOST: "192.168.1.100",
@@ -628,3 +629,132 @@ class TestEfficiencyPump:
         coord = _make_coordinator_direct(data)
         assert coord.entity_visible(desc_volt) is False
         assert coord.entity_visible(desc_percent) is True
+
+
+# ===========================================================================
+# Firmware gates must be series-agnostic
+# ===========================================================================
+
+
+def _coord_on_firmware(version: str) -> LuxtronikCoordinator:
+    """Build a real coordinator reporting `version` as its firmware."""
+    return _make_coordinator_direct(
+        make_coordinator_data(calculations={"ID_WEB_SoftStand": version})
+    )
+
+
+def _number_desc(key: SensorKey, lux_key: str, **match) -> LuxtronikNumberDescription:
+    """Return the single predefined number description matching the criteria."""
+    found = [
+        d
+        for d in NUMBER_SENSORS
+        if d.key == key
+        and d.luxtronik_key == lux_key
+        and all(getattr(d, name) == value for name, value in match.items())
+    ]
+    assert len(found) == 1, f"expected exactly one description, got {len(found)}"
+    return found[0]
+
+
+class TestFirmwareGatesAreSeriesAgnostic:
+    """Register-availability gates must compare the minor version only.
+
+    The firmware major digit is the controller *series* - V1.x, V2.x and
+    V3.x are different hardware generations - and it never advances on a
+    firmware update. The minor digit is what tracks the register layout, so
+    a V1.90.1 controller carries the same registers as a V3.90.1 one.
+
+    An absolute `Version("3.90.1")` gate compares 1.90.1 as older than
+    everything, so every V1.x and V2.x owner is served the pre-90.1 entity
+    set no matter how current their firmware is. Use the `*_minor` fields;
+    for a genuine per-generation difference use `coordinator.firmware_series`.
+    """
+
+    def test_dhw_target_modern_register_active_on_v1(self):
+        """P0105 is the 90.1+ DHW setpoint and must reach a V1.90.1 unit."""
+        coord = _coord_on_firmware("V1.90.1")
+        desc = _number_desc(
+            SensorKey.DHW_TARGET_TEMPERATURE, LP.P0105_DHW_TARGET_TEMPERATURE
+        )
+        assert coord._is_version_not_compatible(desc) is False
+
+    def test_dhw_target_legacy_register_hidden_on_v1(self):
+        """P0002 is the pre-90.1 setpoint; a V1.90.1 unit must not get it."""
+        coord = _coord_on_firmware("V1.90.1")
+        desc = _number_desc(
+            SensorKey.DHW_TARGET_TEMPERATURE, LP.P0002_DHW_TARGET_TEMPERATURE
+        )
+        assert coord._is_version_not_compatible(desc) is True
+
+    def test_dhw_target_legacy_register_active_on_v2_below_cutover(self):
+        """A V2.88.0 unit predates the 90.1 change and keeps P0002."""
+        coord = _coord_on_firmware("V2.88.0")
+        desc = _number_desc(
+            SensorKey.DHW_TARGET_TEMPERATURE, LP.P0002_DHW_TARGET_TEMPERATURE
+        )
+        assert coord._is_version_not_compatible(desc) is False
+
+    def test_dhw_target_modern_register_still_active_on_v3(self):
+        """Regression guard: the V3 behaviour the absolute gates got right."""
+        coord = _coord_on_firmware("V3.90.1")
+        desc = _number_desc(
+            SensorKey.DHW_TARGET_TEMPERATURE, LP.P0105_DHW_TARGET_TEMPERATURE
+        )
+        assert coord._is_version_not_compatible(desc) is False
+
+    def test_cooling_threshold_wide_range_active_on_v2(self):
+        """The 92.1+ cooling threshold spans 10-35 C and must reach V2.92.1."""
+        coord = _coord_on_firmware("V2.92.1")
+        desc = _number_desc(
+            SensorKey.COOLING_OUTDOOR_TEMP_THRESHOLD,
+            LP.P0110_COOLING_OUTDOOR_TEMP_THRESHOLD,
+            native_min_value=10.0,
+        )
+        assert coord._is_version_not_compatible(desc) is False
+
+    def test_cooling_threshold_narrow_range_hidden_on_v2(self):
+        """The pre-92.1 variant spans 18-30 C and must not reach V2.92.1."""
+        coord = _coord_on_firmware("V2.92.1")
+        desc = _number_desc(
+            SensorKey.COOLING_OUTDOOR_TEMP_THRESHOLD,
+            LP.P0110_COOLING_OUTDOOR_TEMP_THRESHOLD,
+            native_min_value=18.0,
+        )
+        assert coord._is_version_not_compatible(desc) is True
+
+    @pytest.mark.parametrize(
+        "firmware",
+        [
+            "V1.88.0",
+            "V1.90.0",
+            "V1.90.1",
+            "V2.88.0",
+            "V2.92.0",
+            "V2.92.1",
+            "V3.90.0",
+            "V3.90.1",
+            "V3.92.1",
+        ],
+    )
+    def test_exactly_one_variant_of_each_pair_is_active(self, firmware):
+        """Paired descriptions must never both apply, nor both drop out.
+
+        Each pair shares one SensorKey, and number.py derives both
+        `entity_id` and `unique_id` from that key alone - so the two
+        variants are the same entity, differing only in which register
+        backs it (DHW) or how wide its range is (cooling). Two active
+        variants would collide on that id; zero would make the entity
+        vanish. This is also why correcting these gates needs no entity
+        registry migration.
+        """
+        coord = _coord_on_firmware(firmware)
+        for key in (
+            SensorKey.DHW_TARGET_TEMPERATURE,
+            SensorKey.COOLING_OUTDOOR_TEMP_THRESHOLD,
+        ):
+            variants = [d for d in NUMBER_SENSORS if d.key == key]
+            assert len(variants) == 2, f"{key} is no longer a gated pair"
+            active = [d for d in variants if not coord._is_version_not_compatible(d)]
+            assert len(active) == 1, (
+                f"{key} on {firmware}: {len(active)} active variants, expected 1"
+            )

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -726,26 +726,39 @@ class TestFirmwareGatesAreSeriesAgnostic:
         "firmware",
         [
             "V1.88.0",
+            "V1.90",  # no patch digit -> minor 90.0
             "V1.90.0",
             "V1.90.1",
+            "V1.92.0",
+            "V1.92.1",
             "V2.88.0",
             "V2.92.0",
             "V2.92.1",
             "V3.90.0",
             "V3.90.1",
             "V3.92.1",
+            "not a version",  # unparsable -> Version("0") -> minor 0.0
         ],
     )
     def test_exactly_one_variant_of_each_pair_is_active(self, firmware):
-        """Paired descriptions must never both apply, nor both drop out.
+        """Exactly one variant of each gated pair may clear the version gate.
 
         Each pair shares one SensorKey, and number.py derives both
         `entity_id` and `unique_id` from that key alone - so the two
-        variants are the same entity, differing only in which register
-        backs it (DHW) or how wide its range is (cooling). Two active
-        variants would collide on that id; zero would make the entity
-        vanish. This is also why correcting these gates needs no entity
-        registry migration.
+        variants are one entity, differing only in which register backs it
+        (DHW) or how wide its range is (cooling). That is why correcting
+        these gates needs no entity registry migration, and it is why the
+        two gates of a pair have to stay complementary: overlapping ones
+        would have two descriptions claiming one id.
+
+        This asserts the version gate only. Whether an entity is actually
+        created also depends on `entity_active` and on the register being
+        present (number.py:66-69), so a passing case here does not by
+        itself prove exactly one entity is built.
+
+        Unlike the tests above, this one also passes before the firmware
+        minor fix - the absolute gates were complementary too. It guards
+        the shared-id property against future gate edits, not the bug.
         """
         coord = _coord_on_firmware(firmware)
         for key in (

--- a/tests/test_predefined_entities.py
+++ b/tests/test_predefined_entities.py
@@ -151,3 +151,25 @@ class TestFirmwareVersionFields:
             for descr in _all_descriptions()
             for name in self.FIELDS
         )
+
+    def test_no_description_gates_on_the_absolute_version(self):
+        """Register gates must compare the minor version, not the whole one.
+
+        The firmware major digit is the controller *series* - V1.x, V2.x and
+        V3.x are different hardware generations - and it never advances on a
+        firmware update. Only the minor digit tracks the register layout, so
+        `Version("3.90.1")` in a gate reads every V1.x and V2.x controller as
+        older than everything and serves those owners the wrong entity set
+        regardless of how current their firmware is.
+
+        Use `min/max_firmware_version_minor`. A difference that really is
+        per-generation belongs in code, against
+        `LuxtronikCoordinator.firmware_series`.
+        """
+        offenders = [
+            (type(descr).__name__, descr.key, name, str(value))
+            for descr in _all_descriptions()
+            for name in ("min_firmware_version", "max_firmware_version")
+            if (value := getattr(descr, name, None)) is not None
+        ]
+        assert offenders == []

--- a/tests/test_predefined_entities.py
+++ b/tests/test_predefined_entities.py
@@ -166,9 +166,14 @@ class TestFirmwareVersionFields:
         per-generation belongs in code, against
         `LuxtronikCoordinator.firmware_series`.
         """
+        descriptions = list(_all_descriptions())
+        # Guard the guard: a walker that silently yielded nothing would make
+        # the assertion below vacuous.
+        assert len(descriptions) > 100
+
         offenders = [
             (type(descr).__name__, descr.key, name, str(value))
-            for descr in _all_descriptions()
+            for descr in descriptions
             for name in ("min_firmware_version", "max_firmware_version")
             if (value := getattr(descr, name, None)) is not None
         ]


### PR DESCRIPTION
## 🐛 The bug

Four entity descriptions in `number_entities_predefined.py` gated on the **whole** firmware version:

```python
max_firmware_version=Version("3.90.0")
min_firmware_version=Version("3.90.1")
min_firmware_version=Version("3.92.1")
max_firmware_version=Version("3.92.0")
```

The major digit is the controller **series** — V1.x, V2.x and V3.x are different hardware generations — and it never advances on a firmware update. Only the minor digit tracks the register layout, so a V1.90.1 controller carries the same registers as a V3.90.1 one.

Comparing the whole version makes every V1.x and V2.x unit read as older than any `3.x` bound, no matter how current its firmware is. Concretely, a **V1.90.1 unit was offered the legacy P0002 DHW setpoint while P0105 — the register its firmware actually uses — was hidden**, and the cooling threshold was capped at the pre-92.1 range.

These four were the only absolute gates left in the integration; `water_heater.py` already used the minor form.

## ✅ The fix

| line | before | after |
|---|---|---|
| 527 | `max_firmware_version=Version("3.90.0")` | `max_firmware_version_minor=Version("90.0")` |
| 540 | `min_firmware_version=Version("3.90.1")` | `min_firmware_version_minor=Version("90.1")` |
| 689 | `min_firmware_version=Version("3.92.1")` | `min_firmware_version_minor=Version("92.1")` |
| 704 | `max_firmware_version=Version("3.92.0")` | `max_firmware_version_minor=Version("92.0")` |

V3 behaviour is unchanged — the thresholds are faithful conversions, not a re-judgement of where the cutovers sit.

## 🎯 Scope, stated honestly

This only changes behaviour for **V1.x / V2.x units at minor ≥ 90.1** (DHW) or **≥ 92.1** (cooling). The local diagnostics corpus contains no such dump — 36 dumps, and every non-V3 unit sits at minor ≤ 90.0. So this is a latent bug fix reasoned from the series/minor rule and consistent with the V1.90.0 unit that does exist, not one confirmed against an affected installation.

**No entity registry migration is needed.** Both variants of each pair share one `SensorKey`, and `number.py` derives `entity_id` and `unique_id` from that key alone — so the two are the same entity. Only the backing register (DHW) or the value range (cooling) corrects itself.

## 🧪 Tests

Three layers, each proven by mutation to catch what it claims:

- **Per-gate behaviour** — 6 tests against the real descriptions with a real coordinator. 4 failed before the fix on the gate verdict itself; 2 pass either way as the regression boundary.
- **Mutual exclusivity** — 13 firmware versions × 2 pairs, including a patchless `V1.90` and an unparsable string. Because both variants share one entity id, overlapping gates would collide and a gap would make the entity vanish. Mutated both ways (`2 active variants` / `0 active variants`) to confirm it catches. This one passes before the fix too, by design — the absolute gates were complementary as well.
- **Recurrence guard** — no predefined description on any platform may use the absolute fields again, pointing at `coordinator.firmware_series` for differences that really are per-generation. The absolute pair is now marked deprecated-for-descriptions in `model.py`.

`ruff` clean, `ruff format --check` clean, `basedpyright` 0 errors, `codespell` clean, **1102 tests passing at 100% coverage**.

## 📝 Documentation

Investigating this surfaced an adjacent question that is **deliberately left alone**: `number` and `water_heater` gate the same P0002/P0105 pair at different minors (90.1 vs 88.3), because commit `fecdf38` rebuilt the minor mechanism and applied it to `water_heater` only.

Rather than churn a threshold on incomplete evidence, `DHW_TARGET_REGISTERS.md` records what is actually known: the register semantics, the two firmware events that usually get conflated, every divergent measurement in the corpus, why neither threshold is clearly right, two dead ends worth not re-deriving, and the single measurement that would settle it. Nothing about the DHW thresholds changes in this PR.

## 👀 Review

Reviewed against the base commit, including a replay of the new tests on pre-fix source to confirm they fail, and an independent check that the coverage baseline was unaffected. No Critical findings; the Important ones are addressed or documented above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
