### PR TITLE
feat(lux_overrides): ✨ decode switchoff code 26

### DIFF
--- a/custom_components/luxtronik2/const.py
+++ b/custom_components/luxtronik2/const.py
@@ -338,7 +338,7 @@ class LuxSwitchoffReason(Enum):
     min_heat_source_out_cooling = 23
     LPC = 24  # upstream's guess: possibly "limit power consumption"
     restart = 25
-    undefined_26 = 26  # ???
+    maximum_return_temperature_increase = 26
     maximum_flow_temperature = 27
     undefined_28 = 28  # ???
     undefined_29 = 29  # ???

--- a/custom_components/luxtronik2/lux_overrides.py
+++ b/custom_components/luxtronik2/lux_overrides.py
@@ -602,10 +602,21 @@ def update_Luxtronik_SwitchoffCodes():
         23: "min. heat source out cooling",
         24: "LPC",
         25: "restart",
-        # 27 is not in upstream's table: read off an HMD2 display, whose
-        # "Abschaltungen" log showed "Aanvoer max." for the same timestamps the
-        # switchoff history reported 27 (confirmed against a run that stopped
-        # at 66.0 degrees flow and resumed two minutes later).
+        # 26 and 27 are not in upstream's table. Both were read off an HMD2
+        # display, whose "Abschaltungen" log lines were matched to the
+        # switchoff history by timestamp.
+        #
+        # 26 showed "max. return increase" (EN) / "TR Verhoging max" (NL),
+        # which the HMD2 manual (83055600 rev d, p22) defines as the maximum
+        # permitted overshoot of the return temperature: once the return runs
+        # that far above its setpoint the controller ignores its internal
+        # minimum run times and switches every heat generator off.
+        # The logged event fits: a heating request started 5 minutes after a
+        # DHW run with the return still at ~51 degrees and ran for 30 seconds.
+        26: "maximum return temperature increase",
+        # 27 showed "Aanvoer max." for the same timestamps the switchoff
+        # history reported 27 (confirmed against a run that stopped at 66.0
+        # degrees flow and resumed two minutes later).
         27: "maximum flow temperature",
     }
 

--- a/custom_components/luxtronik2/lux_overrides.py
+++ b/custom_components/luxtronik2/lux_overrides.py
@@ -606,7 +606,8 @@ def update_Luxtronik_SwitchoffCodes():
         # display, whose "Abschaltungen" log lines were matched to the
         # switchoff history by timestamp.
         #
-        # 26 showed "max. return increase" (EN) / "TR Verhoging max" (NL),
+        # 26 showed "max. return increase" (EN) / "TR Verhoging max" (NL) /
+        # "TR Erh max" (DE, expanded to "TR Erhöhung max" in de.json),
         # which the HMD2 manual (83055600 rev d, p22) defines as the maximum
         # permitted overshoot of the return temperature: once the return runs
         # that far above its setpoint the controller ignores its internal

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -610,6 +610,7 @@
                     "23": "Minimální výstupní teplota zdroje tepla při chlazení",
                     "24": "LPC",
                     "25": "Restart",
+                    "26": "Maximální zvýšení teploty zpátečky",
                     "27": "Maximální teplota výstupu"
                 },
                 "state_attributes": {
@@ -645,6 +646,7 @@
                             "23": "Minimální výstupní teplota zdroje tepla při chlazení",
                             "24": "LPC",
                             "25": "Restart",
+                            "26": "Maximální zvýšení teploty zpátečky",
                             "27": "Maximální teplota výstupu"
                         }
                     },
@@ -680,6 +682,7 @@
                             "23": "Minimální výstupní teplota zdroje tepla při chlazení",
                             "24": "LPC",
                             "25": "Restart",
+                            "26": "Maximální zvýšení teploty zpátečky",
                             "27": "Maximální teplota výstupu"
                         }
                     },
@@ -715,6 +718,7 @@
                             "23": "Minimální výstupní teplota zdroje tepla při chlazení",
                             "24": "LPC",
                             "25": "Restart",
+                            "26": "Maximální zvýšení teploty zpátečky",
                             "27": "Maximální teplota výstupu"
                         }
                     },
@@ -750,6 +754,7 @@
                             "23": "Minimální výstupní teplota zdroje tepla při chlazení",
                             "24": "LPC",
                             "25": "Restart",
+                            "26": "Maximální zvýšení teploty zpátečky",
                             "27": "Maximální teplota výstupu"
                         }
                     },

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -610,6 +610,7 @@
                     "23": "Minimale Wärmequellen-Austrittstemperatur Kühlung",
                     "24": "LPC",
                     "25": "Neustart",
