### PR TITLE
fix(update): 🐛 pin download portal CA chain and quiet portal outages

### DIFF
--- a/.github/workflows/portal-tls-watch.yml
+++ b/.github/workflows/portal-tls-watch.yml
@@ -1,0 +1,40 @@
+name: Download Portal TLS Watch
+
+# www.heatpump24.com serves an incomplete certificate chain, which we work around
+# by pinning two CA certificates (see custom_components/luxtronik2/download_portal_ssl.py
+# and issue #783). This job checks once a month whether Nibe has repaired the chain.
+#
+# A FAILURE here is the good news: it means the workaround can be deleted.
+
+on:
+  schedule:
+    # 06:00 UTC on the first of each month.
+    - cron: '0 6 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  portal-tls-watch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/requirements-dev.txt
+
+      - name: Check whether the pinned CA bundle is still needed
+        env:
+          LUXTRONIK_CHECK_PORTAL_TLS: "1"
+        run: |
+          pytest tests/test_download_portal_ssl.py::TestWorkaroundStillNeeded -v

--- a/custom_components/luxtronik2/download_portal_ssl.py
+++ b/custom_components/luxtronik2/download_portal_ssl.py
@@ -1,0 +1,187 @@
+"""SSL context for the Alpha Innotec / Nibe firmware download portal.
+
+`www.heatpump24.com` serves an **incomplete TLS certificate chain**: it presents
+only its own leaf certificate and omits the two CA certificates that link it to a
+publicly trusted root. Reproduce with::
+
+    openssl s_client -connect www.heatpump24.com:443 -servername www.heatpump24.com
+    # Verify return code: 21 (unable to verify the first certificate)
+
+The chain the server *should* send::
+
+    heatpump24.com                    <- sent by the server
+      +- Telia RSA OV CA v4           <- NOT sent, not in the default CA store
+          +- Telia RSA TLS Root CA v3 <- NOT sent, not in the default CA store
+              +- Telia Root CA v2     <- publicly trusted, present everywhere
+
+Web browsers hide this because they compensate for missing intermediates (Firefox
+preloads every intermediate known to CCADB, Chrome and Edge fetch them via the
+certificate's AIA extension). Python/OpenSSL does neither, so the firmware update
+check fails with ``CERTIFICATE_VERIFY_FAILED`` while the portal opens fine in a
+browser.
+
+As a workaround we pin the two missing CA certificates and use them *only* for
+requests to the download portal. Certificate verification stays fully enabled --
+this closes the chain, it does not skip validation.
+
+Both certificates were verified **offline** to chain up to ``Telia Root CA v2`` in
+the Mozilla/certifi store before being pinned here. Note that ``cadata`` installs
+them as trust anchors, so at runtime OpenSSL may terminate the path at a pinned
+anchor without walking up to that public root. The practical consequence is that
+the revocation status of a pinned CA is never consulted on this context: if Telia
+revoked one of them, this context would keep trusting it. Bounded to one host,
+with hostname verification intact.
+
+Both intermediates are pinned deliberately: if the portal is only partially fixed
+(the common case of adding just the issuing CA to the web server), the chain would
+still dead-end at ``Telia RSA TLS Root CA v3``, which is not in the default store
+either.
+
+**This module can be deleted once Nibe serves a complete chain again** -- see
+https://github.com/BenPru/luxtronik/issues/783. Source of the pinned certificates,
+taken from the AIA extension of the portal's own certificate:
+
+* http://cps.trust.telia.com/teliarsaovcav4.cer
+* http://cps.trust.telia.com/teliarsatlsrootcav3.cer
+"""
+
+# region Imports
+from __future__ import annotations
+
+import ssl
+from typing import Final
+
+from homeassistant.core import HomeAssistant
+from homeassistant.util.ssl import SSL_ALPN_HTTP11, create_client_context
+
+from .const import LOGGER
+
+# endregion Imports
+
+# CN=Telia RSA OV CA v4, O=Telia Company AB, C=SE   (expires 2048-05-23)
+# CN=Telia RSA TLS Root CA v3, O=Telia Company AB, C=SE  (expires 2043-11-28)
+DOWNLOAD_PORTAL_CA_BUNDLE: Final = """\
+-----BEGIN CERTIFICATE-----
+MIIGbTCCBFWgAwIBAgIPAZPeTwwJQRn7bMtN44sDMA0GCSqGSIb3DQEBDAUAMEsx
+CzAJBgNVBAYTAlNFMRkwFwYDVQQKDBBUZWxpYSBDb21wYW55IEFCMSEwHwYDVQQD
+DBhUZWxpYSBSU0EgVExTIFJvb3QgQ0EgdjMwHhcNMjQxMjE5MDk0NDUwWhcNNDgw
+NTIzMTAwMDAwWjBFMQswCQYDVQQGEwJTRTEZMBcGA1UECgwQVGVsaWEgQ29tcGFu
+eSBBQjEbMBkGA1UEAwwSVGVsaWEgUlNBIE9WIENBIHY0MIICIjANBgkqhkiG9w0B
+AQEFAAOCAg8AMIICCgKCAgEAyevbfqI/MpHiVKNeyMb56lR5NQu4Vi0l7lyThYVh
+lTqQzATHvZVm+Pdj6gfhuY1wyRnbkE+bkjdq58rpqn0p2j/4GHqAsas0LJLkS2A4
+LwmxJ+DHr1tJOonMbCwTbwKRdX54LwwDGNw0ShgVWSfI5nNDwg8HhRDFESFFH2n1
+WwmJlu5JQmqK6nb0gB+nGGYMGJzdGNQ5h6PW8TKG2egE1RL79IZ0jeA9Lo65CClC
+JK5bkGqkR0lrfEETyQZBoZp06c4T2XnX+2yUZoIkk/yy8C/mrMv0ilbcR8c8s9lq
+3cKFz15HjS/7L3mUyDqSOOObUr4cSJBrR8fHIHUEfiEv+rKE3iIURWdrJ2ANFgot
+d/H9vbe5cBnShiakQN2lKmyEI9pN9Gt0QS12XmlOe4h4q2En6ERdJi3CiLO15tY3
+6B6guuDpwvJtMhlVduw8u+2/l3gkTwnniYmyG8pjAtEEUJtCAWc/5hHaGqaVwwBK
+vbrqG5SNPeCuKBaIQcVNlIV00+WzTSRTXevnMc0UUiYyDh/qY0Qlg5Xked8P0fuR
+xFhUDlyISUqB3iiNS4YsfJMrkvC5LSthTEMyqo09IT21r8GIRhCtcbRWLexTnil5
+lwtZjVHJTNrpn1bd6qbQG+md8k2wBkvatBL+oRgM5H3XhJ8U7YkCwAQNhUjURDAi
+omECAwEAAaOCAVIwggFOMB8GA1UdIwQYMBaAFLDHqdLdsihWcwSUjBRcSG83UpKo
+MB0GA1UdDgQWBBRV2aNwgnw836jT+d5/BdG6Zku/7TAOBgNVHQ8BAf8EBAMCAQYw
+EQYDVR0gBAowCDAGBgRVHSAAMBIGA1UdEwEB/wQIMAYBAf8CAQAwRwYDVR0fBEAw
+PjA8oDqgOIY2aHR0cDovL2h0dHBjcmwudHJ1c3QudGVsaWEuY29tL3RlbGlhcnNh
+dGxzcm9vdGNhdjMuY3JsMBMGA1UdJQQMMAoGCCsGAQUFBwMBMHcGCCsGAQUFBwEB
+BGswaTA+BggrBgEFBQcwAoYyaHR0cDovL2Nwcy50cnVzdC50ZWxpYS5jb20vdGVs
+aWFyc2F0bHNyb290Y2F2My5jZXIwJwYIKwYBBQUHMAGGG2h0dHA6Ly9vY3NwLnRy
+dXN0LnRlbGlhLmNvbTANBgkqhkiG9w0BAQwFAAOCAgEAjKRIbcTHtBF8nTXO8JMn
+toxF0CSvUFVpTXN2AeF1BRequPvdCy5zteVKnnx5c4lBLgMLasrGH6wKbOdkVTbq
+fNGVNF81R4/AXhqNHPyGpqpb9zMWTYMtswv3k3FpYADypH1Z4BLCIh8mqBnO5dP0
+m16sa075V5MBvB506jixKuB/oZRTaLdBlFclB6VZZtEt/zVSsgY1BXkJIPKJ5hKL
+9AWnCq1XpObnQEnvOgwudD/8ohq5H+OsoY3GhWY6dy7MNoK1Sc/p0FL0UOqlgDcw
+0ze58dD8BUmrf/sZD++4nP8CZ53EzvTv+hIYqTYsOe8Zmp62osGvcf1aOLnGmV0Z
+QWxQR7WfiS42DQ+l3w9b8n0i7+zl9Kp3ONlzkQuUwR/bOUwY1ZhaXGBs4/5C0swv
+Zm76yxPda9gJ8EB1AJzqLdqG96KCVaUmZPWcPr52b/h8XPYTlNqpvuacvYD9K//p
+7bJ5Hqdp/G/rvFTeLhRb/jdVwGE83CXRLqRBBwp25NgwvfTCa4fPCP3uY6g+1C7r
+MqcWxh3+onbnrFY38FfQt5/u0NfCO4PsgeemqPDqBFwu+SmYCLUxm83+p1pvtlA0
+ZzYCJrKF3/9Gq8rDdUSrDqUEmjGz03cNABRbxnEVOBNTDU/dkCydzn4d8Vwc8CaQ
+OSD0WKQ4Ru9c5KCWAB1a5qo=
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIGXTCCBEWgAwIBAgIPAZPeF/aL5o1El0fggo9WMA0GCSqGSIb3DQEBDAUAMEQx
+CzAJBgNVBAYTAkZJMRowGAYDVQQKDBFUZWxpYSBGaW5sYW5kIE95ajEZMBcGA1UE
+AwwQVGVsaWEgUm9vdCBDQSB2MjAeFw0yNDEyMTkwODQzNTVaFw00MzExMjgxMDAw
+MDBaMEsxCzAJBgNVBAYTAlNFMRkwFwYDVQQKDBBUZWxpYSBDb21wYW55IEFCMSEw
+HwYDVQQDDBhUZWxpYSBSU0EgVExTIFJvb3QgQ0EgdjMwggIiMA0GCSqGSIb3DQEB
+AQUAA4ICDwAwggIKAoICAQCxXz0obX2EJ/hLUW+TwPdPIMRGGZy/HwXsqZvhYBPH
+eKN7WJ3cofFETRMqZw0JsBDntu8cURhriFHaXbRWNVp0TGo5b7aV330xsSI76NFU
+7P4FvEvEmeYbAKoj4F+5OONVF4PGzGNC+OAGwKVo7+ybmLvSeVlxYZG0iS9YMrc0
+2RPlG3Bdz87w1MVWltSpPpxGMiPeiUBuVH6VF/gV/Lmj5D19puNif1n1LiK2u4SV
+wQV/0uOTt/B1PJxP+u8lb3D8HcbZrevR//Nc05Wu4gFyoTqmRKiykAJTZsbjZ9gq
+tsz8Zaenu76n0WvPiNo3Clvhge4R5LwGtq01w/xfraNci+8ofGWwwMkKdvhTwnMU
+4uxTqaiFVjnwF1mu+LQaT1Q66qaCgbp2yQeiSyNlOUrrUP8ifOYSgDXIBgkUNXKy
+NHENQ671wDAA1uqarvtYgUvoGmdmBWo+0x8brA3wGtMp1qm+KVWxhHn0EWAiwBUE
+zGsaH5b5By+Ylp9SkBK+UCsq9UbYUjiLo+IuNIFPT7oXoRAutip585AX98E0Rdv6
+eNRDRJRWsCq0fhj46MIj9rj8klCmnF56ZlxDRJRKGCIjkAznEc7mLJpStONgfjPF
+TP2P7UURsMf/Gmy2vWBcHKSym6n6FFNolxsD5Rukmq1Zmd0A910ma3pglD51TekO
+7wIDAQABo4IBQzCCAT8wHwYDVR0jBBgwFoAUcqzkM3mqRYf2/awdntbHL4bYJDkw
+HQYDVR0OBBYEFLDHqdLdsihWcwSUjBRcSG83UpKoMA4GA1UdDwEB/wQEAwIBBjAR
+BgNVHSAECjAIMAYGBFUdIAAwDwYDVR0TAQH/BAUwAwEB/zBBBgNVHR8EOjA4MDag
+NKAyhjBodHRwOi8vaHR0cGNybC50cnVzdC50ZWxpYS5jb20vdGVsaWFyb290Y2F2
+Mi5jcmwwEwYDVR0lBAwwCgYIKwYBBQUHAwEwcQYIKwYBBQUHAQEEZTBjMCcGCCsG
+AQUFBzABhhtodHRwOi8vb2NzcC50cnVzdC50ZWxpYS5jb20wOAYIKwYBBQUHMAKG
+LGh0dHA6Ly9jcHMudHJ1c3QudGVsaWEuY29tL3RlbGlhcm9vdGNhdjIuY2VyMA0G
+CSqGSIb3DQEBDAUAA4ICAQAT4SS0u5ClKu1GEu8h+cTDPYXUNFLFV39Bw6DwsMTm
+86aVP+wsqJC1tCaZ7b/UAIP9+NXxqSkHQG8x+ola4OACGZszvPZVCjhgpHJ2LGW/
+/9lgA+Nj5rvZQ82zPhXMxbVdINvnc+hgBnTNwJeb8Pg2IHOfnInkCXkZSBDXeiqo
+4gR+CAvuvCVmONv8uE5S2NlpKGc15F1qkEGWvYiOOTtokemzkPv30XPZvYbpput+
+rPTMmlZFV/HE1ucbZOtiV2yq68oaSeGnPo69qequyOju/K3J8nBFZXy/VrS34/0p
+iDHqT9fLNnIxGIObo3KSVJRpFkZgxACtNpEUhv4LqnKiradLDC+Z85smkQaJp9O7
+pfGhC2nJ5qZkkqVqTkzPWTq5mD5e3f01co8dGphsfqFlOiSjehqx4MRooEiZNOTf
+WXN7omD2vNbugOX2xOjl6wSszi3er39YJyKPG11nKFkZNHRngohgvfPwnwszBw3z
+e4sF0ALGbvTWCNt5gzYQve3JYkhlVplvJsLeAg4wWZ7gw8WbzKDUbINI/2bA7GXY
+4vneJAlBss8EP635laezoww9Ym6v/jElGcFD6AlIgrIYQjBGl8mneS+eEuER2xLZ
+5I4eAX4i7BLX58gmpffd79bo5445ehUl4hGVlbcZagelzszEWeXCH2jaDy2/a2Pz
+Bg==
+-----END CERTIFICATE-----
+"""
+
+_SSL_CONTEXT: ssl.SSLContext | None = None
+_BUILD_FAILED = False
+
+
+def _create_ssl_context() -> ssl.SSLContext:
+    """Build the download portal SSL context. Blocking, run in an executor.
+
+    Built with `create_client_context()` so it honours the same CA configuration
+    as every other Home Assistant request (REQUESTS_CA_BUNDLE, else certifi).
+    Never `client_context()`: that one is process wide and cached, and loading
+    the pin into it would leak these trust anchors to every client in HA.
+    """
+    context = create_client_context(alpn_protocols=SSL_ALPN_HTTP11)
+    context.load_verify_locations(cadata=DOWNLOAD_PORTAL_CA_BUNDLE)
+    return context
+
+
+async def async_get_download_portal_ssl_context(
+    hass: HomeAssistant,
+) -> ssl.SSLContext | None:
+    """Return the cached SSL context for download portal requests.
+
+    Returns None if the context cannot be built, so the caller can fall back to
+    the default context instead of failing outright.
+    """
+    global _SSL_CONTEXT, _BUILD_FAILED
+
+    if _SSL_CONTEXT is None:
+        # Two config entries polling at once can both build a context here. That
+        # is accepted: last write wins and both contexts are equivalent.
+        try:
+            # create_client_context() loads the CA store from disk.
+            _SSL_CONTEXT = await hass.async_add_executor_job(_create_ssl_context)
+        except Exception:
+            # Report the first failure in full, then stay quiet: this runs on
+            # every poll and repeating the traceback would be the very log spam
+            # this module exists to avoid.
+            if _BUILD_FAILED:
+                LOGGER.debug("Could not build the download portal SSL context")
+            else:
+                _BUILD_FAILED = True
+                LOGGER.warning(
+                    "Could not build the download portal SSL context", exc_info=True
+                )
+            return None
+        _BUILD_FAILED = False
+
+    return _SSL_CONTEXT

