### PR TITLE
fix(coordinator): 🐛 stop a decoded visibility register from killing a platform

### DIFF
--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -630,24 +630,94 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
                 )
                 return None
 
+    @staticmethod
+    def _mk_type_can_cool(value: Any) -> bool:
+        """Does a mixing-circuit type register say the circuit can cool?
+
+        It reads a raw code today, but `lux_overrides` gives parameters
+        selection datatypes as their codes become known, and the register
+        would then read "cooling" rather than 3. Unlike the visibility gate
+        that raised in #773, this comparison fails silently: it evaluates
+        False and takes the mixing-circuit entities - and, through
+        `_detect_cooling_mk`, the whole cooling device - away from every
+        affected user, with nothing in the log to say so. Accepting both
+        spellings of the same answer costs a tuple.
+        """
+        return any(
+            value == mk_type.value or value == mk_type.name
+            for mk_type in (LuxMkTypes.cooling, LuxMkTypes.heating_cooling)
+        )
+
+    def _special_visibility(self, visibility: LV | LP) -> bool | None:
+        """Decide the gates a plain numeric read cannot decide.
+
+        Two kinds live here. Flags the controller sets unreliably (solar, the
+        DHW pump pair, cooling) are detected from the registers instead. And
+        parameters that hold a *mode* rather than a flag: P1030 decodes to a
+        name like "plus_minus", so comparing it to 0 raises (#773). That one
+        is decided here and in `entity_active` through the same
+        `smart_grid_enabled` helper, so the two cannot disagree about whether
+        Smart Grid is on - note that this method only drives
+        `entity_registry_enabled_default`, while `entity_active` is what
+        decides whether an entity exists at all.
+
+        Returns None for the gates that are ordinary numeric flags.
+        """
+        if visibility in (
+            LV.V0038_SOLAR_COLLECTOR,
+            LV.V0039_SOLAR_BUFFER,
+            LV.V0250_SOLAR,
+        ):
+            return self._detect_solar_present()
+        if visibility == LV.V0059_DHW_CIRCULATION_PUMP:
+            return self._detect_dhw_circulation_pump_present()
+        if visibility == LV.V0059A_DHW_CHARGING_PUMP:
+            return not self._detect_dhw_circulation_pump_present()
+        if visibility == LV.V0005_COOLING:
+            return self.detect_cooling_present()
+        if visibility == LP.P1030_SMART_GRID_SWITCH:
+            # P1030 holds a mode, so it needs the helper rather than a
+            # truthiness test - see the note in entity_active. #765, #773
+            return smart_grid_enabled(self.data)
+        return None
+
+    def _visibility_flag_set(self, value: Any, visibility: LV | LP) -> bool:
+        """Read a visibility register as the on/off flag it is meant to be.
+
+        A register whose datatype decodes it to a name is not a flag and
+        cannot be compared to 0. Guessing what such a name means would be
+        worse than useless, so this falls open exactly as an unreadable
+        register does: one entity enabled by default is a far smaller failure
+        than the `TypeError` that aborts `async_setup_entry` and leaves the
+        whole platform without entities (#773). The gate belongs in
+        `_special_visibility`; the warning names it.
+        """
+        # bool is an int, and True/False compare against 0 as intended.
+        if isinstance(value, (int, float)):
+            return value > 0
+        if isinstance(value, str):
+            try:
+                return float(value) > 0
+            except ValueError:
+                pass
+        LOGGER.warning(
+            "Visibility %s reads %s, which is not a flag - treating the entity "
+            "as visible. This register needs its own rule in "
+            "_special_visibility.",
+            visibility,
+            value,
+        )
+        return True
+
     def entity_visible(self, description: LuxtronikEntityDescription) -> bool:
         """Is description visible."""
         if description.visibility == LV.UNSET:
             return True
         # Detecting some options based on visibilities doesn't work reliably.
         # Use special functions
-        if description.visibility in [
-            LV.V0038_SOLAR_COLLECTOR,
-            LV.V0039_SOLAR_BUFFER,
-            LV.V0250_SOLAR,
-        ]:
-            return self._detect_solar_present()
-        if description.visibility == LV.V0059_DHW_CIRCULATION_PUMP:
-            return self._detect_dhw_circulation_pump_present()
-        if description.visibility == LV.V0059A_DHW_CHARGING_PUMP:
-            return not self._detect_dhw_circulation_pump_present()
-        if description.visibility == LV.V0005_COOLING:
-            return self.detect_cooling_present()
+        special_result = self._special_visibility(description.visibility)
+        if special_result is not None:
+            return special_result
         visibility_result = self.get_value(description.visibility)
         if visibility_result is None:
             LOGGER.warning("Could not load visibility %s", description.visibility)
@@ -658,7 +728,7 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
             )
             if formula_result is not None:
                 return formula_result
