### PR TITLE
fix(text): 🩹 rename the DHW schedule entities to blocking times

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
+[![HACS Default](https://img.shields.io/badge/HACS-Default-blue.svg)](https://github.com/custom-components/hacs)
+![GitHub License](https://img.shields.io/github/license/benpru/luxtronik)
+
 [![Release](https://img.shields.io/github/v/release/BenPru/luxtronik?label=latest-release&color=green&logo=github)](https://github.com/BenPru/luxtronik/releases/latest)
 ![GitHub Downloads (all assets, latest release)](https://img.shields.io/github/downloads/BenPru/luxtronik/latest/total)
 [![Pre-release](https://img.shields.io/github/v/release/BenPru/luxtronik?include_prereleases&label=pre-release&color=orange&logo=github)](https://github.com/BenPru/luxtronik/releases)
 ![GitHub Downloads (all assets, latest release)](https://img.shields.io/github/downloads-pre/BenPru/luxtronik/latest/total?label=downloads@pre-release&color=orange)
-![GitHub License](https://img.shields.io/github/license/benpru/luxtronik)
+
+
 
 
 # Luxtronik Home Assistant Integration
@@ -177,7 +181,7 @@ If your system has an integrated **solar thermal collector** feeding the DHW tan
 
 #### 2.4.1 DHW Timer Schedule (Blocking Times)
 
-DHW also supports an editable weekly schedule of **blocking times** — windows during which automatic DHW heating is switched off, exposed as a set of Text entities. The controller offers three schedule shapes (whole week, weekdays + weekend, per day) selected by the *Hot water timer program* entity; only the selected shape's schedule entities are present, the others are disabled. See **[TIMER_SCHEDULES.md](TIMER_SCHEDULES.md)** for the entity list, the `HH:MM-HH:MM/...` format, and an important note on how DHW's blocking-time semantics differ from the heating schedule.
+DHW also supports an editable weekly schedule of **blocking times** — windows during which automatic DHW heating is switched off, exposed as a set of *DHW Blocking Times* Text entities. Leave them empty for no restriction; a window covering the whole day blocks DHW heating around the clock. The controller offers three schedule shapes (whole week, weekdays + weekend, per day) selected by the *Hot water timer program* entity; only the selected shape's schedule entities are present, the others are disabled. See **[TIMER_SCHEDULES.md](TIMER_SCHEDULES.md)** for the entity list, the `HH:MM-HH:MM/...` format, and an important note on how DHW's blocking-time semantics differ from the heating schedule.
 
 **Automating DHW** has its own section further down: [§3.1.2 Automating DHW](#312-automating-dhw).
 

--- a/TIMER_SCHEDULES.md
+++ b/TIMER_SCHEDULES.md
@@ -61,12 +61,14 @@ If you need hot water during an active blocking window, switch *Mode* to *Party*
 | Name | Entity Type | Description |
 | :--- | :--- | :--- |
 | **Hot water timer program** | Select | Which schedule shape the controller uses: *Whole week*, *Weekdays + weekend*, or *Per day*. |
-| **DHW Timer Schedule (Week)** | Text | Exists while the *Week* shape is active. |
-| **DHW Timer Schedule (Weekdays)** | Text | Exists while *Weekday/Weekend* is active; covers Monday-Friday. |
-| **DHW Timer Schedule (Weekend)** | Text | Exists while *Weekday/Weekend* is active; covers Saturday-Sunday. |
-| **DHW Timer Schedule (Monday)** … **(Sunday)** | Text | One entity per day of the week, present while *Per day* is active. |
+| **DHW Blocking Times (Week)** | Text | Exists while the *Week* shape is active. |
+| **DHW Blocking Times (Weekdays)** | Text | Exists while *Weekday/Weekend* is active; covers Monday-Friday. |
+| **DHW Blocking Times (Weekend)** | Text | Exists while *Weekday/Weekend* is active; covers Saturday-Sunday. |
+| **DHW Blocking Times (Monday)** … **(Sunday)** | Text | One entity per day of the week, present while *Per day* is active. |
 
 The example above (`12:00-13:00/22:00-23:30`) blocks DHW heating over lunch and late in the evening.
+
+> **⚠️ Leave the field empty for "no restriction".** An empty schedule means DHW is never blocked. Entering a window that spans the whole day (for example `00:00-23:59`) does the opposite of what it looks like: it blocks automatic DHW heating around the clock.
 
 ## Heating Timer Schedule (Raise / Setback Times)
 

--- a/custom_components/luxtronik2/translations/cs.json
+++ b/custom_components/luxtronik2/translations/cs.json
@@ -1052,34 +1052,34 @@
         },
         "text": {
             "timer_dhw_schedule_week": {
-                "name": "Časový plán teplé vody (týden)"
+                "name": "Blokovací časy teplé vody (týden)"
             },
             "timer_dhw_schedule_weekday": {
-                "name": "Časový plán teplé vody (pracovní dny)"
+                "name": "Blokovací časy teplé vody (pracovní dny)"
             },
             "timer_dhw_schedule_weekend": {
-                "name": "Časový plán teplé vody (víkend)"
+                "name": "Blokovací časy teplé vody (víkend)"
             },
             "timer_dhw_schedule_monday": {
-                "name": "Časový plán teplé vody (pondělí)"
+                "name": "Blokovací časy teplé vody (pondělí)"
             },
             "timer_dhw_schedule_tuesday": {
-                "name": "Časový plán teplé vody (úterý)"
+                "name": "Blokovací časy teplé vody (úterý)"
             },
             "timer_dhw_schedule_wednesday": {
-                "name": "Časový plán teplé vody (středa)"
+                "name": "Blokovací časy teplé vody (středa)"
             },
             "timer_dhw_schedule_thursday": {
-                "name": "Časový plán teplé vody (čtvrtek)"
+                "name": "Blokovací časy teplé vody (čtvrtek)"
             },
             "timer_dhw_schedule_friday": {
-                "name": "Časový plán teplé vody (pátek)"
+                "name": "Blokovací časy teplé vody (pátek)"
             },
             "timer_dhw_schedule_saturday": {
-                "name": "Časový plán teplé vody (sobota)"
+                "name": "Blokovací časy teplé vody (sobota)"
             },
             "timer_dhw_schedule_sunday": {
-                "name": "Časový plán teplé vody (neděle)"
+                "name": "Blokovací časy teplé vody (neděle)"
             },
             "timer_heating_schedule_week": {
                 "name": "Časový plán vytápění (týden)"

--- a/custom_components/luxtronik2/translations/de.json
+++ b/custom_components/luxtronik2/translations/de.json
@@ -1052,34 +1052,34 @@
         },
         "text": {
             "timer_dhw_schedule_week": {
-                "name": "Warmwasser-Zeitschaltplan (Woche)"
+                "name": "Warmwasser-Sperrzeiten (Woche)"
             },
             "timer_dhw_schedule_weekday": {
-                "name": "Warmwasser-Zeitschaltplan (Werktage)"
+                "name": "Warmwasser-Sperrzeiten (Werktage)"
             },
             "timer_dhw_schedule_weekend": {
-                "name": "Warmwasser-Zeitschaltplan (Wochenende)"
+                "name": "Warmwasser-Sperrzeiten (Wochenende)"
             },
             "timer_dhw_schedule_monday": {
-                "name": "Warmwasser-Zeitschaltplan (Montag)"
+                "name": "Warmwasser-Sperrzeiten (Montag)"
             },
             "timer_dhw_schedule_tuesday": {
-                "name": "Warmwasser-Zeitschaltplan (Dienstag)"
+                "name": "Warmwasser-Sperrzeiten (Dienstag)"
             },
             "timer_dhw_schedule_wednesday": {
-                "name": "Warmwasser-Zeitschaltplan (Mittwoch)"
+                "name": "Warmwasser-Sperrzeiten (Mittwoch)"
             },
             "timer_dhw_schedule_thursday": {
-                "name": "Warmwasser-Zeitschaltplan (Donnerstag)"
+                "name": "Warmwasser-Sperrzeiten (Donnerstag)"
             },
             "timer_dhw_schedule_friday": {
-                "name": "Warmwasser-Zeitschaltplan (Freitag)"
+                "name": "Warmwasser-Sperrzeiten (Freitag)"
             },
             "timer_dhw_schedule_saturday": {
-                "name": "Warmwasser-Zeitschaltplan (Samstag)"
+                "name": "Warmwasser-Sperrzeiten (Samstag)"
             },
             "timer_dhw_schedule_sunday": {
-                "name": "Warmwasser-Zeitschaltplan (Sonntag)"
+                "name": "Warmwasser-Sperrzeiten (Sonntag)"
             },
             "timer_heating_schedule_week": {
                 "name": "Heizungs-Zeitschaltplan (Woche)"

--- a/custom_components/luxtronik2/translations/en.json
+++ b/custom_components/luxtronik2/translations/en.json
@@ -1052,34 +1052,34 @@
         },
         "text": {
             "timer_dhw_schedule_week": {
-                "name": "DHW Timer Schedule (Week)"
+                "name": "DHW Blocking Times (Week)"
             },
             "timer_dhw_schedule_weekday": {
-                "name": "DHW Timer Schedule (Weekdays)"
+                "name": "DHW Blocking Times (Weekdays)"
             },
             "timer_dhw_schedule_weekend": {
-                "name": "DHW Timer Schedule (Weekend)"
+                "name": "DHW Blocking Times (Weekend)"
             },
             "timer_dhw_schedule_monday": {
-                "name": "DHW Timer Schedule (Monday)"
+                "name": "DHW Blocking Times (Monday)"
             },
             "timer_dhw_schedule_tuesday": {
-                "name": "DHW Timer Schedule (Tuesday)"
+                "name": "DHW Blocking Times (Tuesday)"
             },
             "timer_dhw_schedule_wednesday": {
-                "name": "DHW Timer Schedule (Wednesday)"
+                "name": "DHW Blocking Times (Wednesday)"
             },
             "timer_dhw_schedule_thursday": {
-                "name": "DHW Timer Schedule (Thursday)"
+                "name": "DHW Blocking Times (Thursday)"
             },
             "timer_dhw_schedule_friday": {
-                "name": "DHW Timer Schedule (Friday)"
+                "name": "DHW Blocking Times (Friday)"
             },
             "timer_dhw_schedule_saturday": {
-                "name": "DHW Timer Schedule (Saturday)"
+                "name": "DHW Blocking Times (Saturday)"
             },
             "timer_dhw_schedule_sunday": {
-                "name": "DHW Timer Schedule (Sunday)"
+                "name": "DHW Blocking Times (Sunday)"
             },
             "timer_heating_schedule_week": {
                 "name": "Heating Timer Schedule (Week)"

--- a/custom_components/luxtronik2/translations/nl.json
+++ b/custom_components/luxtronik2/translations/nl.json
@@ -1052,34 +1052,34 @@
         },
         "text": {
             "timer_dhw_schedule_week": {
-                "name": "Warmwater tijdschema (week)"
+                "name": "Warmwater blokkeertijden (week)"
             },
             "timer_dhw_schedule_weekday": {
-                "name": "Warmwater tijdschema (werkdagen)"
+                "name": "Warmwater blokkeertijden (werkdagen)"
             },
             "timer_dhw_schedule_weekend": {
-                "name": "Warmwater tijdschema (weekend)"
+                "name": "Warmwater blokkeertijden (weekend)"
             },
             "timer_dhw_schedule_monday": {
-                "name": "Warmwater tijdschema (maandag)"
+                "name": "Warmwater blokkeertijden (maandag)"
             },
             "timer_dhw_schedule_tuesday": {
-                "name": "Warmwater tijdschema (dinsdag)"
+                "name": "Warmwater blokkeertijden (dinsdag)"
             },
             "timer_dhw_schedule_wednesday": {
-                "name": "Warmwater tijdschema (woensdag)"
+                "name": "Warmwater blokkeertijden (woensdag)"
             },
             "timer_dhw_schedule_thursday": {
-                "name": "Warmwater tijdschema (donderdag)"
+                "name": "Warmwater blokkeertijden (donderdag)"
             },
             "timer_dhw_schedule_friday": {
-                "name": "Warmwater tijdschema (vrijdag)"
+                "name": "Warmwater blokkeertijden (vrijdag)"
             },
             "timer_dhw_schedule_saturday": {
-                "name": "Warmwater tijdschema (zaterdag)"
+                "name": "Warmwater blokkeertijden (zaterdag)"
             },
             "timer_dhw_schedule_sunday": {
-                "name": "Warmwater tijdschema (zondag)"
+                "name": "Warmwater blokkeertijden (zondag)"
             },
             "timer_heating_schedule_week": {
                 "name": "Verwarming tijdschema (week)"

--- a/custom_components/luxtronik2/translations/pl.json
+++ b/custom_components/luxtronik2/translations/pl.json
@@ -1052,34 +1052,34 @@
         },
         "text": {
             "timer_dhw_schedule_week": {
-                "name": "Harmonogram czasowy ciepłej wody (tydzień)"
+                "name": "Czasy blokady ciepłej wody (tydzień)"
             },
             "timer_dhw_schedule_weekday": {
-                "name": "Harmonogram czasowy ciepłej wody (dni robocze)"
+                "name": "Czasy blokady ciepłej wody (dni robocze)"
             },
             "timer_dhw_schedule_weekend": {
-                "name": "Harmonogram czasowy ciepłej wody (weekend)"
+                "name": "Czasy blokady ciepłej wody (weekend)"
             },
             "timer_dhw_schedule_monday": {
-                "name": "Harmonogram czasowy ciepłej wody (poniedziałek)"
+                "name": "Czasy blokady ciepłej wody (poniedziałek)"
             },
             "timer_dhw_schedule_tuesday": {
-                "name": "Harmonogram czasowy ciepłej wody (wtorek)"
+                "name": "Czasy blokady ciepłej wody (wtorek)"
             },
             "timer_dhw_schedule_wednesday": {
-                "name": "Harmonogram czasowy ciepłej wody (środa)"
+                "name": "Czasy blokady ciepłej wody (środa)"
             },
             "timer_dhw_schedule_thursday": {
-                "name": "Harmonogram czasowy ciepłej wody (czwartek)"
+                "name": "Czasy blokady ciepłej wody (czwartek)"
             },
             "timer_dhw_schedule_friday": {
-                "name": "Harmonogram czasowy ciepłej wody (piątek)"
+                "name": "Czasy blokady ciepłej wody (piątek)"
             },
             "timer_dhw_schedule_saturday": {
-                "name": "Harmonogram czasowy ciepłej wody (sobota)"
+                "name": "Czasy blokady ciepłej wody (sobota)"
             },
             "timer_dhw_schedule_sunday": {
-                "name": "Harmonogram czasowy ciepłej wody (niedziela)"
+                "name": "Czasy blokady ciepłej wody (niedziela)"
             },
             "timer_heating_schedule_week": {
                 "name": "Harmonogram czasowy ogrzewania (tydzień)"


### PR DESCRIPTION
## 🔍 What this fixes

In [#785](https://github.com/BenPru/luxtronik/issues/785) a reporter set `text.luxtronik2_timer_dhw_schedule_week` to `00:00-23:59` believing it meant *"always allowed"*, and thereby blocked automatic hot water heating 23 h 59 m per day. His diagnostics dump confirms it: `P0405 ID_Einst_SUBW_akt2 = week`, `P0406/P0407 = 00:00/23:59`. He then spent several days debugging a heat pump that was doing exactly what it was told.

DHW schedule windows are **blocking** windows — the controller calls them *Sperrzeiten* — which is the opposite polarity from the heating circuit's raise/setback windows. `TIMER_SCHEDULES.md` already documented this correctly, and the reporter quoted it himself after the fact. So the documentation was not the gap: the mistake happens in the Home Assistant UI, before anyone opens the docs. The entity name is where the meaning has to be visible.

## ✨ Changes

**Entity display names** (`custom_components/luxtronik2/translations/{en,de,nl,cs,pl}.json`) — all 10 `timer_dhw_schedule_*` keys in each of the five languages:

| | before | after |
|---|---|---|
| en | DHW Timer Schedule (Week) | **DHW Blocking Times (Week)** |
| de | Warmwasser-Zeitschaltplan (Woche) | **Warmwasser-Sperrzeiten (Woche)** |
| nl | Warmwater tijdschema (week) | **Warmwater blokkeertijden (week)** |
| cs | Časový plán teplé vody (týden) | **Blokovací časy teplé vody (týden)** |
| pl | Harmonogram czasowy ciepłej wody (tydzień) | **Czasy blokady ciepłej wody (tydzień)** |

German uses the controller's own term, so the entity name matches what the user sees on the physical panel.

**Documentation:**
- `TIMER_SCHEDULES.md` — DHW entity table renamed to match, plus a ⚠️ callout stating that an empty field means "no restriction" and that a whole-day window blocks DHW around the clock.
- `README.md` §2.4.1 — names the entities and repeats the warning in one sentence.

**Deliberately untouched:** the heating and ventilation schedule entities. Their windows really are raise/setback schedules, and the contrast with DHW is precisely the point being made.

**No Python changed.** Entity IDs are unaffected: `_timer_schedule_unique_id()` ([text.py:37-48](https://github.com/BenPru/luxtronik/blob/chore/rename-dhw-blocking-times/custom_components/luxtronik2/text.py#L37-L48)) builds the id from `description.key` and the config entry prefix, and `text.py:369-370` reuses that string as the `unique_id`; `_attr_name` is never set anywhere. Fresh installs derive the id from the key, existing installs recover it from the registry via the unchanged `unique_id`. No automations, dashboards or templates break.

## 🧪 Tests

No new tests — this changes display strings and documentation only, and the existing translation guards (`test_translation_files_are_valid_json`, `test_translation_files_use_literal_utf8`, the key-completeness checks) already cover the files that changed.

Full run on the branch: **1219 passed, 1 skipped**, coverage 100% (unchanged). `codespell` clean, `git diff --check` clean. All five locale files verified: no BOM, LF endings, literal UTF-8, 10/10 keys changed each.

Reviewed by a code-review subagent, which independently verified the entity_id stability claim in `text.py` rather than taking it from the description, and confirmed no stale references to the old names remain in shipped content. Two markdown consistency fixes from that review are folded in.

## ⚠️ Upgrade notes

The DHW timer schedule entities are now called **DHW Blocking Times** instead of *DHW Timer Schedule* (German: *Warmwasser-Sperrzeiten*). This is a display-name change only — the entity IDs such as `text.luxtronik2_timer_dhw_schedule_week` are unchanged, so automations, dashboards and templates keep working and nothing needs to be adjusted by hand.

The new name reflects what these entities have always done: each window is a period in which automatic hot water heating is **switched off**. Leave the field **empty** for no restriction. A window covering the whole day, such as `00:00-23:59`, blocks hot water heating around the clock.

If you previously renamed one of these entities yourself, Home Assistant keeps your custom name and you will not see the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

