### PR TITLE
chore(coordinator): 🔧 parent the sub-devices with via_device_id

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13", "3.14"]
+        # 3.14 only: Home Assistant requires Python >=3.14.2 from 2026.7 onwards,
+        # so a 3.13 job resolves back to HA 2026.2 - below the 2026.8 minimum this
+        # integration declares in hacs.json, and a combination no user can run.
+        python-version: ["3.14"]
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ It is used by manufacturers such as:
 - Nibe, 
 - Wolf Heiztechnik.
 
+> **ℹ️ Home Assistant version:** this integration requires **Home Assistant 2026.8 or newer**. HACS will simply not offer you a newer release on an older core, so nothing breaks if you stay behind — you keep the release you have until you update Home Assistant. If you install manually instead of through HACS, note that releases after [2026.08.29](https://github.com/BenPru/luxtronik/releases/tag/2026.08.29) will fail to set up on Home Assistant 2026.7 or older; that release is the last one supporting those versions.
+
 
 ---
 

--- a/custom_components/luxtronik2/__init__.py
+++ b/custom_components/luxtronik2/__init__.py
@@ -81,11 +81,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: LuxtronikConfigEntry) ->
     if entry.unique_id is None:
         hass.config_entries.async_update_entry(entry, unique_id=coordinator.unique_id)
 
-    # Prune device-registry entries that no longer match this device's model
-    # (see I10 follow-up) - moved here from async_migrate_entry so a stale
-    # entry doesn't need a live connection just to migrate. `get_device()`
-    # ensures device_infos is populated before pruning against it.
-    coordinator.get_device()
+    # Registers the physical device and populates `device_infos`: the heat pump
+    # has to exist in the registry before the sub-devices can reference it by
+    # `via_device_id`, and pruning below needs the map to prune against.
+    #
+    # Pruning removes device-registry entries that no longer match this
+    # device's model (see I10 follow-up) - moved here from async_migrate_entry
+    # so a stale entry doesn't need a live connection just to migrate.
+    coordinator.async_register_devices()
     await _async_delete_legacy_devices(hass, entry, coordinator)
     await _async_remove_legacy_smart_grid_switch(hass, entry)
 

--- a/custom_components/luxtronik2/coordinator.py
+++ b/custom_components/luxtronik2/coordinator.py
@@ -13,8 +13,9 @@ from typing import Any, Final
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
@@ -383,31 +384,66 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
         config: Mapping[str, Any],
     ):
         host = config[CONF_HOST]