+                    "26": "TR Erhöhung max",
                     "27": "Vorlauf max."
                 },
                 "state_attributes": {
@@ -645,6 +646,7 @@
                             "23": "Minimale Wärmequellen-Austrittstemperatur Kühlung",
                             "24": "LPC",
                             "25": "Neustart",
+                            "26": "TR Erhöhung max",
                             "27": "Vorlauf max."
                         }
                     },
@@ -680,6 +682,7 @@
                             "23": "Minimale Wärmequellen-Austrittstemperatur Kühlung",
                             "24": "LPC",
                             "25": "Neustart",
+                            "26": "TR Erhöhung max",
                             "27": "Vorlauf max."
                         }
                     },
@@ -715,6 +718,7 @@
                             "23": "Minimale Wärmequellen-Austrittstemperatur Kühlung",
                             "24": "LPC",
                             "25": "Neustart",
+                            "26": "TR Erhöhung max",
                             "27": "Vorlauf max."
                         }
                     },
@@ -750,6 +754,7 @@
                             "23": "Minimale Wärmequellen-Austrittstemperatur Kühlung",
                             "24": "LPC",
                             "25": "Neustart",
+                            "26": "TR Erhöhung max",
                             "27": "Vorlauf max."
                         }
                     },

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -610,6 +610,7 @@
                     "23": "Minimum heat source outlet cooling",
                     "24": "LPC",
                     "25": "Restart",
+                    "26": "Maximum return temperature increase",
                     "27": "Maximum flow temperature"
                 },
                 "state_attributes": {
@@ -645,6 +646,7 @@
                             "23": "Minimum heat source outlet cooling",
                             "24": "LPC",
                             "25": "Restart",
+                            "26": "Maximum return temperature increase",
                             "27": "Maximum flow temperature"
                         }
                     },
@@ -680,6 +682,7 @@
                             "23": "Minimum heat source outlet cooling",
                             "24": "LPC",
                             "25": "Restart",
+                            "26": "Maximum return temperature increase",
                             "27": "Maximum flow temperature"
                         }
                     },
@@ -715,6 +718,7 @@
                             "23": "Minimum heat source outlet cooling",
                             "24": "LPC",
                             "25": "Restart",
+                            "26": "Maximum return temperature increase",
                             "27": "Maximum flow temperature"
                         }
                     },
@@ -750,6 +754,7 @@
                             "23": "Minimum heat source outlet cooling",
                             "24": "LPC",
                             "25": "Restart",
+                            "26": "Maximum return temperature increase",
                             "27": "Maximum flow temperature"
                         }
                     },

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -610,6 +610,7 @@
                     "23": "Minimale uittredetemperatuur warmtebron koeling",
                     "24": "LPC",
                     "25": "Herstart",
+                    "26": "TR Verhoging max",
                     "27": "Aanvoer max."
                 },
                 "state_attributes": {
@@ -645,6 +646,7 @@
                             "23": "Minimale uittredetemperatuur warmtebron koeling",
                             "24": "LPC",
                             "25": "Herstart",
+                            "26": "TR Verhoging max",
                             "27": "Aanvoer max."
                         }
                     },
@@ -680,6 +682,7 @@
                             "23": "Minimale uittredetemperatuur warmtebron koeling",
                             "24": "LPC",
                             "25": "Herstart",
+                            "26": "TR Verhoging max",
                             "27": "Aanvoer max."
                         }
                     },
@@ -715,6 +718,7 @@
                             "23": "Minimale uittredetemperatuur warmtebron koeling",
                             "24": "LPC",
                             "25": "Herstart",
+                            "26": "TR Verhoging max",
                             "27": "Aanvoer max."
                         }
                     },
@@ -750,6 +754,7 @@
                             "23": "Minimale uittredetemperatuur warmtebron koeling",
                             "24": "LPC",
                             "25": "Herstart",
+                            "26": "TR Verhoging max",
                             "27": "Aanvoer max."
                         }
                     },

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -610,6 +610,7 @@
                     "23": "Minimalna temperatura wylotowa dolnego źródła przy chłodzeniu",
                     "24": "LPC",
                     "25": "Restart",
+                    "26": "Maksymalny wzrost temperatury powrotu",
                     "27": "Maksymalna temperatura zasilania"
                 },
                 "state_attributes": {
@@ -645,6 +646,7 @@
                             "23": "Minimalna temperatura wylotowa dolnego źródła przy chłodzeniu",
                             "24": "LPC",
                             "25": "Restart",
+                            "26": "Maksymalny wzrost temperatury powrotu",
                             "27": "Maksymalna temperatura zasilania"
                         }
                     },