--- a/custom_components/luxtronik2/update.py
+++ b/custom_components/luxtronik2/update.py
@@ -7,7 +7,13 @@ from datetime import UTC, datetime, timedelta
 import re
 from typing import Final
 
-from aiohttp import ClientTimeout
+from aiohttp import (
+    ClientError,
+    ClientResponse,
+    ClientResponseError,
+    ClientTimeout,
+    InvalidURL,
+)
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE, EntityCategory
@@ -31,12 +37,18 @@ from .const import (
     SensorKey,
 )
 from .coordinator import LuxtronikCoordinator
+from .download_portal_ssl import async_get_download_portal_ssl_context
 from .lux_helper import get_firmware_download_id, get_manufacturer_firmware_url_by_model
 from .model import LuxtronikUpdateEntityDescription
 
 # endregion Imports
 
 PARALLEL_UPDATES = 0
+
+
+class DownloadPortalError(Exception):
+    """A download portal response we cannot use, and that is worth reporting."""
+
 
 MIN_TIME_BETWEEN_UPDATES: Final = timedelta(hours=1)
 
@@ -177,6 +189,25 @@ class LuxtronikUpdateEntity(  # type: ignore  # pyright: ignore[reportIncompatib
         ):
             await self._request_available_firmware_version()
 
+    @staticmethod
+    def _raise_for_portal_status(response: ClientResponse) -> None:
+        """Raise on a non-200 response from the download portal.
+
+        A 5xx is an outage on their side and nothing the user can act on, so it
+        is raised as a ClientError and ends up in the log at debug level. Any
+        other status may point at a wrong download ID on our side and stays loud.
+        """
+        if response.status == 200:
+            return
+        if response.status >= 500:
+            raise ClientResponseError(
+                response.request_info,
+                response.history,
+                status=response.status,
+                message=f"HTTP error: {response.status}",
+            )
+        raise DownloadPortalError(f"HTTP error: {response.status}")
+
     async def _request_available_firmware_version(self) -> None:
         """Request the latest available firmware version from the download portal."""
         download_id = get_firmware_download_id(self.installed_version)