-        return visibility_result > 0
+        return self._visibility_flag_set(visibility_result, description.visibility)
 
     def entity_active(self, description: LuxtronikEntityDescription) -> bool:
         """Is description activated."""
@@ -669,11 +739,7 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
             LP.P0130_MIXING_CIRCUIT2_TYPE,
             LP.P0780_MIXING_CIRCUIT3_TYPE,
         ]:
-            sensor_value = self.get_value(description.visibility)
-            return sensor_value in [
-                LuxMkTypes.cooling.value,
-                LuxMkTypes.heating_cooling.value,
-            ]
+            return self._mk_type_can_cool(self.get_value(description.visibility))
         if description.visibility in [
             LV.V0038_SOLAR_COLLECTOR,
             LV.V0039_SOLAR_BUFFER,
@@ -843,11 +909,7 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         """We iterate over the mk sensors, detect cooling and return a list of parameters that are may show cooling is enabled."""
         cooling_mk = []
         for mk_sensor in LUX_PARAMETER_MK_SENSORS:
-            sensor_value = self.get_value(mk_sensor)
-            if sensor_value in [
-                LuxMkTypes.cooling.value,
-                LuxMkTypes.heating_cooling.value,
-            ]:
+            if self._mk_type_can_cool(self.get_value(mk_sensor)):
                 cooling_mk = cooling_mk + [mk_sensor]
 
         return cooling_mk

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -562,6 +562,40 @@ class TestEntityVisible:
         desc.visibility = LV.V0059A_DHW_CHARGING_PUMP
         assert coord.entity_visible(desc) is True
 
+    def test_smart_grid_visibility_reads_the_mode(self):
+        """P1030 decodes to a mode name, not a flag, so it cannot be compared
+        to 0 - doing so raised and took the whole number platform down. #773
+        """
+        coord = _make_coordinator(parameters={"ID_Einst_SmartGrid": "plus_minus"})
+        desc = LuxtronikEntityDescription(
+            key="test",
+            visibility=LP.P1030_SMART_GRID_SWITCH,
+        )
+        assert coord.entity_visible(desc) is True
+
+    def test_smart_grid_visibility_off(self):
+        """The same gate entity_active applies, so the two cannot disagree."""
+        coord = _make_coordinator(parameters={"ID_Einst_SmartGrid": "off"})
+        desc = LuxtronikEntityDescription(
+            key="test",
+            visibility=LP.P1030_SMART_GRID_SWITCH,
+        )
+        assert coord.entity_visible(desc) is False
+
+    def test_non_numeric_visibility_value_is_visible(self):
+        """A visibility register a datatype decodes to a name must not raise.
+
+        Nothing knows what such a value means, so it falls open the same way
+        an unreadable register does - an entity enabled by default is a far
+        smaller failure than a platform that does not load at all. #773
+        """
+        coord = _make_coordinator_direct()
+        coord.get_value = MagicMock(return_value="plus_minus")
+        desc = MagicMock(spec=LuxtronikEntityDescription)
+        desc.visibility = LV.V0024_FLOW_OUT_TEMPERATURE_EXTERNAL
+        desc.visibility_formula = None
+        assert coord.entity_visible(desc) is True
+
     def test_visibility_none_returns_true(self):
         coord = _make_coordinator_direct()
         coord.get_value = MagicMock(return_value=None)
@@ -763,6 +797,22 @@ class TestEntityActive:
         desc.visibility = LP.P0042_MIXING_CIRCUIT1_TYPE
         desc.device_key = DeviceKey.heatpump
         assert coord.entity_active(desc) is False
+
+    def test_mixing_circuit_cooling_as_a_decoded_name(self):
+        """The type register may gain a datatype and decode to a name.
+
+        This comparison never raises the way the visibility gate did - it
+        would quietly evaluate False and take the three mixing-circuit
+        entities away from every affected user, which is a worse failure
+        than a crash because nothing reports it. #773
+        """
+        coord = _make_coordinator_direct()
+        coord._is_version_not_compatible = MagicMock(return_value=False)
+        coord.get_value = MagicMock(return_value=LuxMkTypes.cooling.name)
+        desc = MagicMock(spec=LuxtronikEntityDescription)
+        desc.visibility = LP.P0042_MIXING_CIRCUIT1_TYPE
+        desc.device_key = DeviceKey.heatpump
+        assert coord.entity_active(desc) is True
 
     def test_smart_grid_offsets_inactive_when_switched_off(self):
         """P1030 = 0 means the Smart Grid submenu does not exist on the
@@ -1761,6 +1811,15 @@ class TestDetectionMethods:
             parameters={
                 "ID_Einst_MK1Typ_akt": 3,  # LuxMkTypes.cooling.value
             },
+        )
+        assert coord.detect_cooling_present() is True
+
+    def test_detect_cooling_present_from_a_decoded_name(self):
+        """Same register, bigger blast radius: this one gates has_cooling,
+        so a silently False comparison removes the whole cooling device.
+        """
+        coord = _make_coordinator(
+            parameters={"ID_Einst_MK1Typ_akt": LuxMkTypes.heating_cooling.name},
         )
         assert coord.detect_cooling_present() is True
 

--- a/tests/test_entity_platforms.py
+++ b/tests/test_entity_platforms.py
@@ -397,7 +397,7 @@ class TestSmartGridOffsetEntities:
     }
 
     @staticmethod
-    def _coordinator(smart_grid: int):
+    def _coordinator(smart_grid: int | str):
         from custom_components.luxtronik2.coordinator import LuxtronikCoordinator
 
         data = make_coordinator_data(
@@ -446,6 +446,19 @@ class TestSmartGridOffsetEntities:
     async def test_created_when_smart_grid_is_on(self):
         keys = await self._setup_keys(self._coordinator(1))
         assert keys >= self._KEYS
+
+    @pytest.mark.asyncio
+    async def test_created_when_the_mode_reads_as_a_decoded_name(self):
+        """A real unit reports the name, not the code.
+
+        `SmartGridMode` decodes P1030, so `get_value` returns "plus_minus"
+        rather than 1. Comparing that to 0 raised inside the entity
+        constructor and aborted the setup of every number entity, not just
+        the three gated ones. #773
+        """
+        keys = await self._setup_keys(self._coordinator("plus_minus"))
+        assert keys >= self._KEYS
+        assert SK.DHW_TARGET_TEMPERATURE in keys
 
     @pytest.mark.asyncio
     async def test_not_created_when_smart_grid_is_off(self):

--- a/tests/test_predefined_entities.py
+++ b/tests/test_predefined_entities.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 from collections.abc import Iterator
 import importlib
 import pkgutil
+from unittest.mock import patch
 
 from packaging.version import Version
 
+from conftest import make_coordinator_data
 import custom_components.luxtronik2 as luxtronik2
 from custom_components.luxtronik2.binary_sensor_entities_predefined import (
     BINARY_SENSORS,
 )
+from custom_components.luxtronik2.const import LuxParameter, LuxVisibility
+from custom_components.luxtronik2.coordinator import LuxtronikCoordinator
 from custom_components.luxtronik2.date_entities_predefined import CALENDAR_ENTITIES
 from custom_components.luxtronik2.model import LuxtronikEntityDescription
 from custom_components.luxtronik2.number_entities_predefined import NUMBER_SENSORS
@@ -176,5 +180,61 @@ class TestFirmwareVersionFields:
             for descr in descriptions
             for name in ("min_firmware_version", "max_firmware_version")
             if (value := getattr(descr, name, None)) is not None
+        ]
+        assert offenders == []
+
+
+class TestVisibilityGates:
+    """Every gate must survive the value its register actually reports."""
+
+    def test_no_parameter_gate_breaks_on_a_decoded_value(self):
+        """A parameter used as a visibility gate may decode to a name.
+
+        `lux_overrides` gives selection datatypes to parameters as their codes
+        become known, and such a register then reads "plus_minus" rather than
+        1. A gate that assumes a number raises `TypeError` from the entity
+        constructor, which aborts `async_setup_entry` for the whole platform:
+        that is how #773 lost every number entity, not just the three gated
+        ones. Visibility flags themselves are always numeric; parameters are
+        the ones that can change type under us, so they are what this sweeps.
+        """
+        gated = [
+            descr
+            for descr in _all_descriptions()
+            if isinstance(descr.visibility, LuxParameter)
+        ]
+        # Guard the guard: no parameter gates left means nothing was checked.
+        assert gated
+
+        coord = object.__new__(LuxtronikCoordinator)
+        coord.data = make_coordinator_data(
+            parameters={"ID_Einst_SmartGrid": "plus_minus"}
+        )
+        with patch.object(LuxtronikCoordinator, "get_value", return_value="plus_minus"):
+            for descr in gated:
+                assert isinstance(coord.entity_visible(descr), bool), descr.key
+
+    def test_no_description_pairs_a_special_gate_with_a_formula(self):
+        """`_special_visibility` answers before `visibility_formula` is read.
+
+        That early return is deliberate - the special gates exist precisely
+        because their register cannot be read at face value - but it means a
+        formula written against one of those keys would be silently ignored.
+        Nothing does that today; this fails the moment something starts to.
+        """
+        offenders = [
+            (type(descr).__name__, descr.key)
+            for descr in _all_descriptions()
+            if descr.visibility_formula is not None
+            and descr.visibility
+            in (
+                LuxVisibility.V0038_SOLAR_COLLECTOR,
+                LuxVisibility.V0039_SOLAR_BUFFER,
+                LuxVisibility.V0250_SOLAR,
+                LuxVisibility.V0059_DHW_CIRCULATION_PUMP,
+                LuxVisibility.V0059A_DHW_CHARGING_PUMP,
+                LuxVisibility.V0005_COOLING,
+                LuxParameter.P1030_SMART_GRID_SWITCH,
+            )
         ]
         assert offenders == []


### PR DESCRIPTION
## 🔍 What this fixes

Since **2026.08.27**, every user whose heat pump has Smart Grid switched on loses the **entire `number` platform** — DHW hysteresis, heating curves, all of it. Reported by @onsmam in #773:

```
Error while setting up luxtronik2 platform for number:
'>' not supported between instances of 'str' and 'int'
  number.py, line 63, in async_setup_entry
  base.py, line 82, in __init__
    entity_registry_enabled_default=coordinator.entity_visible(description)
  coordinator.py, line 661, in entity_visible
    return visibility_result > 0
TypeError
```

Two changes that were each fine in isolation collided:

1. 40ec59e added three number entities gated on `visibility=LP.P1030_SMART_GRID_SWITCH`, when P1030 was upstream `Unknown` and `get_value()` returned an **int**.
2. 4a03b79 gave P1030 the `SmartGridMode` selection datatype, so it now reads **`"plus_minus"`**.

`entity_visible` ended in an unguarded `visibility_result > 0`. The `TypeError` escapes the list comprehension in `async_setup_entry`, so HA aborts setup of the whole platform — not just the three gated entities.

It only bites units with Smart Grid **on**, because `entity_active` already special-cased P1030 and never builds the entities when it is off. 25 of the 29 pumps in the diagnostics corpus are in that state, which is why it took two releases to surface. `git tag --contains 4a03b79` → `2026.08.27`, `2026.08.28`, matching the reporter's own bisection exactly.

## ✨ Changes

All in `coordinator.py`:

- **`_visibility_flag_set()`** replaces the bare `visibility_result > 0`. Numbers and numeric strings compare against 0; anything else logs a warning naming the register and returns `True` — falling open exactly as an unreadable register already did. This is the structural part: no future datatype change can abort a platform setup again.
- **`_special_visibility()`** collects the gates a numeric read cannot decide — solar, the DHW pump pair, cooling — which were inlined in `entity_visible`, and adds the missing P1030 rule via `smart_grid_enabled()`, the same helper `entity_active` uses. The two can no longer disagree about whether Smart Grid is on.
- **`_mk_type_can_cool()`** hardens the mixing-circuit type comparison the same way, shared by `entity_active` and `_detect_cooling_mk`. Found during review: that comparison never raises — it would quietly evaluate `False` and take the mixing-circuit entities *and the whole cooling device* away from affected users, with nothing in the log. A silent disappearance is worse than a crash.

No change to which entities existing users get. `entity_visible` only drives `entity_registry_enabled_default`; for P1030-gated numbers the old path computed `get_value(P1030) > 0` and the new one computes `smart_grid_enabled()` — same answer whenever the entity exists at all.

## 🧪 Tests

Written test-first; each was watched failing against the pre-fix code.

- `test_entity_platforms.py::TestSmartGridOffsetEntities::test_created_when_the_mode_reads_as_a_decoded_name` — drives the **real** `number.async_setup_entry` with P1030 reading `"plus_minus"`, and asserts the *unrelated* `DHW_TARGET_TEMPERATURE` survives too. This is the user-facing bug. The existing #765 tests missed it because they feed the raw code `1`, which pre-dates the datatype.
- `test_predefined_entities.py::TestVisibilityGates` — sweeps **every** predefined description gated on a `LuxParameter` and asserts `entity_visible` returns a bool when the register decodes to a name. This is the net that catches the next occurrence, on any platform. A second case pins that no description pairs a special gate with a `visibility_formula`, which `_special_visibility` would silently bypass.
- `test_coordinator.py` — P1030 on/off, a non-numeric value on an ordinary gate, plus two mixing-circuit cases that failed with a silent `assert False is True` before the shared helper.

```
1180 passed
TOTAL 3647  0  100%   coverage held (baseline was also 100%)
ruff check / ruff format --check / codespell: clean
basedpyright: 0 errors, 0 warnings, 0 notes
```

Reviewed before opening: verdict "ready to merge", one Important finding (the unhardened `entity_active` sibling) — fixed above and broadened, since the reviewer had not spotted the `_detect_cooling_mk` copy.

## ⚠️ Upgrade notes

If you run Smart Grid and installed 2026.08.27 or 2026.08.28, your number entities (hot water hysteresis, heating curves, Smart Grid offsets) will have vanished from Home Assistant. They come back by themselves on this release — no manual step, nothing to re-add. Any automation or dashboard card that referenced them starts working again as soon as the entities return.

Refs #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)
