### PR TITLE
ci(release): 👷 carry the upgrade notes from merged PRs into the release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## 🔍 What this fixes
+
+<!-- What is wrong today, and how do you know? Link the issue and the evidence. -->
+
+## ✨ Changes
+
+<!-- What changed, file by file or theme by theme. -->
+
+## 🧪 Tests
+
+<!-- What you added, and the result of the full run. -->
+
+## ⚠️ Upgrade notes
+
+<!--
+KEEP THIS SECTION ONLY IF USERS MUST DO SOMETHING AFTER UPGRADING - otherwise
+delete the heading and this comment.
+
+Everything under this heading is copied verbatim into the release notes by
+.github/scripts/collect_release_notes.py, above the generated "What's Changed"
+list. So write it for the person installing the update, not for the reviewer:
+name the entity, say what breaks, and say what they have to change by hand.
+
+Renamed or removed entities, changed state values, anything Home Assistant
+cannot migrate for them (YAML automations, dashboard cards, template sensors,
+utility meters) belong here.
+-->

--- a/.github/scripts/collect_release_notes.py
+++ b/.github/scripts/collect_release_notes.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Collect the upgrade notes written in merged pull requests.
+
+The release workflow asks GitHub to generate its notes, which yields the PR
+*titles* and nothing else. Anything a PR author wrote for users - a renamed
+entity, a changed state value, something to fix by hand after upgrading - was
+therefore lost unless someone pasted it into the release by hand afterwards,
+which is what happened for the 2026.08.15 / .17 / .18 releases.
+
+This script walks the pull requests merged since the previous full release,
+lifts the upgrade-note section out of each body, and writes them to a file the
+release step passes as `body_path`. The action pre-pends that body to the
+generated notes, so the result matches the layout those releases already had.
+
+Matching is deliberately loose. The pull request template offers one canonical
+heading, but six merged PRs each invented their own wording before it existed,
+so any second- or third-level heading mentioning an upgrade note, a release
+note, a breaking change, a migration or a behaviour change counts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+
+# Headings whose section is meant for the people installing the release.
+NOTE_HEADING = re.compile(
+    r"^(#{2,3})[ \t]*.*(?:upgrade note|release note|breaking|migration|behaviour change|behavior change).*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# ... unless the heading negates it. "No behaviour change" (#749) matches the
+# keyword while saying the opposite.
+NEGATED_HEADING = re.compile(r"\b(?:no|without)\b", re.IGNORECASE)
+
+# Instructions to the PR author, including the ones the template ships with:
+# never part of what users read.
+HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+
+# Trailers the section should not swallow when it runs to the end of the body.
+TRAILER = re.compile(
+    r"(?im)^\s*(?:refs|resolves|closes|fixes)\s+#\d+\s*$"
+    r"|^\s*\U0001f916 Generated with \[Claude Code\].*$"
+)
+
+# The compare API returns at most 250 commits, so a release spanning more than
+# that would silently lose the notes of its oldest pull requests.
+COMPARE_COMMIT_LIMIT = 250
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+LOG = logging.getLogger(__name__)
+
+
+def extract_notes(body: str | None) -> list[str]:
+    """Return every upgrade-note section of a pull request body."""
+    if not body:
+        return []
+    body = body.replace("\r\n", "\n")
+    notes: list[str] = []
+    for match in NOTE_HEADING.finditer(body):
+        if NEGATED_HEADING.search(match.group(0)):
+            continue
+        level = len(match.group(1))
+        rest = body[match.end() :]
+        # A section ends at the next heading of the same level or higher, so a
+        # note written with ### subsections keeps them.
+        end = re.search(rf"^#{{1,{level}}}[ \t]", rest, re.MULTILINE)
+        section = rest[: end.start()] if end else rest
+        section = HTML_COMMENT.sub("", section)
+        section = TRAILER.sub("", section).strip()
+        if not section:
+            # An untouched template section, or a heading with nothing under
+            # it: there is no note here to tell anyone about.
+            continue
+        heading = match.group(0).strip()
+        notes.append(f"{heading}\n\n{section}")
+    return notes
+
+
+def render(notes_by_pr: list[tuple[int, list[str]]], repo: str) -> str:
+    """Render the collected notes as the release body."""
+    blocks: list[str] = []
+    for number, notes in notes_by_pr:
+        link = f"https://github.com/{repo}/pull/{number}"
+        for note in notes:
+            heading, _, rest = note.partition("\n")
+            blocks.append(f"{heading} ([#{number}]({link}))\n{rest}".strip())
+    return "\n\n".join(blocks)
+
+
+def _gh(*args: str) -> str:
+    return subprocess.run(
+        ["gh", *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _pull_requests(repo: str, base: str, head: str) -> list[int]:
+    """Pull request numbers merged between two revisions, oldest first."""
+    compare = json.loads(_gh("api", f"repos/{repo}/compare/{base}...{head}"))
+    commits = compare.get("commits", [])
+    total = compare.get("total_commits", len(commits))
+    if total > len(commits):
+        LOG.warning(
+            "::warning::compare returned %s of %s commits (API caps at %s); "
+            "notes from the oldest pull requests in this range are missing",
+            len(commits),
+            total,
+            COMPARE_COMMIT_LIMIT,
+        )
+    numbers: list[int] = []
+    for commit in commits:
+        associated = json.loads(
+            _gh("api", f"repos/{repo}/commits/{commit['sha']}/pulls")
+        )
+        for pull in associated:
+            if pull["number"] not in numbers:
+                numbers.append(pull["number"])
+    return numbers
+
+
+def _write(path: str, content: str) -> None:
+    """Write the release body. Always called, so body_path always resolves;
+    an empty body simply leaves the generated notes alone."""
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(content)
+
+
+def main() -> int:
+    repo = os.environ["GITHUB_REPOSITORY"]
+    base = os.environ.get("PREVIOUS_STABLE", "").strip()
+    head = os.environ.get("GITHUB_SHA", "HEAD").strip()
+    out_path = os.environ.get("RELEASE_NOTES_PATH", "release_notes.md")
+
+    if not base:
+        # No full release to compare against yet - the generated notes stand
+        # on their own. The file is still written: the release step points at
+        # it unconditionally.
+        _write(out_path, "")
+        LOG.info("No previous stable tag; skipping upgrade notes")
+        return 0
+
+    notes_by_pr: list[tuple[int, list[str]]] = []
+    for number in _pull_requests(repo, base, head):
+        body = json.loads(_gh("api", f"repos/{repo}/pulls/{number}")).get("body")
+        notes = extract_notes(body)
+        if notes:
+            notes_by_pr.append((number, notes))
+
+    rendered = render(notes_by_pr, repo)
+    _write(out_path, rendered + "\n" if rendered else "")
+    LOG.info("Collected upgrade notes from %s pull request(s)", len(notes_by_pr))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,17 @@ jobs:
           LATEST_TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq '.tag_name')
           echo "PREVIOUS_STABLE=$LATEST_TAG" >> $GITHUB_ENV
 
+      # Lifts the "⚠️ Upgrade notes" section out of every PR merged since that
+      # tag, so what an author wrote for users reaches the release instead of
+      # having to be pasted in by hand afterwards (as 2026.08.15/.17/.18 were)
+      - name: Collect Upgrade Notes From Pull Requests
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_NOTES_PATH: release_notes.md
+        run: |
+          python3 .github/scripts/collect_release_notes.py
+
       # Creates the release based on your choice
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
@@ -72,6 +83,10 @@ jobs:
           tag_name: ${{ env.VERSION }}
           name: ${{ env.VERSION }}
           generate_release_notes: true
+          # Pre-pended to the generated notes, so the upgrade notes come first
+          # and "What's Changed" follows - the layout the hand-written releases
+          # already used. Empty when no merged PR carried a note
+          body_path: release_notes.md
           # Always compare against the previous full release, so pre-release notes include
           # every PR merged since the last full release too
           previous_tag: ${{ env.PREVIOUS_STABLE }}

--- a/tests/test_release_notes.py
+++ b/tests/test_release_notes.py
@@ -1,0 +1,160 @@
+"""Tests for .github/scripts/collect_release_notes.py.
+
+The release workflow generates its notes from PR titles only, so the upgrade
+notes written into PR bodies never reached a release: #728, #735, #748, #750,
+#759 and #762 each carried one, and every August release body was either the
+bare title list or a block someone re-pasted by hand. This script lifts those
+sections out of the merged PRs and hands them to the release step.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent
+    / ".github"
+    / "scripts"
+    / "collect_release_notes.py"
+)
+_spec = importlib.util.spec_from_file_location("collect_release_notes", _SCRIPT_PATH)
+assert _spec and _spec.loader
+collect_release_notes = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(collect_release_notes)
+
+extract_notes = collect_release_notes.extract_notes
+render = collect_release_notes.render
+
+
+class TestExtractNotes:
+    def test_the_canonical_heading(self):
+        body = "## \u2728 Changes\n\nstuff\n\n## \u26a0\ufe0f Upgrade notes\n\nDo the thing.\n"
+        assert extract_notes(body) == ["## \u26a0\ufe0f Upgrade notes\n\nDo the thing."]
+
+    def test_stops_at_the_next_section(self):
+        body = (
+            "## \u26a0\ufe0f Upgrade notes\n\nDo the thing.\n\n"
+            "## \U0001f9ea Tests\n\n1153 passed\n"
+        )
+        assert extract_notes(body) == ["## \u26a0\ufe0f Upgrade notes\n\nDo the thing."]
+
+    def test_keeps_subsections(self):
+        """The 2026.08.18 note used ### subheadings inside its block."""
+        body = (
+            "## \u26a0\ufe0f Upgrade notes\n\nintro\n\n"
+            "### \u2705 Handled for you\n\nthe migration runs\n\n"
+            "## \U0001f9ea Tests\n"
+        )
+        assert "### \u2705 Handled for you" in extract_notes(body)[0]
+
+    def test_matches_the_headings_used_before_the_convention(self):
+        """Six merged PRs each invented their own wording; all should be found."""
+        for heading in (
+            "## \u26a0\ufe0f Note for release notes",
+            "## \u26a0\ufe0f Breaking change for dump consumers",
+            "## \U0001f517 Migration",
+            "## \u26a0\ufe0f Upgrade note for the release",
+            "## \u26a0\ufe0f Behaviour change worth noting in the release notes",
+            "## \U0001f4a5 Breaking changes",
+        ):
+            assert extract_notes(f"{heading}\n\nbody text\n"), heading
+
+    def test_ignores_a_heading_that_negates_the_keyword(self):
+        """#749 wrote "No behaviour change" - the opposite of a note."""
+        assert extract_notes("## ✅ No behaviour change\n\nnothing to do\n") == []
+        assert extract_notes("## \U0001f50d Without migration\n\nnope\n") == []
+
+    def test_an_untouched_template_section_yields_nothing(self):
+        """The PR template ships the heading with an instruction comment. An
+        author who leaves it in place has no note, not an empty one."""
+        body = (
+            "## ⚠️ Upgrade notes\n\n"
+            "<!--\nKEEP THIS SECTION ONLY IF USERS MUST DO SOMETHING\n-->\n"
+        )
+        assert extract_notes(body) == []
+
+    def test_strips_html_comments_from_a_real_note(self):
+        body = "## ⚠️ Upgrade notes\n\n<!-- a hint -->\nRename it.\n"
+        assert extract_notes(body) == ["## ⚠️ Upgrade notes\n\nRename it."]
+
+    def test_ignores_sections_that_are_not_upgrade_notes(self):
+        body = (
+            "## \U0001f50d What this fixes\n\nnope\n\n"
+            "## \u26a0\ufe0f Field-verification status\n\nalso nope\n"
+        )
+        assert extract_notes(body) == []
+
+    def test_strips_issue_trailers_and_the_generated_with_line(self):
+        """#762's section ran to the end of the body and swallowed both."""
+        body = (
+            "## \u26a0\ufe0f Note for release notes\n\nRenaming 1135 removes it.\n\n"
+            "Refs #752\n\n"
+            "\U0001f916 Generated with [Claude Code](https://claude.com/claude-code)\n"
+        )
+        assert extract_notes(body) == [
+            "## \u26a0\ufe0f Note for release notes\n\nRenaming 1135 removes it."
+        ]
+
+    def test_a_pr_can_carry_more_than_one(self):
+        body = (
+            "## \U0001f4a5 Breaking changes\n\nfirst\n\n"
+            "## \U0001f9ea Tests\n\nx\n\n"
+            "## \U0001f517 Migration\n\nsecond\n"
+        )
+        assert len(extract_notes(body)) == 2
+
+    def test_an_empty_body_yields_nothing(self):
+        assert extract_notes("") == []
+        assert extract_notes(None) == []
+
+
+class TestRender:
+    def test_attributes_each_note_to_its_pull_request(self):
+        out = render(
+            [(771, ["## \u26a0\ufe0f Upgrade notes\n\nDo the thing."])],
+            "BenPru/luxtronik",
+        )
+        assert "## \u26a0\ufe0f Upgrade notes" in out
+        assert "https://github.com/BenPru/luxtronik/pull/771" in out
+        assert "Do the thing." in out
+
+    def test_nothing_to_report_renders_empty(self):
+        assert render([], "BenPru/luxtronik") == ""
+
+    def test_keeps_pull_requests_in_the_order_given(self):
+        out = render(
+            [
+                (728, ["## \u26a0\ufe0f Upgrade notes\n\nfirst"]),
+                (771, ["## \u26a0\ufe0f Upgrade notes\n\nsecond"]),
+            ],
+            "BenPru/luxtronik",
+        )
+        assert out.index("first") < out.index("second")
+
+
+class TestMainAlwaysWritesTheFile:
+    """The release step passes body_path unconditionally, so the file has to
+    exist even when there is nothing to say."""
+
+    def test_writes_an_empty_file_without_a_previous_stable_tag(
+        self, tmp_path, monkeypatch
+    ):
+        out = tmp_path / "release_notes.md"
+        monkeypatch.setenv("GITHUB_REPOSITORY", "BenPru/luxtronik")
+        monkeypatch.setenv("PREVIOUS_STABLE", "")
+        monkeypatch.setenv("RELEASE_NOTES_PATH", str(out))
+
+        assert collect_release_notes.main() == 0
+        assert out.exists()
+        assert out.read_text(encoding="utf-8") == ""
+
+    def test_writes_an_empty_file_when_no_pull_request_carried_a_note(
+        self, tmp_path, monkeypatch
+    ):
+        out = tmp_path / "release_notes.md"
+        monkeypatch.setenv("GITHUB_REPOSITORY", "BenPru/luxtronik")
+        monkeypatch.setenv("PREVIOUS_STABLE", "2026.08.18")
+        monkeypatch.setenv("RELEASE_NOTES_PATH", str(out))
+        monkeypatch.setattr(collect_release_notes, "_pull_requests", lambda *a: [])
+
+        assert collect_release_notes.main() == 0
+        assert out.read_text(encoding="utf-8") == ""


### PR DESCRIPTION
## 🔍 What this fixes

The release workflow asks GitHub to generate its notes, which yields the PR **titles** and nothing else. So anything a PR author wrote *for users* never reached a release.

That has been happening all along. Six PRs merged since June each carried an upgrade note, under six different headings:

| PR | Heading it used |
| --- | --- |
| #728 | `## ⚠️ Behaviour change worth noting in the release notes` |
| #735 | `## ⚠️ Upgrade note` |
| #748 | `## ⚠️ Upgrade note for the release` |
| #750 | `## 🔗 Migration` |
| #759 | `## ⚠️ Breaking change for dump consumers` |
| #762 | `## ⚠️ Note for release notes` |

None of them reached a release automatically. `2026.08.21` and `2026.08.23` are the bare title list; `2026.08.15`, `.17` and `.18` carry the #748 and #735 notes **pasted in by hand**, the same block three times, because each pre-release spans back to the last full release.

## ✨ Changes

- **`.github/scripts/collect_release_notes.py`** — walks the PRs merged since `PREVIOUS_STABLE` (the tag the workflow already computes), lifts the upgrade-note section out of each body, and writes `release_notes.md`.
- **`release.yml`** — a new step before the release, and `body_path: release_notes.md` on the release itself. The action pre-pends the body to the generated notes, so the result is the layout `2026.08.18` already had: upgrade notes first, then `## What's Changed`.
- **`.github/pull_request_template.md`** — new; the repo had none. It offers the canonical `## ⚠️ Upgrade notes` heading, with the instructions in an HTML comment and a note that the text is copied verbatim into the release, so it should be written for the person installing the update.

Matching is loose on purpose — any second- or third-level heading mentioning an upgrade note, release note, breaking change, migration or behaviour change counts. Requiring one exact heading would mean all six PRs above missed.

## 🧪 Tests

16 tests, and the extractor was validated against **real data** rather than only fixtures: run over all 60 PRs merged since June it finds exactly the six above and nothing else.

That check earned its keep — it caught a false positive that would otherwise have shipped:

- **#749 wrote `## ✅ No behaviour change`** — matches the keyword while meaning the opposite. Negated headings are now skipped.

Three more details came out of the real bodies:

- **#762's section ran to the end of the PR**, so `Refs #752` and the Claude Code trailer were being swallowed → trailers are stripped.
- **The `2026.08.18` note used `###` subsections**, so a section ends only at a heading of the same or higher level.
- **An untouched template section must yield nothing** → HTML comments are stripped and an empty section is dropped, so leaving the template heading in place produces no note rather than an empty one.

Full suite 1169 passed · integration coverage still 100% · `ruff check` + `format` clean · `codespell` clean.

## 🔬 How to check it before trusting it

The `gh api` calls only run inside the workflow, but the script is runnable locally — this reproduces exactly what the next release would prepend:

```bash
GITHUB_REPOSITORY=BenPru/luxtronik PREVIOUS_STABLE=2026.08.18 GITHUB_SHA=main \
  python3 .github/scripts/collect_release_notes.py && cat release_notes.md
```

#771 is the first PR carrying the canonical heading, so it is the first one that will appear in a release automatically.

## ⚠️ Known limit

The compare API returns at most 250 commits. A release spanning more than that would silently lose the notes of its oldest PRs, so the script emits a `::warning::` in the job log rather than failing quietly. Far beyond this repo's release cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