@@ -184,13 +215,20 @@ class LuxtronikUpdateEntity(  # type: ignore  # pyright: ignore[reportIncompatib
             self.__firmware_version_available = STATE_UNAVAILABLE
             return
 
+        version_parsed = False
         try:
             session = async_get_clientsession(self.hass)
+            # The download portal serves an incomplete certificate chain, so the
+            # request needs our pinned CA bundle. See download_portal_ssl.py.
+            ssl_context = await async_get_download_portal_ssl_context(self.hass)
+            # True is aiohttp's default: verify against the default context.
+            portal_ssl = ssl_context if ssl_context is not None else True
             async with session.get(
-                f"{DOWNLOAD_PORTAL_URL}{download_id}", timeout=ClientTimeout(total=30)
+                f"{DOWNLOAD_PORTAL_URL}{download_id}",
+                timeout=ClientTimeout(total=30),
+                ssl=portal_ssl,
             ) as response:
-                if response.status != 200:
-                    raise Exception(f"HTTP error: {response.status}")
+                self._raise_for_portal_status(response)
 
                 header_content_disposition = response.headers.get(
                     "Content-Disposition", ""
@@ -205,18 +243,33 @@ class LuxtronikUpdateEntity(  # type: ignore  # pyright: ignore[reportIncompatib
                 self.__firmware_version_available = self.extract_firmware_version(
                     filename
                 )
+                version_parsed = True
 
-            async with session.get(  # pragma: no cover
-                f"{CHANGELOG_URL}{download_id}", timeout=ClientTimeout(total=30)
+            async with session.get(
+                f"{CHANGELOG_URL}{download_id}",
+                timeout=ClientTimeout(total=30),
+                ssl=portal_ssl,
             ) as response:
-                if response.status != 200:
-                    raise Exception(f"HTTP error: {response.status}")
+                self._raise_for_portal_status(response)
 
                 self.__firmware_version_changelog = await response.text()
 
-        except Exception:
-            LOGGER.warning(
-                "Could not request download portal firmware version",
-                exc_info=True,
-            )
-            self.__firmware_version_available = STATE_UNAVAILABLE
+        except Exception as err:
+            # An unreachable or failing portal is not actionable for the user, so
+            # it stays out of the log at warning level. InvalidURL is excluded on
+            # purpose: a malformed URL would be a bug on our side.
+            if isinstance(err, ClientError | TimeoutError) and not isinstance(
+                err, InvalidURL
+            ):
+                LOGGER.debug(
+                    "Could not request download portal firmware version: %s", err
+                )
+            else:
+                LOGGER.warning(
+                    "Could not request download portal firmware version",
+                    exc_info=True,
+                )
+            if not version_parsed:
+                # A failing changelog request must not discard a version we
+                # already read successfully.
+                self.__firmware_version_available = STATE_UNAVAILABLE

--- a/tests/requirements-dev.txt
+++ b/tests/requirements-dev.txt
@@ -10,3 +10,6 @@ packaging>=26.3
 # Imported directly by tests/test_schema_helper.py; it used to arrive via
 # Home Assistant, which stopped resolving it on Python 3.14.
 voluptuous-serialize
+# Imported directly by tests/test_download_portal_ssl.py to verify the pinned CA
+# bundle anchors in the public trust store; it arrives via Home Assistant today.
+certifi

--- a/tests/test_download_portal_ssl.py
+++ b/tests/test_download_portal_ssl.py
@@ -1,0 +1,254 @@
+"""Tests for the firmware download portal SSL context."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import os
+import socket
+import ssl
+from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urlparse
+
+from homeassistant.util.ssl import SSL_ALPN_HTTP11, create_client_context
+import pytest
+
+from custom_components.luxtronik2 import download_portal_ssl
+from custom_components.luxtronik2.const import DOWNLOAD_PORTAL_URL
+from custom_components.luxtronik2.download_portal_ssl import (
+    DOWNLOAD_PORTAL_CA_BUNDLE,
+    async_get_download_portal_ssl_context,
+)
+
+# The two CA certificates www.heatpump24.com fails to send. See issue #783.
+EXPECTED_PINNED_CAS = (
+    "Telia RSA OV CA v4",
+    "Telia RSA TLS Root CA v3",
+)
+
+# Opt in for the live check below. It is not part of a normal run: it needs the
+# network, and an outage at Nibe must never fail an unrelated pull request.
+PORTAL_TLS_CHECK_ENV = "LUXTRONIK_CHECK_PORTAL_TLS"
+
+
+@pytest.fixture(autouse=True)
+def _reset_context_cache():
+    """Reset the module level context cache between tests."""
+    download_portal_ssl._SSL_CONTEXT = None
+    download_portal_ssl._BUILD_FAILED = False
+    yield
+    download_portal_ssl._SSL_CONTEXT = None
+    download_portal_ssl._BUILD_FAILED = False
+
+
+def _make_hass() -> MagicMock:
+    """Return a hass mock whose executor runs the job inline."""
+    hass = MagicMock()
+
+    async def _run(func, *args):
+        return func(*args)
+
+    hass.async_add_executor_job = AsyncMock(side_effect=_run)
+    return hass
+
+
+class TestBundledCertificates:
+    """The pinned CA bundle itself."""
+
+    def test_bundle_contains_both_missing_chain_certificates(self):
+        """Both omitted intermediates must be present, not just the first one.
+
+        Loaded into an *empty* store on purpose: create_default_context() pulls in
+        the OS trust store first, which on some machines already carries these CAs
+        and would make this assertion pass with an empty bundle.
+        """
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.load_verify_locations(cadata=DOWNLOAD_PORTAL_CA_BUNDLE)
+
+        assert len(context.get_ca_certs()) == len(EXPECTED_PINNED_CAS)
+
+        subjects = {
+            value
+            for cert in context.get_ca_certs()
+            for rdn in cert.get("subject", ())
+            for key, value in rdn
+            if key == "commonName"
+        }
+
+        for expected in EXPECTED_PINNED_CAS:
+            assert expected in subjects
+
+    def test_pinned_chain_is_cryptographically_anchored_in_certifi(self):
+        """The property the whole design rests on, checked offline.
+
+        Names are not enough: verify the actual signatures, so a bad paste of PEM
+        bytes cannot slip through. Each pinned CA must be signed by the next, and
+        the topmost one by a CA that is already publicly trusted.
+        """
+        from itertools import pairwise
+        import warnings
+
+        import certifi
+        from cryptography import x509
+        from cryptography.hazmat.primitives.asymmetric import padding
+
+        def _assert_signed_by(cert, issuer) -> None:
+            issuer.public_key().verify(
+                cert.signature,
+                cert.tbs_certificate_bytes,
+                padding.PKCS1v15(),
+                cert.signature_hash_algorithm,
+            )
+
+        pinned = x509.load_pem_x509_certificates(DOWNLOAD_PORTAL_CA_BUNDLE.encode())
+        assert len(pinned) == len(EXPECTED_PINNED_CAS)
+
+        with open(certifi.where(), "rb") as trust_store, warnings.catch_warnings():
+            # certifi ships a certificate with a non-positive serial number.
+            warnings.simplefilter("ignore")
+            trusted = {
+                cert.subject.rfc4514_string(): cert
+                for cert in x509.load_pem_x509_certificates(trust_store.read())
+            }
+
+        # Each pinned CA is signed by the next one in the bundle ...
+        for cert, issuer in pairwise(pinned):
+            assert cert.issuer == issuer.subject
+            _assert_signed_by(cert, issuer)
+
+        # ... and the topmost by a CA that is already publicly trusted.
+        topmost = pinned[-1]
+        public_root = trusted.get(topmost.issuer.rfc4514_string())
+        assert public_root is not None
+        _assert_signed_by(topmost, public_root)
+
+    def test_bundled_certificates_are_not_expired(self):
+        """Guard against silently shipping a stale pin."""
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.load_verify_locations(cadata=DOWNLOAD_PORTAL_CA_BUNDLE)
+
+        now = datetime.now(UTC)
+        pinned = [
+            cert
+            for cert in context.get_ca_certs()
+            if any(
+                value in EXPECTED_PINNED_CAS
+                for rdn in cert.get("subject", ())
+                for key, value in rdn
+                if key == "commonName"
+            )
+        ]
+        assert len(pinned) == len(EXPECTED_PINNED_CAS)
+
+        for cert in pinned:
+            not_after = datetime.strptime(
+                cert["notAfter"], "%b %d %H:%M:%S %Y %Z"
+            ).replace(tzinfo=UTC)
+            assert not_after > now
+
+
+class TestAsyncGetDownloadPortalSslContext:
+    """Context construction and caching."""
+
+    @pytest.mark.asyncio
+    async def test_returns_ssl_context_built_in_executor(self):
+        hass = _make_hass()
+
+        context = await async_get_download_portal_ssl_context(hass)
+
+        assert isinstance(context, ssl.SSLContext)
+        hass.async_add_executor_job.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_context_is_built_once_and_cached(self):
+        hass = _make_hass()
+
+        first = await async_get_download_portal_ssl_context(hass)
+        second = await async_get_download_portal_ssl_context(hass)
+
+        assert first is second
+        hass.async_add_executor_job.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_verification_stays_enabled(self):
+        """The pin must never turn into a blanket 'skip verification'."""
+        hass = _make_hass()
+
+        context = await async_get_download_portal_ssl_context(hass)
+
+        assert context is not None
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_context_cannot_be_built(self, caplog):
+        hass = _make_hass()
+        hass.async_add_executor_job = AsyncMock(side_effect=ssl.SSLError("boom"))
+
+        context = await async_get_download_portal_ssl_context(hass)
+
+        assert context is None
+        assert "download portal" in caplog.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_repeated_build_failure_warns_only_once(self, caplog):
+        """A permanent failure must not re-spam the log on every poll."""
+        import logging
+
+        hass = _make_hass()
+        hass.async_add_executor_job = AsyncMock(side_effect=ssl.SSLError("boom"))
+
+        with caplog.at_level(logging.DEBUG):
+            await async_get_download_portal_ssl_context(hass)
+            await async_get_download_portal_ssl_context(hass)
+
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warnings) == 1
+
+
+@pytest.mark.skipif(
+    not os.environ.get(PORTAL_TLS_CHECK_ENV),
+    reason=f"live network check, set {PORTAL_TLS_CHECK_ENV}=1 to run it",
+)
+@pytest.mark.usefixtures("socket_enabled")
+class TestWorkaroundStillNeeded:
+    """Tells us when the pin can be dropped again.
+
+    Run by the scheduled `portal-tls-watch` workflow. It fails on purpose once
+    Nibe repairs the chain, because that failure is the notification.
+    """
+
+    def test_portal_still_serves_an_incomplete_chain(self, monkeypatch):
+        # The test harness blocks the network twice over: pytest-homeassistant-
+        # custom-component replaces socket.getaddrinfo with one that refuses every
+        # hostname, and pytest-socket wraps connect() with a 127.0.0.1 allow list.
+        # _socket still holds the untouched C originals, so restore both from there
+        # rather than reaching into either plugin's private helpers.
+        import _socket
+
+        monkeypatch.setattr(socket, "getaddrinfo", _socket.getaddrinfo)
+        monkeypatch.setattr(socket.socket, "connect", _socket.socket.connect)
+
+        host = urlparse(DOWNLOAD_PORTAL_URL).hostname
+        assert host is not None
+
+        # Exactly what the integration would use without download_portal_ssl.
+        context = create_client_context(alpn_protocols=SSL_ALPN_HTTP11)
+
+        try:
+            with (
+                socket.create_connection((host, 443), timeout=30) as sock,
+                context.wrap_socket(sock, server_hostname=host),
+            ):
+                pass
+        except ssl.SSLCertVerificationError:
+            # Still broken: the workaround is still earning its place.
+            return
+        except OSError as err:
+            pytest.skip(f"{host} is unreachable, cannot tell either way: {err}")
+
+        pytest.fail(
+            f"{host} now verifies without the pinned CA bundle, so the "
+            "workaround is obsolete. Delete custom_components/luxtronik2/"
+            "download_portal_ssl.py, drop the ssl= argument and this test, "
+            "and close https://github.com/BenPru/luxtronik/issues/783."
+        )

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import ssl
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.update import UpdateEntityFeature
@@ -74,6 +75,13 @@ def _make_update_entity(data=None):
     entity.hass = MagicMock()
     entity.hass.config.time_zone = "UTC"
     entity.hass.config.language = "en"
+
+    # Run executor jobs inline: a bare MagicMock returns a non-awaitable, which
+    # silently pushes anything using the executor down its failure path.
+    async def _run_executor_job(func, *args):
+        return func(*args)
+
+    entity.hass.async_add_executor_job = AsyncMock(side_effect=_run_executor_job)
     entity.async_write_ha_state = MagicMock()
     entity.async_schedule_update_ha_state = MagicMock()
     return entity
@@ -480,3 +488,222 @@ class TestReleaseNotes:
         entity._LuxtronikUpdateEntity__firmware_version_changelog = "Fixes"
         result = entity.release_notes()
         assert result is not None
+
+
+# ===========================================================================
+# Download portal TLS workaround (issue #783)
+# ===========================================================================
+
+
+class TestDownloadPortalSslWorkaround:
+    """www.heatpump24.com serves an incomplete certificate chain."""
+
+    @pytest.mark.asyncio
+    async def test_pinned_ssl_context_is_passed_to_portal_requests(self):
+        entity = _make_update_entity()
+        entity._attr_state = "V3.90.1"
+        sentinel_context = object()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.headers = {"Content-Disposition": "filename=wpVXXXX_V3.91.0.zip"}
+        mock_response.text = AsyncMock(return_value="Bug fixes")
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+
+        with (
+            patch(
+                "custom_components.luxtronik2.update.async_get_clientsession",
+                return_value=mock_session,
+            ),
+            patch(
+                "custom_components.luxtronik2.update."
+                "async_get_download_portal_ssl_context",
+                new=AsyncMock(return_value=sentinel_context),
+            ),
+        ):
+            await entity._request_available_firmware_version()
+
+        assert mock_session.get.call_count == 2
+        for call in mock_session.get.call_args_list:
+            assert call.kwargs["ssl"] is sentinel_context
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_default_context_when_pin_unavailable(self):
+        """A context that cannot be built must not break the request."""
+        entity = _make_update_entity()
+        entity._attr_state = "V3.90.1"
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.headers = {"Content-Disposition": "filename=wpVXXXX_V3.91.0.zip"}
+        mock_response.text = AsyncMock(return_value="Bug fixes")
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+
+        with (
+            patch(
+                "custom_components.luxtronik2.update.async_get_clientsession",
+                return_value=mock_session,
+            ),
+            patch(
+                "custom_components.luxtronik2.update."
+                "async_get_download_portal_ssl_context",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            await entity._request_available_firmware_version()
+
+        for call in mock_session.get.call_args_list:
+            assert call.kwargs["ssl"] is True
+        assert entity._LuxtronikUpdateEntity__firmware_version_available == "V3.91.0"
+
+    @pytest.mark.asyncio
+    async def test_certificate_error_does_not_log_a_warning(self, caplog):
+        """An unreachable portal is not actionable, so it must not shout."""
+        import logging
+
+        from aiohttp import ClientConnectorCertificateError
+
+        entity = _make_update_entity()
+        entity._attr_state = "V3.90.1"
+
+        error = ClientConnectorCertificateError(
+            MagicMock(), ssl.SSLCertVerificationError("unable to get local issuer")
+        )
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(side_effect=error)
+
+        with (
+            patch(
+                "custom_components.luxtronik2.update.async_get_clientsession",
+                return_value=mock_session,
+            ),
+            patch(
+                "custom_components.luxtronik2.update."
+                "async_get_download_portal_ssl_context",
+                new=AsyncMock(return_value=None),
+            ),
+            caplog.at_level(logging.DEBUG),
+        ):
+            await entity._request_available_firmware_version()
+
+        assert (
+            entity._LuxtronikUpdateEntity__firmware_version_available
+            == STATE_UNAVAILABLE
+        )
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert not [
+            r for r in warnings if "download portal firmware version" in r.getMessage()
+        ]
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_still_logs_a_warning(self, caplog):
+        """Genuine bugs on our side must stay visible."""
+        import logging
+
+        entity = _make_update_entity()
+        entity._attr_state = "V3.90.1"
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(side_effect=ValueError("boom"))
+
+        with (
+            patch(
+                "custom_components.luxtronik2.update.async_get_clientsession",
+                return_value=mock_session,
+            ),
+            patch(
+                "custom_components.luxtronik2.update."
+                "async_get_download_portal_ssl_context",
+                new=AsyncMock(return_value=None),
+            ),
+            caplog.at_level(logging.DEBUG),
+        ):
+            await entity._request_available_firmware_version()
+
+        assert [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.WARNING
+            and "download portal firmware version" in r.getMessage()
+        ]
+
+    @pytest.mark.asyncio
+    async def test_portal_server_error_does_not_log_a_warning(self, caplog):
+        """A 5xx is the portal being broken, not something the user can fix."""
+        import logging
+
+        entity = _make_update_entity()
+        entity._attr_state = "V3.90.1"
+
+        mock_response = AsyncMock()
+        mock_response.status = 503
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+
+        with (
+            patch(
+                "custom_components.luxtronik2.update.async_get_clientsession",
+                return_value=mock_session,
+            ),
+            patch(
+                "custom_components.luxtronik2.update."
+                "async_get_download_portal_ssl_context",
+                new=AsyncMock(return_value=None),
+            ),
+            caplog.at_level(logging.DEBUG),
+        ):
+            await entity._request_available_firmware_version()
+
+        assert (
+            entity._LuxtronikUpdateEntity__firmware_version_available
+            == STATE_UNAVAILABLE
+        )
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    @pytest.mark.asyncio
+    async def test_portal_client_error_status_still_logs_a_warning(self, caplog):
+        """A 404 can mean our download ID mapping is wrong, which is actionable."""
+        import logging
+
+        entity = _make_update_entity()
+        entity._attr_state = "V3.90.1"
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = MagicMock()
+        mock_session.get = MagicMock(return_value=mock_response)
+
+        with (
+            patch(
+                "custom_components.luxtronik2.update.async_get_clientsession",
+                return_value=mock_session,
+            ),
+            patch(
+                "custom_components.luxtronik2.update."
+                "async_get_download_portal_ssl_context",
+                new=AsyncMock(return_value=None),
+            ),
+            caplog.at_level(logging.DEBUG),
+        ):
+            await entity._request_available_firmware_version()
+
+        assert [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.WARNING
+            and "download portal firmware version" in r.getMessage()
+        ]


### PR DESCRIPTION
Resolves #783

## 🐛 The problem

`www.heatpump24.com` reissued its TLS certificate on **31 Aug 2026, 15:01 UTC** and now serves an **incomplete certificate chain** — only the leaf certificate. Two CA certificates are missing from the handshake, and neither is in the default trust store:

```
heatpump24.com                    ← sent by the server
  └─ Telia RSA OV CA v4           ✗ NOT sent, not in the default CA store
      └─ Telia RSA TLS Root CA v3 ✗ NOT sent, not in the default CA store
          └─ Telia Root CA v2     ✓ publicly trusted, present everywhere
```

Reproducible with one command:

```console
$ openssl s_client -connect www.heatpump24.com:443 -servername www.heatpump24.com
 0 s:C=SE, L=MARKARYD, O=Nibe AB, CN=heatpump24.com
   Verify return code: 21 (unable to verify the first certificate)
```

The firmware update check therefore fails with `CERTIFICATE_VERIFY_FAILED` and logs a **WARNING with a full traceback on every poll**, while the portal opens fine in a browser. That difference is not evidence the server is correct — browsers compensate for missing intermediates (Firefox preloads every intermediate known to CCADB; Chrome and Edge fetch them via the AIA extension). Python/OpenSSL does neither, and neither do Java, Go, curl on Linux, or any monitoring client.

This is **not** caused by core 2026.9.0, and not by a change in this integration.

## ✅ What this PR does

**Pins the two missing CA certificates** in a new `download_portal_ssl.py`, used *only* for the two download portal requests.

- Built with `homeassistant.util.ssl.create_client_context(alpn_protocols=SSL_ALPN_HTTP11)`, so the `REQUESTS_CA_BUNDLE` / certifi contract every other HA request honours is preserved. Deliberately **not** the `@cache`d `client_context()` — loading the pin into that would leak the trust anchors to every HTTP client in HA.
- **Certificate verification stays fully enabled.** This closes the chain, it does not skip validation.
- Context construction runs in an executor (it loads the CA store from disk) and is cached, with the first build failure logged in full and later ones at debug.
- **Both** CAs are pinned on purpose: if the portal is only partially fixed — the common case of adding just the issuing CA to the web server — the chain would still dead-end at `Telia RSA TLS Root CA v3`, which is not in the default store either.

**Quiets non-actionable log noise** in `update.py`: connection failures and portal-side 5xx responses now log at debug without a traceback. Other statuses and `InvalidURL` stay loud, because a 404 can mean our download-ID mapping is wrong and a malformed URL would be our own bug.

**Fixes an adjacent bug** the logging change would otherwise have hidden: when the changelog request failed after the version request succeeded, an already-parsed firmware version was thrown away and the entity showed `unavailable` for a full update interval despite having had the answer.

## 🔍 Verification

Live handshake with the exact bundle in this PR:

```
LIVE OK: TLSv1.2 | ALPN: http/1.1
verify_mode: 2 | check_hostname: True
HA shared context CA count: 120 -> 120 (unchanged)
hostname check enforced: SSLCertVerificationError
```

`verify_mode: 2` is `CERT_REQUIRED`. Hostname checking is on and provably rejects a wrong `server_hostname`. Nothing leaks into HA's shared context.

Both pinned certificates were verified offline: fingerprints match the AIA-published files, signatures check out, and the chain anchors in `Telia Root CA v2` in certifi. There is a test asserting exactly that — signatures, not just matching names.

- `basedpyright` 0 errors · `ruff check` clean · `ruff format --check` clean · `codespell` clean
- **1219 passed, 1 skipped** · coverage **100%** maintained

## ⏰ Knowing when to delete this

`portal-tls-watch.yml` runs a monthly opt-in live check that connects **without** the pin. It fails the day Nibe repairs their chain, telling you to delete the module — the failure is the notification. Skipped in normal runs (`LUXTRONIK_CHECK_PORTAL_TLS=1` to run it), so a Nibe outage can never fail an unrelated PR. An unreachable host skips rather than passes, so downtime is never misread as "still broken".

The workaround is confined to one self-contained module with a docstring carrying the reproduction, the chain diagram, the AIA source URLs, and a pointer to #783. Removing it later is a clean revert, and nothing breaks once the server sends a complete chain — the extra anchors simply become redundant.

## ⚠️ Note on residual risk

`load_verify_locations(cadata=...)` installs these as **trust anchors**, so the revocation status of a pinned CA is not consulted on this context. Bounded to one hostname with hostname verification intact, and documented in the module docstring.

## 📮 Upstream

The real fix belongs to Nibe — one line of Apache config. A ready-to-send report is in [#783](https://github.com/BenPru/luxtronik/issues/783) for anyone with a Nibe or Alpha Innotec contact. Every non-browser consumer of that portal is currently broken, not just us.