@@ -680,6 +682,7 @@
                             "23": "Minimalna temperatura wylotowa dolnego źródła przy chłodzeniu",
                             "24": "LPC",
                             "25": "Restart",
+                            "26": "Maksymalny wzrost temperatury powrotu",
                             "27": "Maksymalna temperatura zasilania"
                         }
                     },
@@ -715,6 +718,7 @@
                             "23": "Minimalna temperatura wylotowa dolnego źródła przy chłodzeniu",
                             "24": "LPC",
                             "25": "Restart",
+                            "26": "Maksymalny wzrost temperatury powrotu",
                             "27": "Maksymalna temperatura zasilania"
                         }
                     },
@@ -750,6 +754,7 @@
                             "23": "Minimalna temperatura wylotowa dolnego źródła przy chłodzeniu",
                             "24": "LPC",
                             "25": "Restart",
+                            "26": "Maksymalny wzrost temperatury powrotu",
                             "27": "Maksymalna temperatura zasilania"
                         }
                     },

--- a/tests/test_lux_overrides.py
+++ b/tests/test_lux_overrides.py
@@ -516,6 +516,7 @@ class TestSwitchoffCodes:
         assert item.from_heatpump(3) == "evu lock"
         assert item.from_heatpump(11) == "flow rate"
         assert item.from_heatpump(25) == "restart"
+        assert item.from_heatpump(26) == "maximum return temperature increase"
         assert item.from_heatpump(27) == "maximum flow temperature"
 
     def test_every_code_is_named_and_translated(self):
@@ -545,8 +546,8 @@ class TestSwitchoffCodes:
         """Codes past the observed ones stay undocumented - keep asking for reports."""
         lux_overrides.update_Luxtronik_SwitchoffCodes()
         lux_overrides.warn_on_unknown_selection_codes()
-        assert SwitchoffFile("ID_WEB_Switchoff_file_Nr1").from_heatpump(26) is None
-        assert "26" in caplog.text
+        assert SwitchoffFile("ID_WEB_Switchoff_file_Nr1").from_heatpump(28) is None
+        assert "28" in caplog.text
 
     def test_nonzero_unknown_on_sentinel_class_still_warns(
         self, restore_selection_base, caplog


### PR DESCRIPTION
## 🔍 What

Teaches the integration switchoff code **26 — maximum return temperature increase**. Until now a controller reporting it produced a stateless `switchoff_reason` entity plus the integration's "please report it" warning:

```
Heat pump reported code 26 for register 'ID_WEB_Switchoff_file_Nr3' (SwitchoffFile),
which this integration cannot decode - the matching entity will have no state.
```

Neither the pinned `luxtronik` 0.3.14 (codes 1-9) nor upstream `main` (up to 25) knows this code.

## 🔬 How it was decoded

Same method as code 27: the controller's own **Info → Abschaltungen** log was read off the display and matched to the `switchoff_reason` sensor's timestamp attributes.

| slot | code | timestamp (local) | display line |
|---|---|---|---|
| 0 | 27 | 30-08 14:40:33 | `max. flow temp.` / `Vorlauf max.` |
| 1 | **26** | **30-08 12:11:06** | **`max. return increase` / `TR Verhoging max` / `TR Erh max`** |
| 2 | 17 | 30-08 12:05:51 | `stop` / `Halt` |

The HMD2 manual (doc `83055600` rev d, p22) defines that setting as the maximum permitted overshoot of the return temperature — once the return runs that far above its setpoint the controller ignores its internal minimum run times and switches every heat generator off.

The logged event fits: a heating request started five minutes after a DHW run with the return still at ~51 °C, and was aborted after 30 seconds.

## 📝 Changes

- `lux_overrides.py` — `26: "maximum return temperature increase"` in the overridden `SwitchoffFile.codes`, with the provenance comment the file's other non-upstream entries carry (display strings in all three languages, manual citation, observed event). Code 27's own provenance is preserved verbatim.
- `const.py` — `undefined_26 = 26  # ???` → `maximum_return_temperature_increase = 26`.
- `translations/{en,de,nl,cs,pl}.json` — new `switchoff_reason` state in all five files, all five repeated blocks each. `de`/`nl` follow the controller display strings (as code 27 does); `en`/`cs`/`pl` use expanded wording.
- `tests/test_lux_overrides.py` — assert 26 decodes; the "still warns on undecodable codes" test moves to code 28, which is genuinely absent from the table.

## ✅ Verification

- `pytest` — 1205 passed, coverage 100 % (no regression)
- `ruff check` / `ruff format --check` clean, `codespell` clean, `basedpyright` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)