-        self.device_infos[DeviceKey.heatpump] = self._build_device_info(
-            DeviceKey.heatpump, host
-        )
-        via = (
-            DOMAIN,
-            f"{self.unique_id}_{DeviceKey.heatpump}".lower(),
-        )
-        self.device_infos[DeviceKey.heating] = self._build_device_info(
-            DeviceKey.heating, host, via
-        )
-        self.device_infos[DeviceKey.domestic_water] = self._build_device_info(
-            DeviceKey.domestic_water, host, via
-        )
-        self.device_infos[DeviceKey.cooling] = self._build_device_info(
-            DeviceKey.cooling, host, via
-        )
-        self.device_infos[DeviceKey.ventilation] = self._build_device_info(
-            DeviceKey.ventilation, host, via
+        heatpump = self._build_device_info(DeviceKey.heatpump, host)
+        heatpump_device_id = self._register_heatpump(hass, heatpump)
+        # Built as one map and assigned in a single step: `__init__` prunes the
+        # device registry against `device_infos`, so a half-filled map would
+        # read as "these devices are gone".
+        device_infos = {DeviceKey.heatpump: heatpump}
+        for key in (
+            DeviceKey.heating,
+            DeviceKey.domestic_water,
+            DeviceKey.cooling,
+            DeviceKey.ventilation,
+        ):
+            device_infos[key] = self._build_device_info(key, host, heatpump_device_id)
+        self.device_infos = device_infos
+
+    @callback
+    def async_register_devices(self) -> None:
+        """Register the physical device and build every device info.
+
+        Registering the heat pump is what lets the sub-devices reference it by
+        `via_device_id`, so it has to happen before the platforms are set up.
+        `get_device()` would do it lazily on first use, but that would put a
+        device registry write inside an entity constructor; calling this from
+        `async_setup_entry` keeps the write on an explicit, loop-only path.
+        """
+        self._create_device_infos(self.hass, self._config)
+
+    def _register_heatpump(
+        self,
+        hass: HomeAssistant,
+        heatpump: DeviceInfo,
+    ) -> str | None:
+        """Register the physical unit and return its device registry id.
+
+        The sub-devices are linked to it with `via_device_id`, which is a
+        registry id rather than an identifier tuple, so the heat pump has to be
+        registered before they are built - entity setup is too late.
+
+        Returns `None` when there is no config entry to own the device, which
+        leaves the sub-devices unparented. No production path reaches that:
+        `config_flow` does build entry-less coordinators to probe a connection,
+        but it only ever reads `unique_id` from them. The branch is kept as the
+        safe fallback for that shape rather than as a case that happens.
+        """
+        if self.config_entry is None:
+            return None
+        # Only main-device keys may be splatted here: `async_get_or_create`
+        # rejects unexpected keyword arguments, and `DeviceInfo` has grown
+        # child-device keys that `entity_platform` strips before its own call.
+        return (
+            dr.async_get(hass)
+            .async_get_or_create(config_entry_id=self.config_entry.entry_id, **heatpump)
+            .id
         )
 
     def _build_device_info(
         self,
         key: DeviceKey,
         host: str,
-        via_device: tuple[str, str] | None = None,
+        via_device_id: str | None = None,
     ) -> DeviceInfo:
         device_info = DeviceInfo(
             identifiers={
@@ -425,18 +461,19 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
             hw_version=None,
             manufacturer=self.manufacturer,
         )
-        if via_device is not None:
-            device_info["via_device"] = via_device
-        else:
+        if key is DeviceKey.heatpump:  # the root device
             # Only the physical unit carries the serial: heating, domestic
             # water and cooling are logical sub-devices of the same heat pump
-            # (they are the ones passing `via_device`), and repeating the
-            # serial on each would read as several units sharing one serial.
+            # (they are the ones parented by `via_device_id`), and repeating
+            # the serial on each would read as several units sharing one
+            # serial.
             #
             # Rendered as `unique_id` rather than `serial_number` so it matches
             # the string `config_flow` prints when a second config entry
             # collides on this serial.
             device_info["serial_number"] = self.unique_id
+        if via_device_id is not None:
+            device_info["via_device_id"] = via_device_id
         return device_info
 
     def _is_version_not_compatible(

--- a/custom_components/luxtronik2/diagnostics.py
+++ b/custom_components/luxtronik2/diagnostics.py
@@ -29,7 +29,6 @@ TO_REDACT = {
     "unique_id",
     "serial_number",
     "identifiers",
-    "via_device",
     "configuration_url",
 }
 

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
     "zip_release": true,
     "filename": "luxtronik2.zip",
     "render_readme": true,
-    "homeassistant": "2025.6.0"
+    "homeassistant": "2026.8.0"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,10 +8,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from packaging.version import Version
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from conftest import make_coordinator_data
 from custom_components.luxtronik2.const import (
@@ -2201,3 +2204,111 @@ class TestDhwTransitionHold:
             self._data(LuxOperationMode.no_request, recirculation=True)
         )
         assert coord._dhw_hold_until == deadline
+
+
+class TestCoordinatorSubDeviceParenting:
+    """The four logical sub-devices hang off the physical heat pump device."""
+
+    @staticmethod
+    def _coordinator_with_entry(hass) -> tuple[LuxtronikCoordinator, ConfigEntry]:
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_HOST: "192.168.1.100", CONF_PORT: DEFAULT_PORT},
+        )
+        entry.add_to_hass(hass)
+        coord = _make_coordinator(
+            hass=hass,
+            calculations={
+                "ID_WEB_SoftStand": "V3.90.1",
+                "ID_WEB_Code_WP_akt": "LWP 10",
+            },
+            parameters={
+                "ID_WP_SerienNummer_DATUM": 20230101,
+                "ID_WP_SerienNummer_HEX": 255,
+            },
+        )
+        coord.config_entry = entry
+        return coord, entry
+
+    async def test_sub_device_links_to_the_heatpump_by_registry_id(
+        self, hass: HomeAssistant
+    ) -> None:
+        """`via_device_id` carries the heat pump's registry id."""
+        coord, entry = self._coordinator_with_entry(hass)
+
+        heating = coord.get_device(DeviceKey.heating)
+
+        heatpump = dr.async_get(hass).async_get_device_by_identifier(
+            (DOMAIN, f"{coord.unique_id}_{DeviceKey.heatpump}".lower()),
+            entry.entry_id,
+        )
+        assert heatpump is not None
+        assert heating["via_device_id"] == heatpump.id
+
+    async def test_sub_device_does_not_use_the_deprecated_via_device(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The identifier-tuple form was removed from `DeviceInfo` in HA 2026.9."""
+        coord, _entry = self._coordinator_with_entry(hass)
+
+        for key in (
+            DeviceKey.heating,
+            DeviceKey.domestic_water,
+            DeviceKey.cooling,
+            DeviceKey.ventilation,
+        ):
+            assert "via_device" not in coord.get_device(key)
+
+    async def test_the_heatpump_itself_is_not_parented(
+        self, hass: HomeAssistant
+    ) -> None:
+        """The physical unit is the root; it carries the serial instead."""
+        coord, _entry = self._coordinator_with_entry(hass)
+
+        heatpump = coord.get_device(DeviceKey.heatpump)
+
+        assert "via_device_id" not in heatpump
+        assert heatpump["serial_number"] == coord.unique_id
+
+    async def test_an_existing_heatpump_device_is_adopted_not_duplicated(
+        self, hass: HomeAssistant
+    ) -> None:
+        """Upgrades keep the device users already have.
+
+        Before this migration the heat pump device was created by
+        `entity_platform` from the identifier tuple. Registering it explicitly
+        has to find that same device, not add a second one beside it.
+        """
+        coord, entry = self._coordinator_with_entry(hass)
+        registry = dr.async_get(hass)
+        existing = registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, f"{coord.unique_id}_{DeviceKey.heatpump}".lower())},
+        )
+
+        heating = coord.get_device(DeviceKey.heating)
+
+        assert heating["via_device_id"] == existing.id
+        assert len(dr.async_entries_for_config_entry(registry, entry.entry_id)) == 1
+
+    async def test_sub_devices_survive_without_a_config_entry(
+        self, hass: HomeAssistant
+    ) -> None:
+        """`config_flow` builds entry-less coordinators; that must not raise."""
+        coord = _make_coordinator(
+            hass=hass,
+            calculations={
+                "ID_WEB_SoftStand": "V3.90.1",
+                "ID_WEB_Code_WP_akt": "LWP 10",
+            },
+            parameters={
+                "ID_WP_SerienNummer_DATUM": 20230101,
+                "ID_WP_SerienNummer_HEX": 255,
+            },
+        )
+        assert coord.config_entry is None
+
+        heating = coord.get_device(DeviceKey.heating)
+
+        assert "via_device_id" not in heating
+        assert "serial_number" not in heating

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -184,8 +184,13 @@ class TestRedactLogRecords:
 
     @pytest.mark.asyncio
     async def test_device_identifiers_are_redacted(self):
-        """M9: device identifiers/via_device/configuration_url embed the
-        serial number and host, and must be redacted like core integrations."""
+        """M9: device identifiers/configuration_url embed the serial number
+        and host, and must be redacted like core integrations.
+
+        `via_device_id` is a device registry id, which carries neither, so it
+        stays readable: it is what shows the sub-devices hang off the heat
+        pump.
+        """
         from custom_components.luxtronik2.diagnostics import (
             async_get_config_entry_diagnostics,
         )
@@ -211,7 +216,7 @@ class TestRedactLogRecords:
             },
             "heating": {
                 "identifiers": {("luxtronik2", "20230101_0xff_heating")},
-                "via_device": ("luxtronik2", "20230101_0xff_heatpump"),
+                "via_device_id": "0123456789abcdef0123456789abcdef",
                 "name": "heating",
             },
         }
@@ -227,7 +232,10 @@ class TestRedactLogRecords:
         assert result["devices"]["heatpump"]["identifiers"] == REDACTED
         assert result["devices"]["heatpump"]["configuration_url"] == REDACTED
         assert result["devices"]["heating"]["identifiers"] == REDACTED
-        assert result["devices"]["heating"]["via_device"] == REDACTED
+        assert (
+            result["devices"]["heating"]["via_device_id"]
+            == "0123456789abcdef0123456789abcdef"
+        )
         # Non-sensitive fields must survive untouched
         assert result["devices"]["heatpump"]["name"] == "heatpump"
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -710,7 +710,7 @@ class TestAsyncSetupEntry:
 
         coordinator = MagicMock()
         coordinator.manufacturer = "Alpha Innotec"
-        coordinator.get_device = MagicMock()
+        coordinator.async_register_devices = MagicMock()
         coordinator.async_config_entry_first_refresh = AsyncMock()
 
         with (
@@ -727,7 +727,9 @@ class TestAsyncSetupEntry:
             result = await async_setup_entry(hass, entry)
 
         assert result is True
-        coordinator.get_device.assert_called_once()
+        # Registration must happen before pruning: pruning compares the
+        # registry against `device_infos`, which registration fills in.
+        coordinator.async_register_devices.assert_called_once()
         mock_prune.assert_awaited_once_with(hass, entry, coordinator)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## 🔧 What changed

The four logical sub-devices (heating, domestic water, cooling, ventilation) are now parented to the physical heat pump with `via_device_id` — the device registry id — instead of the deprecated `via_device` identifier tuple.

The heat pump is registered explicitly in `async_setup_entry` via a new `LuxtronikCoordinator.async_register_devices()`, because `via_device_id` needs the parent to exist in the registry before the children are built. That also keeps the registry write on an explicit, loop-only path instead of hiding it inside `get_device()`, which is called from an entity constructor.

## ❓ Why now

Home Assistant 2026.8 added `via_device_id` and deprecated `via_device`; 2026.9 removed `via_device` from the `DeviceInfo` `TypedDict` entirely, which makes the old assignment a **basedpyright error** as soon as `homeassistant-stubs` reaches 2026.9. The tuple form is also ambiguous now that device identifiers are only unique per config entry.

Supporting both keys behind a runtime capability check was considered and **rejected**: `tests/requirements-dev.txt` pins no Home Assistant version and both CI legs install the current release, so a `< 2026.8` branch could never be executed — permanently uncovered code in a repo that enforces 100% coverage.

So `hacs.json` now declares `"homeassistant": "2026.8.0"`. HACS gates per release, reading the `hacs.json` of the version being downloaded, so anyone on an older core simply keeps [2026.08.29](https://github.com/BenPru/luxtronik/releases/tag/2026.08.29) and stops being offered updates — nothing breaks for them. That release has been marked as the last one supporting HA ≤ 2026.7, and the README now states the requirement for manual installs, which HACS does not gate.

## 📦 Also in here

- `diagnostics.py`: dropped the now-dead `"via_device"` from `TO_REDACT`. A registry id is a random hex string; the tuple it replaces embedded the serial number, which is why it was redacted.
- `device_infos` is built as one map and assigned in a single step — `_async_delete_legacy_devices` prunes against it, so a half-filled map would read as "these devices are gone".

## ✅ Verification

Full gate green: **1205 tests pass**, coverage stays at **100%**, basedpyright **0 errors** (the `via_device` type error is gone), ruff check + format and codespell clean.

Verified on a live install as well — Home Assistant 2026.9.0b4, Container install, with a device registry that already held the four devices created the old way:

```
name=WP           ident=..._heatpump        via_device_id=None      serial_number=260126_0477
name=Verw         ident=..._heating         via_device_id=1ee1938e  parent=WP
name=Warmwater    ident=..._domestic_water  via_device_id=1ee1938e  parent=WP
name=Koel         ident=..._cooling         via_device_id=1ee1938e  parent=WP
```

Four devices, not eight, and the user-assigned names survived — `name_by_user` lives on the device record, so the existing devices were adopted rather than recreated. The deprecation warnings the integration emitted on 2026.9 are gone.

## 🧪 Tests

`TestCoordinatorSubDeviceParenting` covers the parenting id, the absence of the deprecated key on all four sub-devices, the heat pump staying unparented while keeping the serial, adoption of an already-registered heat pump without duplication, and the entry-less coordinator the config flow builds.

Resolves #770 (item 1). Item 2 — `DeviceEntry.config_entries` in `_resolve_write_target` — is untouched and still works through Home Assistant's compatibility shim, with runway to 2027.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
