### PR TITLE
fix(common): 🐛 stop a single flow-rate dropout from clearing cooling

### DIFF
--- a/custom_components/luxtronik2/common.py
+++ b/custom_components/luxtronik2/common.py
@@ -402,7 +402,15 @@ def _derive_operation_mode(value: Any, coordinator: LuxtronikCoordinatorData) ->
             )
             Flow_WQ = get_sensor_data(coordinator, LC.C0173_HEAT_SOURCE_FLOW_RATE)
             Pump = get_sensor_data(coordinator, LC.C0043_PUMP_FLOW)
-            if (T_out > T_in) and (T_heat_out > T_heat_in) and (Flow_WQ > 0) and Pump:
+            # Flow rate and pump are OR-ed rather than AND-ed: either one is
+            # enough to show the machine is circulating. AND-ing them let one
+            # register veto the other, and both are seen dropping out on their
+            # own - in #773 the flow rate read 0 for a single poll while the
+            # pump stayed on, clearing cooling on roughly a fifth of all polls,
+            # and units 330612_0542, 330123_0145 and 350909_0135 in the corpus
+            # show the reverse, over 900 l/h with the pump register False. The
+            # two temperature deltas stay AND-ed: they discriminate cooling.
+            if (T_out > T_in) and (T_heat_out > T_heat_in) and ((Flow_WQ > 0) or Pump):
                 return LuxOperationMode.cooling
 
     if (

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -461,6 +461,71 @@ class TestNormalizeSensorValue:
         )
         assert result == LuxOperationMode.cooling
 
+    def test_cooling_survives_a_flow_meter_dropout(self):
+        """A single-poll zero from the heat-source flow meter must not clear cooling.
+
+        Issue #773: on a cooling unit the flow register drops to 0 for exactly
+        one poll while the pump output stays on, which flipped the status to
+        no_request on ~20% of polls. Either register is enough to show the
+        machine is circulating, so one dropping out must not clear cooling.
+        """
+        data = make_coordinator_data(
+            calculations={
+                "ID_WEB_HauptMenuStatus_Zeile3": LuxStatus3Option.heating,
+                "ID_WEB_Temperatur_TVL": 17.4,
+                "ID_WEB_Temperatur_TRL": 18.7,  # +1.3 K, house water warms up
+                "ID_WEB_Temperatur_TWE": 13.1,
+                "ID_WEB_Temperatur_TWA": 14.9,  # +1.8 K, heat source warms
+                "ID_WEB_Durchfluss_WQ": 0.0,  # C0173 dropout
+                "ID_WEB_VBOout": True,  # C0043 source pump still running
+            }
+        )
+        result = normalize_sensor_value(
+            LuxOperationMode.no_request, data, LC.C0080_STATUS
+        )
+        assert result == LuxOperationMode.cooling
+
+    def test_cooling_survives_a_lagging_pump_register(self):
+        """The mirror case: real flow while the pump register reads False.
+
+        Units 330612_0542, 330123_0145 and 350909_0135 in the diagnostics
+        corpus all report over 900 l/h with VBOout False, so the pump
+        register can drop out just as the flow register can.
+        """
+        data = make_coordinator_data(
+            calculations={
+                "ID_WEB_HauptMenuStatus_Zeile3": LuxStatus3Option.heating,
+                "ID_WEB_Temperatur_TVL": 17.4,
+                "ID_WEB_Temperatur_TRL": 18.7,
+                "ID_WEB_Temperatur_TWE": 13.1,
+                "ID_WEB_Temperatur_TWA": 14.9,
+                "ID_WEB_Durchfluss_WQ": 887.0,
+                "ID_WEB_VBOout": False,
+            }
+        )
+        result = normalize_sensor_value(
+            LuxOperationMode.no_request, data, LC.C0080_STATUS
+        )
+        assert result == LuxOperationMode.cooling
+
+    def test_cooling_needs_something_circulating(self):
+        """With neither flow nor pump there is no circulation - not cooling."""
+        data = make_coordinator_data(
+            calculations={
+                "ID_WEB_HauptMenuStatus_Zeile3": LuxStatus3Option.heating,
+                "ID_WEB_Temperatur_TVL": 17.4,
+                "ID_WEB_Temperatur_TRL": 18.7,
+                "ID_WEB_Temperatur_TWE": 13.1,
+                "ID_WEB_Temperatur_TWA": 14.9,
+                "ID_WEB_Durchfluss_WQ": 0.0,
+                "ID_WEB_VBOout": False,
+            }
+        )
+        result = normalize_sensor_value(
+            LuxOperationMode.no_request, data, LC.C0080_STATUS
+        )
+        assert result == LuxOperationMode.no_request
+
     def test_status_no_request_not_active_cooling(self):
         """If no_request + status_line3=heating but temps don't indicate cooling → stays no_request."""
         data = make_coordinator_data(


### PR DESCRIPTION
## 🔍 What this fixes

Resolves #773 — during cooling the status sensor flaps `cooling` ↔ `no_request` on roughly a fifth of all polls.

The raw status word sits at `no_request` for the whole cooling cycle on these units, so the `cooling` state comes entirely from the temperature heuristic added for #404. That heuristic AND-s four terms, two of which are the heat-source flow rate (C0173) and the pump output (C0043).

The reporter's minute-resolution history isolates the failing term: at **15 of 15** dips in one cooling cycle the flow rate reads exactly `0.0`, and it reads `0.0` at no other sample in the window — a clean 1:1 line-up — while the pump output stays on continuously and both temperature deltas hold comfortably (house side +0.9…+1.4 K, source side +1.3…+2.1 K). The flow meter drops out for a single poll; nothing about the machine's state changes.

The reverse dropout is in our own diagnostics corpus: units `330612_0542`, `330123_0145` and `350909_0135` all report over 900 l/h with the pump register `False`. Neither register is reliable enough to veto the other.

## ✨ Changes

- `common.py` — in the #404 heuristic, `(Flow_WQ > 0) and Pump` becomes `((Flow_WQ > 0) or Pump)`. Either register is enough to show the machine is circulating. The two temperature deltas stay AND-ed; they are what discriminates cooling.

Checked against the diagnostics corpus: of 80 dumps, only 2 evaluate differently, and both already return `cooling` from the earlier status-line branch — so **no dump changes verdict**. The corpus contains 15 dumps where the two registers disagree, i.e. rows where the AND and the OR genuinely differ, and none of them produces a cooling verdict either way.

## 🧪 Tests

Three new cases in `tests/test_common.py`, each failing under the old AND:

- flow rate `0.0` with the pump on → `cooling` (the #773 dropout, using the reporter's own dip-minute values)
- 887 l/h with the pump register `False` → `cooling` (the reverse dropout)
- neither running → stays `no_request`, so the term cannot be dropped entirely

Full suite: **1172 passed**, coverage unchanged at 100%. `ruff check`, `ruff format --check`, `codespell` and `basedpyright` all clean.
