### PR TITLE
fix(common,const): 🐛 stop inverting the smartgrid evu1 input on 2.0 wiring

### DIFF
--- a/custom_components/luxtronik2/common.py
+++ b/custom_components/luxtronik2/common.py
@@ -196,11 +196,27 @@ def read_smart_grid_inputs(
     The rail test is a band rather than an exact match: the register may not be
     clamped at the rail on every unit, so reading slightly past it must still
     count. It is bounded above because a signed Celsius register can also
-    report something implausible, and treating that as SG2 would move a 2.1
-    unit onto this branch and invert its EVU1 as well.
+    report something implausible, and treating that as SG2 would read a 2.1
+    unit's SG2 off a temperature.
 
-    On 2.0 the EVU terminal carries SG1 itself, and there "released" means the
-    SG1 row of the table is 0, so EVU1 is inverted along with it.
+    Only SG2 moves. EVU1 is read off calc 31 unchanged on every generation,
+    and the four-state table it feeds is itself generation-independent - it is
+    verbatim the same in the Luxtronik 2.0 (83055300h p32), Luxtronik 2.1
+    (83055400g p33) and HMD2 (83055600d p29) manuals.
+
+    Releases 2026.08.17 through 2026.08.23 inverted EVU1 on this branch, fitted
+    to two dumps in #669 that had SG1 closed in both and so could not tell an
+    inverted input from a misread controller display. What settles it without
+    relying on anyone's reading of the display is C0080, the controller's own
+    operating state: across all seven dumps from that unit it reports `evu`
+    (EVU lock active) in exactly the dumps where calc 31 is True, and
+    `no request` in exactly those where it is False. So True means locked, the
+    EVU1=1 row of the table, and the register is passed through as-is.
+
+    Caveat for the next reader: no dump pins the EVU1=1 + EVU2=1 corner, and
+    the two dumps sitting there report C0080 `evu` rather than the increased
+    operation the table promises. That row is unverified in the field; it is
+    left as the manual specifies.
     """
     evu1 = _as_bool(get_sensor_data(coordinator, LC.C0031_EVU_UNLOCKED))
     rfv = get_sensor_data(coordinator, LC.C0023_ROOM_STATION_RFV)
@@ -219,8 +235,12 @@ def read_smart_grid_inputs(
     if rfv_value is not None and SMART_GRID_RFV_RAIL <= abs(rfv_value) <= (
         SMART_GRID_RFV_RAIL * 2
     ):
-        LOGGER.debug("SmartGrid SG2 read from the RFV terminal (%s)", rfv_value)
-        return not evu1, rfv_value < 0
+        LOGGER.debug(
+            "SmartGrid SG2 read from the RFV terminal (%s), EVU1 %s",
+            rfv_value,
+            evu1,
+        )
+        return evu1, rfv_value < 0
 
     return evu1, _as_bool(get_sensor_data(coordinator, LC.C0185_EVU2))
 

--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -599,6 +599,11 @@ class LuxCalculation(StrEnum):
     C0026_SOLAR_COLLECTOR_TEMPERATURE = "calculations.ID_WEB_Temperatur_TSK"
     C0027_SOLAR_BUFFER_TEMPERATURE = "calculations.ID_WEB_Temperatur_TSS"
     C0029_DEFROST_END_FLOW_OKAY = "calculations.ID_WEB_ASDin"
+    # Misnomer kept for compatibility: True means the EVU lock is *active*,
+    # not released. C0080 reads `evu` in exactly the dumps where this is True
+    # (all seven from the #669 unit), which is what refuted the short-lived
+    # EVU1 inversion in read_smart_grid_inputs. The user-facing string is
+    # correct already ("Locktime"); only this identifier reads backwards.
     C0031_EVU_UNLOCKED = "calculations.ID_WEB_EVUin"
     # C0032_HIGH_PRESSURE_OKAY: Final = "calculations.ID_WEB_HDin"  # True/False -> Hochdruck OK
     C0034_MOTOR_PROTECTION = "calculations.ID_WEB_MOTin"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -198,19 +198,33 @@ class TestReadSmartGridInputs:
         )
 
     def test_rfv_wiring_reads_evu2_from_the_rfv_sign(self):
-        """Luxtronik 2.0: SG2 sits on the room station terminal, EVU1 inverted.
+        """Luxtronik 2.0: SG2 sits on the room station terminal.
 
-        Both rows are taken from the two diagnostics dumps in #669, together
-        with the state the controller display showed for each.
+        Every row is one of the three-point SG sweep posted on 2026-08-20 in
+        #669, together with the state the controller display showed for it.
+        That set is the one that varies SG1, so it is the one that pins both
+        inputs down.
         """
-        # SG2 on -> display state 3 -> EVU1=0, EVU2=1
-        assert read_smart_grid_inputs(_sg_data(evu_in=True, rfv=-5.0)) == (False, True)
-        # SG2 off -> display state 2 -> EVU1=0, EVU2=0
-        assert read_smart_grid_inputs(_sg_data(evu_in=True, rfv=5.0)) == (False, False)
+        # SG2 closed -> display state 3 -> EVU1=0, EVU2=1
+        assert read_smart_grid_inputs(_sg_data(evu_in=False, rfv=-5.0)) == (False, True)
+        # SG2 open -> display state 2 -> EVU1=0, EVU2=0
+        assert read_smart_grid_inputs(_sg_data(evu_in=False, rfv=5.0)) == (False, False)
+        # SG1 closed -> display state 1 -> EVU1=1, EVU2=0
+        assert read_smart_grid_inputs(_sg_data(evu_in=True, rfv=5.0)) == (True, False)
 
-    def test_rfv_wiring_inverts_evu1(self):
-        """On 2.0 the EVU terminal is SG1 itself, so released == EVU1 off."""
-        assert read_smart_grid_inputs(_sg_data(evu_in=False, rfv=-5.0)) == (True, True)
+    def test_rfv_wiring_passes_evu1_through(self):
+        """EVU1 comes off calc 31 unchanged, exactly as on the other wirings.
+
+        Releases 2026.08.17-2026.08.23 inverted it here. That is refuted by
+        C0080, the controller's own operating state, which reads `evu` in
+        exactly the dumps where calc 31 is True - so True is the EVU1=1 row.
+
+        This asserts the pass-through only. The input pair here is EVU1=1 +
+        EVU2=1, whose mapping to `increased` no dump confirms; see the caveat
+        in read_smart_grid_inputs.
+        """
+        assert read_smart_grid_inputs(_sg_data(evu_in=True, rfv=-5.0)) == (True, True)
+        assert read_smart_grid_inputs(_sg_data(evu_in=False, rfv=-5.0)) == (False, True)
 
     def test_room_station_configured_keeps_hzio(self):
         """A real room station owns the terminal, so it can never be SG2.
@@ -246,16 +260,20 @@ class TestReadSmartGridInputs:
         ) == (True, True)
 
     def test_smart_grid_mode_value_is_enabled(self):
-        """P1030 holds a mode, not a flag - the #669 unit reports 3, not 1."""
+        """P1030 holds a mode, not a flag - the #669 unit reports 3, not 1.
+
+        The tell that the mode counted as enabled is EVU2 coming off the RFV
+        sign rather than the HZIO register, which reads 0 here.
+        """
         assert read_smart_grid_inputs(
             _sg_data(evu_in=True, rfv=-5.0, smart_grid=3)
-        ) == (False, True)
+        ) == (True, True)
 
     def test_implausible_rfv_reading_keeps_hzio(self):
         """A signed Celsius register can report garbage; only the rails count.
 
         Without a ceiling such a reading would move a 2.1 unit onto the 2.0
-        branch, which also inverts its EVU1.
+        branch and read its SG2 off a temperature.
         """
         for rfv in (3276.7, -100.0):
             assert read_smart_grid_inputs(

--- a/tests/test_entity_platforms.py
+++ b/tests/test_entity_platforms.py
@@ -875,7 +875,7 @@ class TestSmartGridSensor:
         """Luxtronik 2.0 with SG2 on the RFV terminal, display state 3 (#669)."""
         from custom_components.luxtronik2.const import LuxSmartGridStatus
 
-        entity, _ = self._make_smart_grid(evu=1, evu2=0, rfv=-5.0)
+        entity, _ = self._make_smart_grid(evu=0, evu2=0, rfv=-5.0)
         entity._handle_coordinator_update()
         assert entity._attr_native_value == LuxSmartGridStatus.normal
 
@@ -883,9 +883,20 @@ class TestSmartGridSensor:
         """Same unit with SG2 open, display state 2 (#669)."""
         from custom_components.luxtronik2.const import LuxSmartGridStatus
 
-        entity, _ = self._make_smart_grid(evu=1, evu2=0, rfv=5.0)
+        entity, _ = self._make_smart_grid(evu=0, evu2=0, rfv=5.0)
         entity._handle_coordinator_update()
         assert entity._attr_native_value == LuxSmartGridStatus.reduced
+
+    def test_smart_grid_rfv_wiring_locked(self):
+        """Same unit with SG1 closed, display state 1 (#669).
+
+        The dump behind this row is the one the earlier fix never had.
+        """
+        from custom_components.luxtronik2.const import LuxSmartGridStatus
+
+        entity, _ = self._make_smart_grid(evu=1, evu2=0, rfv=5.0)
+        entity._handle_coordinator_update()
+        assert entity._attr_native_value == LuxSmartGridStatus.locked
 
     def test_smart_grid_room_station_still_uses_hzio(self):
         """A configured room station never doubles as SG2."""


### PR DESCRIPTION
## 🐛 Problem

The RFV-terminal fix for #669 (`5fff1ce`, released in 2026.08.17) correctly moved the SmartGrid **SG2** input to the RFV register on Luxtronik 2.0 wiring — but it also **inverted EVU1** on that branch. The result is that every SmartGrid state on the affected units is reported one row off:

| controller display | reported by 2026.08.17–2026.08.23 |
|---|---|
| 1 = EVU-Sperre | `reduced_operation` |
| 2 = abgesenkte Betriebsweise | `evu_locked` |
| 3 = Normalbetrieb | `increased_operation` |
| 4 = erhöhte Betriebsweise | `normal_operation` |

So the original "always `evu_locked`" symptom became "always wrong, differently".

## 🔍 Why the inversion got there

It was fitted to the only two diagnostics dumps available at the time (2026-07-10). Both were taken with **SG1 closed**, so EVU1 never varied across the sample — and with the input constant, "EVU1 is inverted on this generation" and "these two display readings were misrecorded" fit the data equally well. The commit picked the first and reported it as verified, because the fitted model reproduced the two points it was fitted to. The accompanying test asserted the inverted case for an input combination no dump covered.

## ✅ What settles it

**1. A three-point sweep that varies SG1** (posted 2026-08-20 in #669), which fits the manual's table with calc 31 read straight:

| contacts | display | `C0031` | `C0023` RFV |
|---|---|---|---|
| SG1 off, SG2 on | 3 | `False` | `-5.0` |
| SG1 off, SG2 off | 2 | `False` | `5.0` |
| SG1 on, SG2 off | 1 | `True` | `5.0` |

Recorded on integration 2026.08.18 — whose own output for row 1 is `increased_operation`, not the "3" the reporter wrote — so those numbers come from the controller, not from the entity.

**2. `C0080 ID_WEB_WP_BZ_akt`, the controller's own operating state** — this is the argument that does not depend on anyone's reading of a display. Across **all seven** dumps from that unit it reports `evu` (lock active) in exactly the dumps where `C0031` is `True`, and `no request` in exactly those where it is `False`. So `True` is the `EVU1=1` row. This also directly contradicts the July report: both July dumps show the pump in `evu` while claiming displays 2 and 3.

**3. No per-generation state table exists.** Verified verbatim in three manuals — Luxtronik 2.0 (83055300h p32), Luxtronik 2.1 (83055400g p33), HMD2 (83055600d p29). All identical; only the *terminal plan* differs per generation, which is what `5fff1ce` already handles. None of the three documents any "SG 1.1" variant table.

## 🔧 Changes

- `common.py` — `return not evu1, …` → `return evu1, …`; docstring rewritten to state only what the evidence supports, with the `C0080` correlation inlined (the previous version cited a gitignored path); the debug line now logs EVU1 alongside the RFV value
- `const.py` — `C0031_EVU_UNLOCKED` annotated as a misnomer (`True` = lock **active**), since the name asserts the polarity the registers refute and is what made this ambiguous twice
- `tests/` — assertions re-anchored to the August sweep; `test_rfv_wiring_inverts_evu1` → `test_rfv_wiring_passes_evu1_through`, now claiming only the pass-through; new `test_smart_grid_rfv_wiring_locked` covers the SG1-closed row the earlier fix never had

## 🛡️ Blast radius

Confined to the RFV branch — SmartGrid on, no room station configured, RFV parked at a ±5 K rail. A scan of all 82 parseable dumps in the local corpus finds exactly one unit that meets those conditions (the #669 reporter's). Luxtronik 2.1 / HMD2 and everything else fall through to the unchanged `evu1, C0185` path.

## ⚠️ Known gap

The `EVU1=1 + EVU2=1` → `increased_operation` row remains **unverified in the field**. No dump pins it, and the two dumps that sit there report `C0080 = evu` rather than the increased operation the table promises. The row is left exactly as all three manuals specify rather than invented from two samples, and the caveat is documented in the docstring and the test. A reading with both contacts closed would close it — requested from the reporter.

## 🧪 Verification

- 1083 tests pass (was 1082 + 1 new)
- Coverage 100% maintained (3590 statements, 0 missed)
- `ruff check` / `ruff format --check` / `codespell` clean, `basedpyright` 0 errors
- The patched helper reproduces all three August dumps; it deliberately does **not** reproduce the two July display readings, which `C0080` shows to be misrecorded

Refs #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)
